### PR TITLE
fix(postinst): kill stale python procs, show installed version + impo…

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.16.3"
+GUI_VERSION = "0.16.4"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.16.3"
+VERSION="0.16.4"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"

--- a/packaging/entware/postinst
+++ b/packaging/entware/postinst
@@ -7,51 +7,90 @@ APP_DIR="/opt/share/zapret-gui"
 CONFIG_DIR="/opt/etc/zapret-gui"
 LOG_DIR="/tmp/zapret-gui"
 INITD_SCRIPT="/opt/etc/init.d/S99zapret-gui"
+PID_FILE="/opt/var/run/zapret-gui.pid"
 
 echo "═══════════════════════════════════════════"
 echo "  Zapret Web-GUI — установка"
 echo "═══════════════════════════════════════════"
 
-# 1. Директория конфигурации
+# 1. Снимаем все осиротевшие python-процессы zapret-gui.
+#    Без этого старый процесс продолжит держать порт 8080 и работать со
+#    старым кодом в памяти, а S99zapret-gui увидит живой PID и не
+#    перезапустит сервис, поэтому пользователь продолжит видеть
+#    предыдущую версию (см. отчёт пользователя по 0.16.2/0.16.3).
+WAS_RUNNING=""
+if [ -f "$PID_FILE" ]; then
+    OLD_PID=$(cat "$PID_FILE" 2>/dev/null || true)
+    if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+        WAS_RUNNING=1
+    fi
+fi
+if [ -x "$INITD_SCRIPT" ]; then
+    "$INITD_SCRIPT" stop >/dev/null 2>&1 || true
+fi
+# Подстраховка: убиваем по cmdline всё, что выглядит как наш app.py
+if command -v pgrep >/dev/null 2>&1; then
+    for pid in $(pgrep -f "python.* $APP_DIR/app.py" 2>/dev/null); do
+        kill "$pid" 2>/dev/null || true
+    done
+    sleep 1
+    for pid in $(pgrep -f "python.* $APP_DIR/app.py" 2>/dev/null); do
+        kill -9 "$pid" 2>/dev/null || true
+    done
+fi
+rm -f "$PID_FILE" 2>/dev/null || true
+
+# 2. Директория конфигурации
 if [ ! -d "$CONFIG_DIR" ]; then
     mkdir -p "$CONFIG_DIR"
     echo "  ✓ Создана директория конфигурации: $CONFIG_DIR"
 fi
 
-# 2. Директория для логов (в RAM)
+# 3. Директории
 mkdir -p "$LOG_DIR" 2>/dev/null || true
-
-# 3. Рабочие директории
 mkdir -p "$APP_DIR/init.d" 2>/dev/null || true
 mkdir -p "$APP_DIR/lists" 2>/dev/null || true
-
-# 4. Директория для user-стратегий
 mkdir -p "$APP_DIR/config/strategies/user" 2>/dev/null || true
 
-# 5. Права на исполнение
+# 4. Права
 chmod 755 "$APP_DIR/app.py" 2>/dev/null || true
 chmod 755 "$INITD_SCRIPT" 2>/dev/null || true
 
-# 6. Очистка stale __pycache__ от предыдущей установки.
-#    Это критично: после обновления .py файлов python может загрузить
-#    устаревший .pyc, если mtime не обновлены — и тогда GUI продолжит
-#    показывать старую GUI_VERSION и старые пути.
+# 5. Очистка stale __pycache__/*.pyc от предыдущей установки.
+#    Это критично: иначе python может загрузить старый .pyc и GUI продолжит
+#    показывать предыдущую GUI_VERSION и старые пути.
 find "$APP_DIR" -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
 find "$APP_DIR" -name '*.pyc' -delete 2>/dev/null || true
 
