### PR TITLE
fix: установка, релизы (Keenetic), install.sh, README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # ═══════════════════════════════════════════════════════════════
 
 PKG_NAME     := zapret-gui
-PKG_VERSION  := 0.14.0
+PKG_VERSION  := 0.14.2
 PKG_RELEASE  := 1
 PKG_ARCH     := all
 PKG_FULLNAME := $(PKG_NAME)_$(PKG_VERSION)-$(PKG_RELEASE)_$(PKG_ARCH)

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.14.0"
+GUI_VERSION = "0.14.2"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.14.0"
+VERSION="0.14.2"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"


### PR DESCRIPTION
## Что исправлено

### 🐛 Makefile — Entware/Keenetic ipk пропадал из релизов
`make openwrt-ipk` вызывал `clean`, который удалял `dist/` вместе с ранее собранным Entware ipk. Поэтому в v0.14.1 в релизе только OpenWrt пакет, Entware/Keenetic отсутствует.

**Решение:** добавлена цель `_clean_build` (чистит только `build/`), `ipk` и `openwrt-ipk` теперь используют её вместо `clean`.

### 📦 release.yml — стабильные имена + Keenetic артефакт
После сборки CI теперь создаёт постоянно-именованные копии:
- `zapret-gui-keenetic.ipk`
- `zapret-gui-entware.ipk`
- `zapret-gui-openwrt.ipk`

URL вида `releases/latest/download/zapret-gui-keenetic.ipk` больше не устаревает при смене версии.

### ❌ `python3-bottle` недоступен в opkg (основная жалоба пользователей)
- Убран из `Depends` в `packaging/entware/control` и `packaging/openwrt/control` → `opkg install *.ipk` больше не падает
- `postinst` теперь сам устанавливает bottle: pip → прямой wget `bottle.py`
- `install.sh` для opkg-платформ: вместо `opkg install python3-bottle` (которого нет в репо) — pip → `_install_bottle_direct`

### 🐧 Generic Linux — systemd
`install.sh` теперь определяет наличие `systemctl` и создаёт unit-файл `/etc/systemd/system/zapret-gui.service`.

### 📖 README
- Hardcoded `_0.14.0-1_all.ipk` → стабильные имена
- Добавлена секция **Keenetic** (отдельная от Entware)
- Ручная установка: `opkg install python3-bottle` → `python3 -m pip install bottle`

### 🔢 Версия
Bumped `0.14.0 → 0.14.2` в Makefile, `core/version.py`, `install.sh`.

---

## После мержа — запустить релиз v0.14.2

```bash
git pull origin main
git tag -a v0.14.2 -m "Release v0.14.2"
git push origin v0.14.2
```

CI соберёт оба ipk + создаст `zapret-gui-keenetic.ipk`, `zapret-gui-entware.ipk`, `zapret-gui-openwrt.ipk`. Ссылки из README станут рабочими.