### PR TITLE
fix(release): write linux archive to /tmp to avoid tar self-detection…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,8 @@ jobs:
       - name: Create Linux archive
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          tar czf "${PKG_NAME}-${VERSION}-linux.tar.gz" \
+          ARCHIVE="/tmp/${PKG_NAME}-${VERSION}-linux.tar.gz"
+          tar czf "$ARCHIVE" \
             --exclude='.git' \
             --exclude='build' \
             --exclude='dist' \
@@ -109,8 +110,7 @@ jobs:
             --exclude='*.7z' \
             --exclude='.github' \
             .
-          echo "✓ Архив: ${PKG_NAME}-${VERSION}-linux.tar.gz"
-          ls -lh "${PKG_NAME}-${VERSION}-linux.tar.gz"
+          echo "✓ Архив: $(ls -lh $ARCHIVE)"
 
       # ── Именование артефактов ────────────────────────────────
 
@@ -125,7 +125,7 @@ jobs:
           cp "dist/${PKG_NAME}_${VERSION}-1_openwrt.ipk" \
              "release-artifacts/${PKG_NAME}-${VERSION}-openwrt.ipk"
 
-          cp "${PKG_NAME}-${VERSION}-linux.tar.gz" \
+          cp "/tmp/${PKG_NAME}-${VERSION}-linux.tar.gz" \
              "release-artifacts/"
 
           echo "── Артефакты релиза ──"


### PR DESCRIPTION
… error

tar: .: file changed as we read it — happens when the output file is written into the same directory being archived.

