### PR TITLE
fix(ipk): bundle import/ into IPK and run asset_importer in postinst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ DIST_DIR     := dist
 
 # ── Исходные файлы ───────────────────────────────────────────
 APP_FILES    := app.py
-APP_DIRS     := api core config web catalogs data
+APP_DIRS     := api core config web catalogs data import
 EXCLUDE      := --exclude='__pycache__' --exclude='*.pyc' --exclude='*.pyo' \
                 --exclude='.DS_Store' --exclude='.git' --exclude='build' \
                 --exclude='dist' --exclude='packaging' --exclude='Makefile' \

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.16.1"
+GUI_VERSION = "0.16.2"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.16.1"
+VERSION="0.16.2"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"

--- a/packaging/entware/postinst
+++ b/packaging/entware/postinst
@@ -32,7 +32,26 @@ mkdir -p "$APP_DIR/config/strategies/user" 2>/dev/null || true
 chmod 755 "$APP_DIR/app.py" 2>/dev/null || true
 chmod 755 "$INITD_SCRIPT" 2>/dev/null || true
 
-# 6. Проверяем и устанавливаем bottle
+# 6. Импортируем bundled-ассеты (blobs/lua/lists → /opt/zapret2/{bin,lua,lists},
+#    дополнительные стратегии → catalogs/basic|advanced|builtin).
+#    Базовый zapret2 содержит только бинарник nfqws2 — blob'ы, lua-скрипты
+#    и hostlist/ipset'ы приезжают вместе с GUI в $APP_DIR/import/ и
+#    раскладываются asset_importer'ом в места, на которые ссылаются стратегии.
+if [ -f "$APP_DIR/core/asset_importer.py" ] && [ -d "$APP_DIR/import" ]; then
+    echo "  Импорт blobs/lua/lists/стратегий..."
+    if env PYTHONPATH="$APP_DIR" python3 \
+            -m core.asset_importer --only all >/tmp/zapret-gui-import.log 2>&1; then
+        echo "  ✓ Ассеты импортированы"
+    else
+        echo "  ⚠ Ошибка импорта ассетов (см. /tmp/zapret-gui-import.log)"
+    fi
+else
+    if [ ! -d "$APP_DIR/import" ]; then
+        echo "  ⚠ $APP_DIR/import отсутствует — bundled-ассеты не импортированы"
+    fi
+fi
+
+# 7. Проверяем и устанавливаем bottle
 if ! python3 -c "import bottle" 2>/dev/null; then
     echo "  Установка bottle (python3-bottle недоступен в opkg)..."
     if python3 -m pip install bottle --quiet 2>/dev/null; then

--- a/packaging/openwrt/postinst
+++ b/packaging/openwrt/postinst
@@ -21,6 +21,23 @@ chmod 755 "$APP_DIR/app.py" 2>/dev/null || true
 # Включаем автозапуск
 /etc/init.d/zapret-gui enable 2>/dev/null || true
 
+# Импортируем bundled-ассеты (blobs/lua/lists → /opt/zapret2/{bin,lua,lists},
+# дополнительные стратегии → catalogs/basic|advanced|builtin).
+# Базовый zapret2 содержит только бинарник nfqws2 — всё остальное
+# приезжает вместе с GUI в $APP_DIR/import/ и раскладывается
+# asset_importer'ом в места, на которые ссылаются стратегии.
+if [ -f "$APP_DIR/core/asset_importer.py" ] && [ -d "$APP_DIR/import" ]; then
+    echo "  Импорт blobs/lua/lists/стратегий..."
+    if env PYTHONPATH="$APP_DIR" python3 \
+            -m core.asset_importer --only all >/tmp/zapret-gui-import.log 2>&1; then
+        echo "  ✓ Ассеты импортированы"
+    else
+        echo "  ⚠ Ошибка импорта ассетов (см. /tmp/zapret-gui-import.log)"
+    fi
+elif [ ! -d "$APP_DIR/import" ]; then
+    echo "  ⚠ $APP_DIR/import отсутствует — bundled-ассеты не импортированы"
+fi
+
 # Проверяем и устанавливаем bottle
 if ! python3 -c "import bottle" 2>/dev/null; then
     echo "  Установка bottle (python3-bottle недоступен в opkg)..."


### PR DESCRIPTION
Проблема: в релизных IPK (v0.16.0, v0.16.1) директория import/ не попадала в пакет, а postinst не вызывал asset_importer. Поэтому на роутере после opkg install пакета blob'ы/lua/ipset'ы никуда не копировались — стратегии, ссылающиеся на эти файлы, ломались.

Две дыры:
  1) Makefile:39 APP_DIRS не включал `import` → 3.7 MB ассетов
     отсутствовали в data.tar.gz. IPK весил 342 KB вместо ~1.3 MB.
  2) packaging/{entware,openwrt}/postinst не запускал asset_importer →
     даже при наличии import/ в $APP_DIR файлы не раскладывались в
     /opt/zapret2/{bin,lua,lists} и в catalogs/.

Что меняется:
  * Makefile: `import` добавлен в APP_DIRS → попадает в data.tar.gz.
  * entware/openwrt postinst: вызов env PYTHONPATH=$APP_DIR python3 -m core.asset_importer --only all с логом в /tmp/zapret-gui-import.log. Если import/ или asset_importer.py отсутствуют (старая сборка) — пишет WARN.
  * Версия 0.16.1 → 0.16.2 (core/version.py, install.sh).

Проверено: после `make ipk` пакет 1.3 MB, распакован содержит opt/share/zapret-gui/import/ с 83 blob + 27 lua + 86 lists.