-# 7. Импортируем bundled-ассеты:
+# 6. Сообщаем установленную версию (помогает диагностировать "GUI показывает старую версию")
+VERSION_PY="$APP_DIR/core/version.py"
+if [ -f "$VERSION_PY" ]; then
+    INSTALLED_VER=$(grep '^GUI_VERSION' "$VERSION_PY" 2>/dev/null \
+        | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+    [ -n "$INSTALLED_VER" ] && echo "  ✓ Установлен: zapret-gui v$INSTALLED_VER"
+fi
+
+# 7. Импорт bundled-ассетов:
 #    blobs  → $base/files/fake/   (--blob=...:@bin/*.bin)
 #    lua    → $base/lua/          (--lua-init=@lua/*.lua)
 #    lists  → $base/lists/        (--hostlist=lists/*.txt)
 #    ipset  → $base/ipset/        (--ipset[-exclude]=lists/ipset-*.txt)
 #    плюс bundled-стратегии → catalogs/basic|advanced|builtin.
+IMP_LOG="/tmp/zapret-gui-import.log"
 if [ -f "$APP_DIR/core/asset_importer.py" ] && [ -d "$APP_DIR/import" ]; then
     echo "  Импорт blobs/lua/lists/ipset/стратегий..."
     if env PYTHONPATH="$APP_DIR" python3 \
-            -m core.asset_importer --only all >/tmp/zapret-gui-import.log 2>&1; then
-        echo "  ✓ Ассеты импортированы"
+            -m core.asset_importer --only all >"$IMP_LOG" 2>&1; then
+        # Краткая статистика по реально лежащим в zapret2 файлам
+        BASE="/opt/zapret2"
+        FAKE_N=$(find "$BASE/files/fake" -maxdepth 1 -type f 2>/dev/null | wc -l)
+        LUA_N=$(find "$BASE/lua"        -maxdepth 1 -type f 2>/dev/null | wc -l)
+        LIST_N=$(find "$BASE/lists"     -maxdepth 1 -type f 2>/dev/null | wc -l)
+        IPSET_N=$(find "$BASE/ipset"    -maxdepth 1 -type f 2>/dev/null | wc -l)
+        echo "  ✓ Ассеты импортированы (files/fake=$FAKE_N, lua=$LUA_N, lists=$LIST_N, ipset=$IPSET_N)"
     else
-        echo "  ⚠ Ошибка импорта ассетов (см. /tmp/zapret-gui-import.log)"
+        echo "  ⚠ Ошибка импорта ассетов (см. $IMP_LOG)"
+        tail -5 "$IMP_LOG" 2>/dev/null | sed 's/^/    /' || true
     fi
 else
     if [ ! -d "$APP_DIR/import" ]; then
@@ -59,7 +98,7 @@ else
     fi
 fi
 
-# 7. Проверяем и устанавливаем bottle
+# 8. Проверяем и устанавливаем bottle
 if ! python3 -c "import bottle" 2>/dev/null; then
     echo "  Установка bottle (python3-bottle недоступен в opkg)..."
     if python3 -m pip install bottle --quiet 2>/dev/null; then
@@ -84,20 +123,16 @@ fi
 
 echo ""
 echo "  ✓ Zapret Web-GUI установлен в $APP_DIR"
-echo ""
 
-# 8. Перезапуск сервиса, если он был запущен.
-#    Без рестарта старый python-процесс продолжит работать со
-#    старым кодом и GUI_VERSION в памяти — пользователь увидит
-#    предыдущую версию даже после успешной установки нового IPK.
-if [ -x "$INITD_SCRIPT" ]; then
-    PID_FILE="/opt/var/run/zapret-gui.pid"
-    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE" 2>/dev/null)" 2>/dev/null; then
-        echo "  Перезапуск Zapret Web-GUI..."
-        "$INITD_SCRIPT" restart >/dev/null 2>&1 \
-            && echo "  ✓ Сервис перезапущен" \
-            || echo "  ⚠ Не удалось перезапустить ($INITD_SCRIPT restart)"
-    fi
+# 9. Запускаем сервис, если он работал до установки.
+#    Старый процесс мы уже убили выше, поэтому если был запущен — стартуем
+#    свежий с обновлённым кодом и версией.
+if [ -n "$WAS_RUNNING" ] && [ -x "$INITD_SCRIPT" ]; then
+    echo ""
+    echo "  Запуск Zapret Web-GUI..."
+    "$INITD_SCRIPT" start >/dev/null 2>&1 \
+        && echo "  ✓ Сервис запущен" \
+        || echo "  ⚠ Не удалось запустить ($INITD_SCRIPT start)"
 fi
 
 echo ""

--- a/packaging/openwrt/postinst
+++ b/packaging/openwrt/postinst
@@ -8,6 +8,25 @@ CONFIG_DIR="/etc/zapret-gui"
 
 echo "Zapret Web-GUI — установка (OpenWrt)"
 
+# Запоминаем, был ли запущен сервис, и аккуратно глушим его + любые
+# осиротевшие python-процессы. Иначе старый код продолжит крутиться в памяти,
+# держать порт 8080 и пользователь будет видеть предыдущую GUI_VERSION
+# даже после успешной установки нового IPK.
+WAS_RUNNING=""
+if /etc/init.d/zapret-gui running 2>/dev/null; then
+    WAS_RUNNING=1
+fi
+/etc/init.d/zapret-gui stop >/dev/null 2>&1 || true
+if command -v pgrep >/dev/null 2>&1; then
+    for pid in $(pgrep -f "python.* $APP_DIR/app.py" 2>/dev/null); do
+        kill "$pid" 2>/dev/null || true
+    done
+    sleep 1
+    for pid in $(pgrep -f "python.* $APP_DIR/app.py" 2>/dev/null); do
+        kill -9 "$pid" 2>/dev/null || true
+    done
+fi
+
 # Создаём директории
 mkdir -p "$CONFIG_DIR" 2>/dev/null || true
 mkdir -p "$APP_DIR/config/strategies/user" 2>/dev/null || true
@@ -21,33 +40,49 @@ chmod 755 "$APP_DIR/app.py" 2>/dev/null || true
 # Включаем автозапуск
 /etc/init.d/zapret-gui enable 2>/dev/null || true
 
-# Очистка stale __pycache__ от предыдущей установки (см. entware/postinst).
+# Очистка stale __pycache__/*.pyc — иначе python загрузит старый .pyc
+# и GUI продолжит показывать предыдущую версию.
 find "$APP_DIR" -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
 find "$APP_DIR" -name '*.pyc' -delete 2>/dev/null || true
 
-# Импортируем bundled-ассеты:
-#   blobs  → /opt/zapret2/files/fake/  (--blob=...:@bin/*.bin)
-#   lua    → /opt/zapret2/lua/         (--lua-init=@lua/*.lua)
-#   lists  → /opt/zapret2/lists/       (--hostlist=lists/*.txt)
-#   ipset  → /opt/zapret2/ipset/       (--ipset[-exclude]=lists/ipset-*.txt)
+# Сообщаем установленную версию
+VERSION_PY="$APP_DIR/core/version.py"
+if [ -f "$VERSION_PY" ]; then
+    INSTALLED_VER=$(grep '^GUI_VERSION' "$VERSION_PY" 2>/dev/null \
+        | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+    [ -n "$INSTALLED_VER" ] && echo "  ✓ Установлен: zapret-gui v$INSTALLED_VER"
+fi
+
+# Импорт bundled-ассетов:
+#   blobs  → /opt/zapret2/files/fake/
+#   lua    → /opt/zapret2/lua/
+#   lists  → /opt/zapret2/lists/       (hostlist'ы)
+#   ipset  → /opt/zapret2/ipset/       (ipset-*.txt и *-ipset.txt)
+IMP_LOG="/tmp/zapret-gui-import.log"
 if [ -f "$APP_DIR/core/asset_importer.py" ] && [ -d "$APP_DIR/import" ]; then
     echo "  Импорт blobs/lua/lists/ipset/стратегий..."
     if env PYTHONPATH="$APP_DIR" python3 \
-            -m core.asset_importer --only all >/tmp/zapret-gui-import.log 2>&1; then
-        echo "  ✓ Ассеты импортированы"
+            -m core.asset_importer --only all >"$IMP_LOG" 2>&1; then
+        BASE="/opt/zapret2"
+        FAKE_N=$(find "$BASE/files/fake" -maxdepth 1 -type f 2>/dev/null | wc -l)
+        LUA_N=$(find "$BASE/lua"        -maxdepth 1 -type f 2>/dev/null | wc -l)
+        LIST_N=$(find "$BASE/lists"     -maxdepth 1 -type f 2>/dev/null | wc -l)
+        IPSET_N=$(find "$BASE/ipset"    -maxdepth 1 -type f 2>/dev/null | wc -l)
+        echo "  ✓ Ассеты импортированы (files/fake=$FAKE_N, lua=$LUA_N, lists=$LIST_N, ipset=$IPSET_N)"
     else
-        echo "  ⚠ Ошибка импорта ассетов (см. /tmp/zapret-gui-import.log)"
+        echo "  ⚠ Ошибка импорта ассетов (см. $IMP_LOG)"
+        tail -5 "$IMP_LOG" 2>/dev/null | sed 's/^/    /' || true
     fi
 elif [ ! -d "$APP_DIR/import" ]; then
     echo "  ⚠ $APP_DIR/import отсутствует — bundled-ассеты не импортированы"
 fi
 
-# Перезапуск, если сервис уже был запущен.
-if /etc/init.d/zapret-gui running 2>/dev/null; then
-    echo "  Перезапуск Zapret Web-GUI..."
-    /etc/init.d/zapret-gui restart >/dev/null 2>&1 \
-        && echo "  ✓ Сервис перезапущен" \
-        || echo "  ⚠ Не удалось перезапустить"
+# Стартуем сервис, если он работал до установки.
+if [ -n "$WAS_RUNNING" ]; then
+    echo "  Запуск Zapret Web-GUI..."
+    /etc/init.d/zapret-gui start >/dev/null 2>&1 \
+        && echo "  ✓ Сервис запущен" \
+        || echo "  ⚠ Не удалось запустить"
 fi
 
 # Проверяем и устанавливаем bottle


### PR DESCRIPTION
…rt stats

после opkg install свежего IPK GUI продолжает показывать предыдущую версию и файлы из import/ не оказываются в /opt/zapret2/. Скачанный IPK сам по себе корректный (проверено: 0.16.3 содержит верный version.py, import/ и обновлённый postinst), значит проблема возникает при применении пакета на роутере.

Главная гипотеза: предыдущий python-процесс zapret-gui продолжает крутиться в памяти и держать порт 8080. S99zapret-gui видит живой PID и не перезапускает сервис, пользователь видит старую GUI_VERSION, загруженную в память до установки.

postinst (entware/openwrt) теперь:
* до распаковки/импорта явно стопит сервис и УБИВАЕТ любой осиротевший процесс по cmdline (pgrep -f "python.* $APP_DIR/app.py", сначала TERM, потом KILL) — это страхует от ситуации, когда PID-файл протух или сервис был запущен не через init.d.
* запоминает, был ли запущен сервис ДО установки, и если да — стартует его в самом конце, чтобы новый python подхватил обновлённый код.
* выводит фактическую установленную версию (`grep GUI_VERSION $APP_DIR/core/version.py`) — пользователь сразу видит в выводе opkg install, что именно лежит на диске.
* после импорта показывает количество файлов в каждой целевой директории (files/fake, lua, lists, ipset) — это сразу подсвечивает, если в зап-2 что-то не доехало.

Версия: 0.16.3 → 0.16.4.