### PR TITLE
fix: sidebar всегда показывает актуальную версию GUI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -39,7 +39,7 @@
             </div>
 
             <div class="sidebar-footer">
-                <div class="sidebar-version" id="sidebar-version">v0.14.2</div>
+                <div class="sidebar-version" id="sidebar-version">...</div>
             </div>
         </nav>
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -27,10 +27,23 @@ const App = (() => {
     let currentPage = null;
     let currentPageId = null;
 
+    async function loadSidebarVersion() {
+        try {
+            const data = await API.get('/api/gui/version');
+            const el = document.getElementById('sidebar-version');
+            if (el && data && data.version) {
+                el.textContent = 'v' + data.version;
+            }
+        } catch (_) {}
+    }
+
     function init() {
         // Рендерим sidebar
         Sidebar.render();
         Sidebar.initMobileToggle();
+
+        // Загружаем версию GUI в sidebar
+        loadSidebarVersion();
 
         // Слушаем изменение hash
         window.addEventListener('hashchange', onHashChange);


### PR DESCRIPTION
Версия загружается из /api/gui/version при старте приложения (app.js), а не только при открытии страницы настроек. Заглушка '...' в index.html заменяется реальным значением сразу после загрузки страницы.
