### PR TITLE
Deep probe & target profiles for strategy scanning

### DIFF
--- a/core/catalog_loader.py
+++ b/core/catalog_loader.py
@@ -75,9 +75,11 @@ _VALID_LABELS = frozenset({
 _QUICK_SET_SIZE = 30
 _STANDARD_SET_SIZE = 80
 
-# Уровни, которые НЕ используются scanner-ом
-# (builtin — полные конфигурации с --filter-*, не отдельные приёмы desync)
-_SCANNER_EXCLUDED_LEVELS = frozenset({"builtin"})
+# Уровни, которые НЕ используются scanner-ом.
+# Раньше сюда попадал "builtin", но сейчас полные пресеты как раз
+# нужны — у них есть собственные --filter-*/--hostlist=, и они часто
+# самые рабочие. Сканер их использует как-есть, не модифицируя args.
+_SCANNER_EXCLUDED_LEVELS: frozenset = frozenset()
 
 # Директории, которые НЕ содержат INI-каталоги
 # (presets/ содержит raw-файлы пресетов, конвертированных в JSON)

--- a/core/models.py
+++ b/core/models.py
@@ -279,7 +279,12 @@ class BlockcheckReport:
 
 @dataclass
 class StrategyProbeResult:
-    """Результат проверки одной стратегии на одной цели."""
+    """Результат проверки одной стратегии на одной цели.
+
+    Поля throughput/body_passed/success_rate/score добавлены для глубокой
+    пробы: одной TLS-успехи мало, DPI часто пускает первые 16-20 КБ и
+    обрывает соединение. score используется для ранжирования.
+    """
 
     strategy_id: str
     strategy_name: str
@@ -290,6 +295,14 @@ class StrategyProbeResult:
     http_code: int = 0
     timestamp: float = 0.0
     protocol: str = "tcp"
+    # Пропускная способность тела (KB/s), 0 если body-проба не делалась
+    throughput_kbps: float = 0.0
+    # True, если удалось скачать > 21 КБ хотя бы на одном из test_hosts
+    body_passed: bool = False
+    # Доля успешных под-проб 0..1 (TLS+body на нескольких хостах)
+    success_rate: float = 0.0
+    # Композитный балл, по которому сортируется UI
+    score: float = 0.0
     raw_data: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -307,6 +320,10 @@ class StrategyProbeResult:
             "http_code": self.http_code,
             "timestamp": self.timestamp,
             "protocol": self.protocol,
+            "throughput_kbps": round(self.throughput_kbps, 1),
+            "body_passed": self.body_passed,
+            "success_rate": round(self.success_rate, 3),
+            "score": round(self.score, 2),
             # FIX: включаем raw_data — содержит args_preview, details и др.
             "raw_data": self.raw_data,
         }

--- a/core/scan_targets.py
+++ b/core/scan_targets.py
@@ -1,0 +1,298 @@
+# core/scan_targets.py
+"""
+Профили целей для подбора стратегий.
+
+Каждой популярной цели (youtube, discord, telegram, ...) сопоставляется
+набор тестовых хостов, ожидаемых hostlist'ов и параметров фильтрации
+nfqws2 (--filter-l7, --payload, порты TCP/UDP).
+
+Используется strategy_scanner для:
+  1) построения временного hostlist'а под конкретную цель скана
+     (чтобы nfqws2 действительно "видел" SNI/Host цели);
+  2) обогащения "приёмов" (catalogs/basic|advanced|direct) корректными
+     --filter-l7=/--payload= под TCP/UDP;
+  3) расширенной пробы (несколько test_hosts, тело >=64 KB на TCP).
+
+Полные пресеты (catalogs/builtin/*) используются как есть — у них уже
+свои --filter-*/--hostlist=, мы их не трогаем.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ScanTarget:
+    """Профиль цели сканирования."""
+
+    # Ключ профиля ("youtube", "discord", ...) — для логов и UI.
+    key: str
+
+    # Основной домен ("youtube.com") — он же берётся из формы.
+    primary_host: str = ""
+
+    # Дополнительные домены, которые тоже нужно протестировать,
+    # чтобы исключить «псевдо-успехи» (когда главный пускают, а CDN режут).
+    test_hosts: list[str] = field(default_factory=list)
+
+    # Все домены, которые добавляются во временный hostlist nfqws2.
+    # Если пусто — берётся primary_host + test_hosts.
+    hostlist_domains: list[str] = field(default_factory=list)
+
+    # Имена hostlist-файлов (без пути), которые ожидаются в zapret2/lists/.
+    # Если присутствуют — подставляются в "trick"-стратегии вместо other.txt.
+    expected_hostlists: list[str] = field(default_factory=list)
+
+    # TCP-параметры
+    tcp_ports: str = "443"
+    tcp_l7: str = "tls"
+    tcp_payload: str = "tls_client_hello"
+
+    # UDP-параметры
+    udp_ports: str = "443"
+    udp_l7: str = "quic"
+    udp_payload: str = "quic_initial"
+
+    # URL для тяжёлой пробы (загрузка >=64 KB).
+    # Используется для детекта 16-20 KB DPI-блокировки.
+    # Если пусто — собирается на лету: https://<primary_host>/
+    probe_url: str = ""
+
+    def all_hostlist_domains(self) -> list[str]:
+        """Список доменов для временного hostlist nfqws2."""
+        if self.hostlist_domains:
+            return list(self.hostlist_domains)
+        out: list[str] = []
+        if self.primary_host:
+            out.append(self.primary_host)
+        for h in self.test_hosts:
+            if h not in out:
+                out.append(h)
+        return out
+
+    def get_probe_url(self) -> str:
+        """URL для body-download пробы."""
+        return self.probe_url or ("https://%s/" % self.primary_host)
+
+
+# ═══════════════════════════════════════════════════════════
+#  Известные профили
+# ═══════════════════════════════════════════════════════════
+
+_KNOWN: dict[str, ScanTarget] = {
+    "youtube": ScanTarget(
+        key="youtube",
+        primary_host="youtube.com",
+        test_hosts=[
+            "www.youtube.com",
+            "i.ytimg.com",
+            "yt3.ggpht.com",
+        ],
+        # nfqws2 хостлист матчит по точному совпадению SNI/Host;
+        # для youtube QUIC/TLS реально нужны три семейства доменов.
+        hostlist_domains=[
+            "youtube.com",
+            "www.youtube.com",
+            "m.youtube.com",
+            "youtu.be",
+            "youtubei.googleapis.com",
+            "youtube-nocookie.com",
+            "googlevideo.com",
+            "rr1---sn-axq7sn7s.googlevideo.com",
+            "ytimg.com",
+            "i.ytimg.com",
+            "yt3.ggpht.com",
+            "ggpht.com",
+            "lh3.googleusercontent.com",
+            "yt3.googleusercontent.com",
+        ],
+        expected_hostlists=[
+            "youtube.txt",
+            "youtubeGV.txt",
+            "youtubeQ.txt",
+            "youtube_v2.txt",
+        ],
+        tcp_ports="80,443",
+        tcp_l7="tls",
+        tcp_payload="tls_client_hello",
+        udp_ports="443",
+        udp_l7="quic",
+        udp_payload="quic_initial",
+        probe_url="https://i.ytimg.com/generate_204",
+    ),
+    "discord": ScanTarget(
+        key="discord",
+        primary_host="discord.com",
+        test_hosts=[
+            "gateway.discord.gg",
+            "cdn.discordapp.com",
+            "media.discordapp.net",
+        ],
+        hostlist_domains=[
+            "discord.com",
+            "discordapp.com",
+            "discord.gg",
+            "discord.media",
+            "discord-attachments-uploads-prd.storage.googleapis.com",
+            "gateway.discord.gg",
+            "cdn.discordapp.com",
+            "media.discordapp.net",
+        ],
+        expected_hostlists=["discord.txt"],
+        tcp_ports="443",
+        tcp_l7="tls",
+        tcp_payload="tls_client_hello",
+        udp_ports="50000-65535",  # Discord voice
+        udp_l7="discord",
+        udp_payload="",
+        probe_url="https://discord.com/api/v9/gateway",
+    ),
+    "telegram": ScanTarget(
+        key="telegram",
+        primary_host="web.telegram.org",
+        test_hosts=["telegram.org", "t.me"],
+        hostlist_domains=[
+            "telegram.org",
+            "web.telegram.org",
+            "telegram.me",
+            "t.me",
+            "cdn-telegram.org",
+        ],
+        expected_hostlists=["telegram.txt"],
+        tcp_ports="443",
+        tcp_l7="tls",
+        tcp_payload="tls_client_hello",
+        udp_ports="443",
+        udp_l7="quic",
+        udp_payload="quic_initial",
+        probe_url="https://web.telegram.org/k/",
+    ),
+    "instagram": ScanTarget(
+        key="instagram",
+        primary_host="instagram.com",
+        test_hosts=["www.instagram.com", "i.instagram.com"],
+        hostlist_domains=[
+            "instagram.com",
+            "www.instagram.com",
+            "i.instagram.com",
+            "scontent.cdninstagram.com",
+            "cdninstagram.com",
+        ],
+        expected_hostlists=["instagram.txt"],
+    ),
+    "twitter": ScanTarget(
+        key="twitter",
+        primary_host="x.com",
+        test_hosts=["twitter.com", "abs.twimg.com"],
+        hostlist_domains=[
+            "x.com",
+            "twitter.com",
+            "t.co",
+            "twimg.com",
+            "abs.twimg.com",
+            "video.twimg.com",
+        ],
+        expected_hostlists=["twitter.txt"],
+    ),
+    "facebook": ScanTarget(
+        key="facebook",
+        primary_host="facebook.com",
+        test_hosts=["www.facebook.com", "scontent.xx.fbcdn.net"],
+        hostlist_domains=[
+            "facebook.com",
+            "www.facebook.com",
+            "fbcdn.net",
+            "scontent.xx.fbcdn.net",
+        ],
+        expected_hostlists=["facebook.txt"],
+    ),
+    "google": ScanTarget(
+        key="google",
+        primary_host="www.google.com",
+        test_hosts=["google.com", "fonts.gstatic.com"],
+        hostlist_domains=[
+            "google.com",
+            "www.google.com",
+            "gstatic.com",
+            "fonts.gstatic.com",
+        ],
+    ),
+}
+
+
+# Маппинг признаков в имени домена → ключ профиля.
+# Порядок важен: YouTube ловится по нескольким альтернативным именам.
+_HOST_HINTS = (
+    ("youtube", "youtube"),
+    ("ytimg",   "youtube"),
+    ("ggpht",   "youtube"),
+    ("googlevideo", "youtube"),
+    ("youtu.be", "youtube"),
+    ("discord", "discord"),
+    ("telegram", "telegram"),
+    ("t.me",    "telegram"),
+    ("instagram", "instagram"),
+    ("cdninstagram", "instagram"),
+    ("twitter", "twitter"),
+    ("twimg",   "twitter"),
+    ("x.com",   "twitter"),
+    ("facebook", "facebook"),
+    ("fbcdn",   "facebook"),
+    ("google",  "google"),
+)
+
+
+def detect_target(host: str) -> ScanTarget:
+    """
+    Определить профиль цели по имени домена.
+
+    Если профиль не известен — собирается generic-профиль на основе
+    переданного хоста (без расширенного списка hostlist_domains).
+    """
+    host_lower = (host or "").strip().lower()
+    if not host_lower:
+        host_lower = "youtube.com"
+
+    for hint, key in _HOST_HINTS:
+        if hint in host_lower:
+            base = _KNOWN[key]
+            # Если пользователь указал нестандартный домен — добавляем его
+            # в primary_host и в hostlist_domains как первую запись.
+            if host_lower != base.primary_host:
+                merged_domains = [host_lower] + [
+                    d for d in base.hostlist_domains if d != host_lower
+                ]
+                merged_tests = [host_lower] + [
+                    h for h in base.test_hosts if h != host_lower
+                ]
+                return ScanTarget(
+                    key=base.key,
+                    primary_host=host_lower,
+                    test_hosts=merged_tests[:4],
+                    hostlist_domains=merged_domains,
+                    expected_hostlists=list(base.expected_hostlists),
+                    tcp_ports=base.tcp_ports,
+                    tcp_l7=base.tcp_l7,
+                    tcp_payload=base.tcp_payload,
+                    udp_ports=base.udp_ports,
+                    udp_l7=base.udp_l7,
+                    udp_payload=base.udp_payload,
+                    probe_url=base.probe_url,
+                )
+            return base
+
+    # Generic профиль для незнакомой цели.
+    return ScanTarget(
+        key="generic",
+        primary_host=host_lower,
+        test_hosts=[host_lower],
+        hostlist_domains=[host_lower],
+        tcp_ports="443",
+        tcp_l7="tls",
+        tcp_payload="tls_client_hello",
+        udp_ports="443",
+        udp_l7="quic",
+        udp_payload="quic_initial",
+    )

--- a/core/strategy_scanner.py
+++ b/core/strategy_scanner.py
@@ -49,12 +49,21 @@ from core.models import (
 #  Constants
 # ═══════════════════════════════════════════════════════════
 
-# Таймауты (увеличены для роутера)
-STABILIZATION_DELAY = 2.0       # Ожидание после запуска nfqws2
-PROBE_TIMEOUT = 10              # Таймаут проверки TLS/STUN
-STUN_PROBE_TIMEOUT = 5          # Таймаут STUN-пробы
+# Таймауты (значения по умолчанию; могут быть переопределены в конфиге).
+# Раньше PROBE_TIMEOUT был 10с — это и было главной причиной «медленно»:
+# каждая неудачная стратегия съедала весь TLS-таймаут.
+STABILIZATION_DELAY = 1.0       # Ожидание после запуска nfqws2
+PROBE_TIMEOUT = 6               # Таймаут TLS handshake
+BODY_PROBE_TIMEOUT = 8          # Таймаут body-загрузки (>=64 KB)
+STUN_PROBE_TIMEOUT = 4          # Таймаут STUN-пробы (UDP)
 KILL_TIMEOUT = 4                # Ожидание остановки nfqws2
-INTER_STRATEGY_DELAY = 0.5     # Пауза между стратегиями
+INTER_STRATEGY_DELAY = 0.3      # Пауза между стратегиями
+BODY_PROBE_MIN_BYTES = 65_536   # Минимум для прохождения 16-20 KB барьера
+
+# Tmp hostlist для приёмов (basic/advanced/direct), обогащённый доменами
+# цели. nfqws2 матчит SNI/Host строго по записям; без них десинк
+# не применяется к трафику цели и проба всегда падает.
+TMP_HOSTLIST_PATH = "/tmp/zapret-gui-scan-target.txt"
 
 # Resume state
 RESUME_FILE = "/tmp/zapret-gui-scan-resume.json"
@@ -106,6 +115,10 @@ class StrategyScanner:
         self._protocol = "tcp"
         self._mode = "quick"
         self._start_index = 0
+        # Профиль цели (см. core/scan_targets.py)
+        self._scan_profile = None  # type: ignore[var-annotated]
+        # Путь временного hostlist'а для приёмов (создаётся в _run_scan)
+        self._tmp_hostlist: Optional[str] = None
 
         # Saved state (for restoring nfqws after scan)
         self._saved_nfqws_running = False
@@ -310,6 +323,18 @@ class StrategyScanner:
             # 1. Сохраняем текущее состояние nfqws/firewall
             self._save_current_state()
 
+            # 1a. Готовим профиль цели + tmp hostlist для приёмов
+            from core.scan_targets import detect_target
+            self._scan_profile = detect_target(self._target)
+            self._ensure_tmp_hostlist()
+            log.info(
+                "Профиль цели: %s, тестовых хостов: %d, hostlist в %s"
+                % (self._scan_profile.key,
+                   len(self._scan_profile.test_hosts) + 1,
+                   self._tmp_hostlist or "—"),
+                source="scanner",
+            )
+
             # 2. Загружаем стратегии из каталога
             strategies = self._select_strategies()
             if not strategies:
@@ -491,6 +516,9 @@ class StrategyScanner:
             # КРИТИЧЕСКИ ВАЖНО: гарантируем cleanup
             self._ensure_cleanup()
 
+            # Удаляем временный hostlist
+            self._remove_tmp_hostlist()
+
             # Восстанавливаем предыдущее состояние nfqws
             self._restore_previous_state()
 
@@ -504,6 +532,10 @@ class StrategyScanner:
         """
         Выбрать стратегии из каталога по режиму и протоколу.
 
+        Порядок: сначала full-presets (level=builtin) — у них собственные
+        --filter-*/--hostlist=, шанс успеха высокий; затем «приёмы»
+        (basic/advanced/direct), которые сканер обогащает шаблоном цели.
+
         Returns:
             Список CatalogEntry для тестирования.
         """
@@ -512,12 +544,54 @@ class StrategyScanner:
         cm = get_catalog_manager()
         protocol = self._protocol
 
+        # quick/standard/full — отбираем кандидатов из каталога
         if self._mode == "quick":
             entries = cm.get_quick_set(protocol=protocol)
         elif self._mode == "standard":
             entries = cm.get_standard_set(protocol=protocol)
         else:  # full
             entries = cm.get_full_set(protocol=protocol)
+
+        # quick может оказаться без builtin (label=recommended нет у
+        # пресетов). Подставляем топ-N builtin в начало, общий размер
+        # quick остаётся ~30.
+        if self._mode == "quick":
+            builtin_full = [
+                e for e in cm.get_catalog_entries(
+                    protocol=protocol, level="builtin")
+                if _is_full_preset_entry(e)
+            ]
+            top_builtin = builtin_full[:10]
+            existing_ids = {e.section_id for e in top_builtin}
+            tail = [e for e in entries if e.section_id not in existing_ids]
+            # Суммарно ~30: до 10 builtin + добор приёмами
+            entries = top_builtin + tail[: max(20, 30 - len(top_builtin))]
+
+        # standard — добавим побольше builtin (до 20 шт.)
+        elif self._mode == "standard":
+            builtin_full = [
+                e for e in cm.get_catalog_entries(
+                    protocol=protocol, level="builtin")
+                if _is_full_preset_entry(e)
+            ]
+            top_builtin = builtin_full[:20]
+            existing_ids = {e.section_id for e in top_builtin}
+            tail = [e for e in entries if e.section_id not in existing_ids]
+            entries = top_builtin + tail
+
+        # Сортировка: full presets вперёд, recommended вторыми
+        def _sort_key(e: CatalogEntry) -> tuple:
+            full = _is_full_preset_entry(e)
+            recommended = (e.label == "recommended")
+            # 0 — самый приоритетный
+            return (
+                0 if full else (1 if recommended else 2),
+                # внутри группы — стабильный порядок
+                e.source_file,
+                e.section_id,
+            )
+
+        entries.sort(key=_sort_key)
 
         # Применяем start_index для resume
         if self._start_index > 0 and self._start_index < len(entries):
@@ -650,35 +724,37 @@ class StrategyScanner:
                     },
                 )
 
-            # 6. Проба доступности
-            if self._protocol == "udp":
-                probe_result = self._probe_stun()
-            else:
-                probe_result = self._probe_tls()
+            # 6. Проба доступности — глубокая, с детектом 16-20 KB
+            probe = self._deep_probe()
 
             elapsed_ms = (time.time() - start_time) * 1000
 
             # 7. Формируем результат
-            success = probe_result.status == TestStatus.SUCCESS.value
-
             return StrategyProbeResult(
                 strategy_id=entry.section_id,
                 strategy_name=entry.name,
                 target=self._target,
-                success=success,
-                latency_ms=round(probe_result.latency_ms, 2),
-                error="" if success else (probe_result.error or probe_result.details),
-                http_code=probe_result.raw_data.get("status_code", 0)
-                    if success else 0,
+                success=probe["success"],
+                latency_ms=round(probe["latency_ms"], 2),
+                error=probe["error"],
+                http_code=probe["http_code"],
                 protocol=self._protocol,
+                throughput_kbps=probe["kbps"],
+                body_passed=probe["body_passed"],
+                success_rate=probe["success_rate"],
+                score=probe["score"],
                 raw_data={
-                    "test_type": probe_result.test_type,
-                    "details": probe_result.details,
+                    "test_type": probe["test_type"],
+                    "details": probe["details"],
                     "args_preview": args_full,
                     "source_file": entry.source_file,
                     "level": entry.level,
                     "label": entry.label,
                     "probe_elapsed_ms": round(elapsed_ms, 1),
+                    "probe_per_host": probe["per_host"],
+                    "is_full_preset": _is_full_preset_args(
+                        entry.get_args_list()
+                    ),
                 },
             )
 
@@ -729,16 +805,19 @@ class StrategyScanner:
         """
         Собрать аргументы nfqws2 из записи каталога.
 
-        Включает:
-        - Аргументы стратегии из CatalogEntry.args
-        - Резолвинг путей (@lua/, lists/)
-        - Фильтры по протоколу (--filter-tcp/--filter-udp)
+        Различает два типа стратегий:
 
-        Базовые аргументы (--user, --fwmark, --qnum, --lua-init)
-        добавляются автоматически NFQWSManager._build_base_args().
+        ▸ Full preset (catalogs/builtin/* и подобные с собственными
+          --filter-*/--hostlist=/--new): берём args как-есть, только
+          резолвим пути @lua/, @bin/, lists/.
 
-        Returns:
-            list[str] аргументов для NFQWSManager.start().
+        ▸ Trick (catalogs/basic|advanced|direct: один-два
+          --lua-desync=...): оборачиваем в шаблон цели — добавляем
+          --filter-tcp/udp + порт, --filter-l7=, --payload= и --hostlist=
+          с временным файлом, в котором перечислены домены цели.
+
+        Базовые аргументы (--user, --fwmark, --qnum, --lua-init) добавляет
+        NFQWSManager._build_base_args().
         """
         from core.catalog_loader import CatalogManager
         from core.config_manager import get_config_manager
@@ -749,53 +828,270 @@ class StrategyScanner:
                              default="/opt/zapret2/lists")
         bin_path = cfg.get("zapret", "bin_path",
                            default="/opt/zapret2/bin")
+        ipset_path = cfg.get("zapret", "ipset_path",
+                             default="/opt/zapret2/ipset")
 
-        # Получаем аргументы из записи каталога
         raw_args = CatalogManager.build_nfqws_args_from_entry(entry)
-
         if not raw_args:
             return []
 
-        # Резолвим пути (@lua/ → /opt/zapret2/lua/, @bin/ → /opt/zapret2/bin/,
-        #               lists/ → ...)
-        resolved = CatalogManager.resolve_paths_in_args(
+        is_full = _is_full_preset_args(raw_args)
+
+        if is_full:
+            # Полный пресет — ничего не дописываем, только резолвим пути.
+            return CatalogManager.resolve_paths_in_args(
+                raw_args,
+                lua_path=lua_path,
+                lists_path=lists_path,
+                bin_path=bin_path,
+                ipset_path=ipset_path,
+            )
+
+        # Trick: разворачиваем под цель
+        return self._wrap_trick_args(
             raw_args,
             lua_path=lua_path,
             lists_path=lists_path,
             bin_path=bin_path,
+            ipset_path=ipset_path,
         )
 
-        # Добавляем фильтры протокола если их нет в аргументах стратегии
-        has_filter = any(
-            a.startswith("--filter-tcp") or a.startswith("--filter-udp")
-            for a in resolved
+    def _wrap_trick_args(
+        self,
+        raw_args: list[str],
+        *,
+        lua_path: str,
+        lists_path: str,
+        bin_path: str,
+        ipset_path: str,
+    ) -> list[str]:
+        """Обернуть «приём» в шаблон под self._scan_profile."""
+        from core.catalog_loader import CatalogManager
+        from core.scan_targets import detect_target
+
+        profile = self._scan_profile or detect_target(self._target)
+
+        # --filter-* + порты + l7 + payload
+        if self._protocol == "udp":
+            filter_arg = "--filter-udp=%s" % profile.udp_ports
+            l7_arg = ("--filter-l7=%s" % profile.udp_l7) if profile.udp_l7 else ""
+            payload_arg = (
+                "--payload=%s" % profile.udp_payload
+            ) if profile.udp_payload else ""
+        else:
+            filter_arg = "--filter-tcp=%s" % profile.tcp_ports
+            l7_arg = ("--filter-l7=%s" % profile.tcp_l7) if profile.tcp_l7 else ""
+            payload_arg = (
+                "--payload=%s" % profile.tcp_payload
+            ) if profile.tcp_payload else ""
+
+        # Hostlist: tmp-файл (создан в _ensure_tmp_hostlist) с доменами цели.
+        # Если по какой-то причине файла нет — пропускаем --hostlist и
+        # nfqws2 будет десинхронизировать весь трафик по фильтру.
+        hostlist_arg = ""
+        if self._tmp_hostlist and os.path.isfile(self._tmp_hostlist):
+            hostlist_arg = "--hostlist=%s" % self._tmp_hostlist
+
+        wrapped: list[str] = []
+        if filter_arg:
+            wrapped.append(filter_arg)
+        if l7_arg:
+            wrapped.append(l7_arg)
+        if hostlist_arg:
+            wrapped.append(hostlist_arg)
+        if payload_arg:
+            wrapped.append(payload_arg)
+        wrapped.extend(raw_args)
+
+        # Резолвим пути в самих raw_args (могут содержать @lua/, @bin/, lists/)
+        return CatalogManager.resolve_paths_in_args(
+            wrapped,
+            lua_path=lua_path,
+            lists_path=lists_path,
+            bin_path=bin_path,
+            ipset_path=ipset_path,
         )
-
-        if not has_filter:
-            if self._protocol == "udp":
-                resolved = ["--filter-udp=443"] + resolved
-            else:
-                resolved = ["--filter-tcp=443"] + resolved
-
-        # Добавляем hostlist если его нет
-        has_hostlist = any(
-            a.startswith("--hostlist=") or a.startswith("--hostlist-exclude=")
-            for a in resolved
-        )
-
-        if not has_hostlist:
-            hostlist_path = os.path.join(lists_path, "other.txt")
-            if os.path.isfile(hostlist_path):
-                # Вставляем после --filter-*
-                insert_pos = 0
-                for i, a in enumerate(resolved):
-                    if a.startswith("--filter-"):
-                        insert_pos = i + 1
-                resolved.insert(insert_pos, "--hostlist=%s" % hostlist_path)
-
-        return resolved
 
     # ─────────────────── Probe tests ───────────────────
+
+    def _deep_probe(self) -> dict[str, Any]:
+        """Глубокая проба: TLS gate + body-загрузка по нескольким хостам.
+
+        Возвращает словарь с ключами:
+            success, latency_ms, error, http_code,
+            kbps, body_passed, success_rate, score,
+            test_type, details, per_host (list[dict]).
+
+        Алгоритм:
+          1) Для каждого test_host (1 в quick, 2 в standard, все в full):
+             a) TLS handshake (быстрый gate; если падает — суб-неудача).
+             b) Body-загрузка ≥64 КБ — отсеиваем «псевдо-успехи»,
+                когда DPI пускает первые 16-20 КБ и обрывает.
+          2) Композитный score = success_rate × min(kbps, 2048) /
+             max(latency_ms, 50).
+        """
+        from core.testers.tls_tester import test_tls
+        from core.testers.body_tester import probe_body
+        from core.scan_targets import detect_target
+
+        profile = self._scan_profile or detect_target(self._target)
+
+        # UDP: ничего лучше STUN сейчас не умеем.
+        if self._protocol == "udp":
+            stun = self._probe_stun()
+            ok = stun.status == TestStatus.SUCCESS.value
+            kbps = 0.0
+            return {
+                "success": ok,
+                "latency_ms": stun.latency_ms,
+                "error": "" if ok else (stun.error or stun.details),
+                "http_code": 0,
+                "kbps": kbps,
+                "body_passed": False,
+                "success_rate": 1.0 if ok else 0.0,
+                "score": (1.0 / max(stun.latency_ms, 50.0)) * 1000.0
+                         if ok else 0.0,
+                "test_type": stun.test_type,
+                "details": stun.details,
+                "per_host": [{
+                    "host": self._target,
+                    "tls_ok": ok,
+                    "body_ok": False,
+                    "kbps": kbps,
+                    "latency_ms": stun.latency_ms,
+                    "details": stun.details,
+                }],
+            }
+
+        # TCP: TLS + body
+        hosts = self._select_test_hosts(profile)
+
+        per_host: list[dict[str, Any]] = []
+        sum_latency = 0.0
+        sum_kbps = 0.0
+        kbps_count = 0
+        body_ok_count = 0
+        tls_ok_count = 0
+        any_http_code = 0
+
+        for host in hosts:
+            # Шаг 1: TLS handshake — быстрый gate
+            tls_res = test_tls(
+                host=host, port=443, timeout=PROBE_TIMEOUT,
+            )
+            tls_ok = tls_res.status == TestStatus.SUCCESS.value
+            if tls_ok:
+                tls_ok_count += 1
+                any_http_code = tls_res.raw_data.get("status_code", 0) or any_http_code
+
+            host_entry: dict[str, Any] = {
+                "host": host,
+                "tls_ok": tls_ok,
+                "body_ok": False,
+                "kbps": 0.0,
+                "latency_ms": tls_res.latency_ms,
+                "details": tls_res.details,
+            }
+
+            if not tls_ok:
+                per_host.append(host_entry)
+                continue
+
+            # Шаг 2: body-загрузка
+            url = (profile.get_probe_url()
+                   if host == profile.primary_host
+                   else "https://%s/" % host)
+            body = probe_body(
+                url=url,
+                min_bytes=BODY_PROBE_MIN_BYTES,
+                timeout=BODY_PROBE_TIMEOUT,
+            )
+            body_ok = body.status == TestStatus.SUCCESS.value
+            host_entry["body_ok"] = body_ok
+            host_entry["details"] = body.details
+            host_entry["kbps"] = body.raw_data.get("kbps", 0.0)
+            host_entry["bytes"] = body.raw_data.get("bytes_received", 0)
+            host_entry["dpi_marker"] = body.raw_data.get("dpi_marker", "")
+            host_entry["status_code"] = body.raw_data.get("status_code", 0)
+            host_entry["latency_ms"] = body.latency_ms
+
+            sum_latency += body.latency_ms
+            kbps = body.raw_data.get("kbps", 0.0) or 0.0
+            if body_ok:
+                body_ok_count += 1
+                sum_kbps += kbps
+                kbps_count += 1
+                any_http_code = body.raw_data.get("status_code", 0) or any_http_code
+
+            per_host.append(host_entry)
+
+        total_subprobes = max(len(hosts), 1)
+        # success_rate: 0.5 за TLS-only, 1.0 за TLS+body
+        weighted = (tls_ok_count * 0.4 + body_ok_count * 0.6) / total_subprobes
+        success_rate = round(weighted, 3)
+
+        # Стратегия "успешна" если хотя бы на одном хосте прошла body-проба.
+        # TLS-only без body — это «псевдо-успех» (классический 16-20 КБ).
+        success = body_ok_count > 0
+
+        avg_kbps = (sum_kbps / kbps_count) if kbps_count > 0 else 0.0
+        avg_latency = (sum_latency / total_subprobes) if per_host else 0.0
+
+        # Композитный score: чем выше скорость и ниже задержка, тем лучше;
+        # отсутствие body-успеха обнуляет.
+        if success:
+            score = success_rate * (min(avg_kbps, 2048.0) /
+                                    max(avg_latency, 50.0)) * 1000.0
+        else:
+            # Половинный score за частичный TLS-успех, чтобы они шли ниже
+            # «настоящих» удач, но всё же видимы в списке.
+            score = success_rate * 1.0
+
+        # Сообщение об ошибке для UI
+        if success:
+            err = ""
+        elif tls_ok_count == 0:
+            err = "TLS_FAIL"
+        else:
+            # TLS ok, но body не прошёл — почти наверняка 16-20 KB block
+            markers = {h.get("dpi_marker", "") for h in per_host}
+            if "tcp_16_20" in markers:
+                err = "TCP_16_20"
+            elif "short_body" in markers:
+                err = "SHORT_BODY"
+            else:
+                err = "BODY_FAIL"
+
+        details = "TLS %d/%d, body %d/%d, %.1f KB/s" % (
+            tls_ok_count, total_subprobes,
+            body_ok_count, total_subprobes,
+            avg_kbps,
+        )
+
+        return {
+            "success": success,
+            "latency_ms": avg_latency,
+            "error": err,
+            "http_code": any_http_code,
+            "kbps": round(avg_kbps, 1),
+            "body_passed": body_ok_count > 0,
+            "success_rate": success_rate,
+            "score": round(score, 2),
+            "test_type": "tls+body",
+            "details": details,
+            "per_host": per_host,
+        }
+
+    def _select_test_hosts(self, profile) -> list[str]:
+        """Сколько хостов проверять: 1 (quick) / 2 (standard) / все (full)."""
+        all_hosts = [profile.primary_host] + [
+            h for h in profile.test_hosts if h != profile.primary_host
+        ]
+        if self._mode == "quick":
+            return all_hosts[:1]
+        if self._mode == "standard":
+            return all_hosts[:2]
+        return all_hosts[:4]
 
     def _probe_tls(self) -> SingleTestResult:
         """Проверить доступность по TLS/HTTPS."""
@@ -1034,10 +1330,15 @@ class StrategyScanner:
         """Сформировать итоговый отчёт."""
         working = [r for r in self._results if r.success]
 
-        # Лучшая стратегия = минимальная latency
+        # Лучшая = максимальный score (success_rate × kbps/latency).
+        # Это надёжнее, чем просто latency: latency низкий бывает у
+        # «псевдо-успехов», у которых body обрывается на 16-20 KB.
         best: Optional[StrategyProbeResult] = None
         if working:
-            best = min(working, key=lambda r: r.latency_ms)
+            best = max(working, key=lambda r: r.score)
+
+        # Сортируем self._results по score (для UI)
+        self._results.sort(key=lambda r: r.score, reverse=True)
 
         self._report = StrategyScanReport(
             target=self._target,
@@ -1096,6 +1397,11 @@ class StrategyScanner:
                 source="scanner",
             )
             return False
+
+        # Если в args есть ссылка на TMP_HOSTLIST_PATH (это означает,
+        # что стратегия была trick-обёрткой), переписываем её в постоянный
+        # hostlist в lists_path — иначе после удаления tmp файл пропадёт.
+        args = self._materialize_tmp_hostlist(args, probe_result)
 
         # Создаём user-стратегию в JSON-формате
         sm = get_strategy_manager()
@@ -1165,6 +1471,51 @@ class StrategyScanner:
             )
             return False
 
+    def _materialize_tmp_hostlist(
+        self,
+        args: list[str],
+        probe_result: StrategyProbeResult,
+    ) -> list[str]:
+        """Заменить ссылку на TMP_HOSTLIST_PATH на постоянный файл.
+
+        При сканировании trick'ам подсовывается /tmp/...target.txt, который
+        удаляется в finally. Чтобы применённая стратегия пережила перезапуск
+        nfqws2, копируем содержимое в lists_path/zapret-gui-target-<key>.txt
+        и переписываем --hostlist=… на этот путь.
+        """
+        if not any(a.endswith(TMP_HOSTLIST_PATH) for a in args):
+            return args
+
+        from core.config_manager import get_config_manager
+        cfg = get_config_manager()
+        lists_path = cfg.get("zapret", "lists_path",
+                             default="/opt/zapret2/lists")
+
+        from core.scan_targets import detect_target
+        profile = self._scan_profile or detect_target(probe_result.target)
+        permanent = os.path.join(
+            lists_path, "zapret-gui-target-%s.txt" % profile.key,
+        )
+
+        try:
+            os.makedirs(lists_path, exist_ok=True)
+            with open(permanent, "w", encoding="utf-8") as f:
+                for d in profile.all_hostlist_domains():
+                    f.write(d.strip() + "\n")
+        except OSError as e:
+            log.warning(
+                "Не удалось записать постоянный hostlist (%s): %s"
+                % (permanent, e),
+                source="scanner",
+            )
+            return args
+
+        return [
+            ("--hostlist=%s" % permanent) if a == ("--hostlist=%s" % TMP_HOSTLIST_PATH)
+            else a
+            for a in args
+        ]
+
     # ─────────────────── Helpers ───────────────────
 
     def _set_phase(self, phase: str) -> None:
@@ -1200,6 +1551,76 @@ class StrategyScanner:
         except (ValueError, TypeError):
             pass
         return STABILIZATION_DELAY
+
+    # ─────────────────── tmp hostlist ───────────────────
+
+    def _ensure_tmp_hostlist(self) -> None:
+        """
+        Создать временный hostlist для приёмов basic/advanced/direct.
+
+        nfqws2 матчит SNI/Host строго по записям файла; чтобы trick'и
+        реально применялись к трафику цели, нужны корректные домены.
+        """
+        if self._scan_profile is None:
+            self._tmp_hostlist = None
+            return
+
+        domains = self._scan_profile.all_hostlist_domains()
+        if not domains:
+            self._tmp_hostlist = None
+            return
+
+        try:
+            with open(TMP_HOSTLIST_PATH, "w", encoding="utf-8") as f:
+                for d in domains:
+                    f.write(d.strip() + "\n")
+            self._tmp_hostlist = TMP_HOSTLIST_PATH
+        except OSError as e:
+            log.warning(
+                "Не удалось создать временный hostlist: %s" % e,
+                source="scanner",
+            )
+            self._tmp_hostlist = None
+
+    def _remove_tmp_hostlist(self) -> None:
+        """Удалить временный hostlist."""
+        if self._tmp_hostlist:
+            try:
+                if os.path.exists(self._tmp_hostlist):
+                    os.remove(self._tmp_hostlist)
+            except OSError:
+                pass
+        self._tmp_hostlist = None
+
+
+# ═══════════════════════════════════════════════════════════
+#  Helpers (module-level)
+# ═══════════════════════════════════════════════════════════
+
+def _is_full_preset_args(args: list[str]) -> bool:
+    """Эвристика: «полный пресет» — содержит --filter-* или --new или
+    собственные --hostlist/--blob/--ipset. У «приёма» в args обычно один
+    или два --lua-desync= и больше ничего.
+    """
+    if not args:
+        return False
+    for a in args:
+        if a == "--new":
+            return True
+        if a.startswith("--filter-tcp") or a.startswith("--filter-udp"):
+            return True
+        if a.startswith("--hostlist=") or a.startswith("--hostlist-domains="):
+            return True
+        if a.startswith("--ipset=") or a.startswith("--ipset-exclude="):
+            return True
+        if a.startswith("--blob="):
+            return True
+    return False
+
+
+def _is_full_preset_entry(entry: CatalogEntry) -> bool:
+    """То же, но для CatalogEntry."""
+    return _is_full_preset_args(entry.get_args_list())
 
 
 # ═══════════════════════════════════════════════════════════

--- a/core/testers/body_tester.py
+++ b/core/testers/body_tester.py
@@ -1,0 +1,225 @@
+# core/testers/body_tester.py
+"""
+Глубокая проба загрузки тела HTTP/HTTPS — для отсева «псевдо-успехов»,
+когда DPI пускает ClientHello, но обрывает соединение через 16–20 КБ.
+
+Делает GET к указанному хосту, читает поток до min_bytes, классифицирует
+исход:
+
+  - SUCCESS:    >TCP_BLOCK_RANGE_MAX (≥21 КБ) скачано без ошибок.
+  - FAILED  TCP_16_20:   обрыв в диапазоне 15 000…21 000 (DPI).
+  - FAILED  TLS_TIMEOUT/RST/etc.: до handshake/при чтении.
+  - SUCCESS_PARTIAL: скачано меньше min_bytes, но >21 КБ — считаем ОК.
+
+Использование:
+    from core.testers.body_tester import probe_body
+    res = probe_body("https://i.ytimg.com/generate_204",
+                     min_bytes=65536, timeout=10)
+"""
+
+from __future__ import annotations
+
+import http.client
+import socket
+import ssl
+import time
+from urllib.parse import urlparse
+
+from core.models import SingleTestResult, TestStatus, TestType
+from core.testers.config import (
+    TCP_BLOCK_RANGE_MAX,
+    TCP_BLOCK_RANGE_MIN,
+)
+
+
+_DEFAULT_MIN_BYTES = 65_536   # 64 KB — заметно больше 16-20 KB порога
+_READ_CHUNK = 4096
+
+
+def probe_body(
+    url: str,
+    min_bytes: int = _DEFAULT_MIN_BYTES,
+    timeout: float = 10.0,
+) -> SingleTestResult:
+    """Скачать ≥ min_bytes байт тела через GET и классифицировать исход.
+
+    Args:
+        url: Полный URL (http/https).
+        min_bytes: Минимум байт, после которого можно остановить чтение.
+        timeout: Сетевой таймаут в секундах.
+
+    Returns:
+        SingleTestResult со статусом SUCCESS/FAILED/ERROR/TIMEOUT и
+        деталями: bytes_received, kbps, http_code, dpi_marker.
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname:
+        return SingleTestResult(
+            target=url,
+            test_type=TestType.HTTP.value,
+            status=TestStatus.ERROR.value,
+            error="BAD_URL",
+            details="Невалидный URL",
+        )
+
+    host = parsed.hostname
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    path = parsed.path or "/"
+    if parsed.query:
+        path += "?" + parsed.query
+
+    start = time.time()
+    bytes_received = 0
+    status_code = 0
+    conn = None
+
+    try:
+        if parsed.scheme == "https":
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = True
+            ctx.verify_mode = ssl.CERT_REQUIRED
+            conn = http.client.HTTPSConnection(
+                host, port=port, timeout=timeout, context=ctx,
+            )
+        else:
+            conn = http.client.HTTPConnection(host, port=port, timeout=timeout)
+
+        conn.request(
+            "GET", path,
+            headers={
+                "Host": host,
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) "
+                              "AppleWebKit/537.36 (KHTML, like Gecko) "
+                              "Chrome/124.0 Safari/537.36",
+                "Accept": "*/*",
+                "Accept-Encoding": "identity",
+                "Connection": "close",
+                # Range помогает: если сервер отдаёт 204/304 — всё равно
+                # успех, и не качаем терабайт. Не все хосты понимают Range,
+                # тогда просто читаем поток.
+                "Range": "bytes=0-%d" % (min_bytes + 4096),
+            },
+        )
+        resp = conn.getresponse()
+        status_code = resp.status
+
+        # 204/205/304/404/403 без тела — это всё ещё «трафик прошёл DPI».
+        # Если код не пятиста и handshake состоялся, можно считать,
+        # что десинк работает. Дочитываем сколько есть.
+        deadline = time.time() + timeout
+        while True:
+            if time.time() > deadline:
+                raise TimeoutError("read timeout")
+            chunk = resp.read(_READ_CHUNK)
+            if not chunk:
+                break
+            bytes_received += len(chunk)
+            if bytes_received >= min_bytes:
+                break
+
+        elapsed = time.time() - start
+        kbps = (bytes_received / 1024.0) / max(elapsed, 0.001)
+
+        # Классификация
+        if (TCP_BLOCK_RANGE_MIN <= bytes_received <= TCP_BLOCK_RANGE_MAX
+                and bytes_received < min_bytes):
+            return SingleTestResult(
+                target=url,
+                test_type=TestType.TCP_16_20.value,
+                status=TestStatus.FAILED.value,
+                error="TCP_16_20",
+                latency_ms=round(elapsed * 1000, 2),
+                details="Обрыв на %d B (DPI 16-20 KB)" % bytes_received,
+                raw_data={
+                    "bytes_received": bytes_received,
+                    "kbps": round(kbps, 1),
+                    "status_code": status_code,
+                    "dpi_marker": "tcp_16_20",
+                },
+            )
+
+        # Достаточно прошло: либо ≥ min_bytes, либо честный EOF за пределами
+        # подозрительного диапазона.
+        passed = (bytes_received >= min_bytes
+                  or bytes_received > TCP_BLOCK_RANGE_MAX
+                  or status_code in (204, 205, 304))
+        if passed:
+            return SingleTestResult(
+                target=url,
+                test_type=TestType.HTTP.value,
+                status=TestStatus.SUCCESS.value,
+                latency_ms=round(elapsed * 1000, 2),
+                details="HTTP %d, %d B, %.1f KB/s"
+                        % (status_code, bytes_received, kbps),
+                raw_data={
+                    "bytes_received": bytes_received,
+                    "kbps": round(kbps, 1),
+                    "status_code": status_code,
+                    "dpi_marker": "",
+                },
+            )
+
+        # Получили < TCP_BLOCK_RANGE_MIN — короткое тело и не из «безопасных»
+        # кодов. Чаще всего это сразу обрыв после handshake.
+        return SingleTestResult(
+            target=url,
+            test_type=TestType.HTTP.value,
+            status=TestStatus.FAILED.value,
+            error="SHORT_BODY",
+            latency_ms=round(elapsed * 1000, 2),
+            details="Тело %d B (HTTP %d) — слишком мало"
+                    % (bytes_received, status_code),
+            raw_data={
+                "bytes_received": bytes_received,
+                "kbps": round(kbps, 1),
+                "status_code": status_code,
+                "dpi_marker": "short_body",
+            },
+        )
+
+    except (socket.timeout, TimeoutError):
+        elapsed = time.time() - start
+        marker = "tcp_16_20" if (
+            TCP_BLOCK_RANGE_MIN <= bytes_received <= TCP_BLOCK_RANGE_MAX
+        ) else "timeout"
+        kbps = (bytes_received / 1024.0) / max(elapsed, 0.001)
+        return SingleTestResult(
+            target=url,
+            test_type=TestType.HTTP.value,
+            status=TestStatus.TIMEOUT.value,
+            error="TIMEOUT" if marker == "timeout" else "TCP_16_20",
+            latency_ms=round(elapsed * 1000, 2),
+            details="Таймаут при чтении (получено %d B)" % bytes_received,
+            raw_data={
+                "bytes_received": bytes_received,
+                "kbps": round(kbps, 1),
+                "status_code": status_code,
+                "dpi_marker": marker,
+            },
+        )
+    except (ssl.SSLError, OSError, http.client.HTTPException) as e:
+        elapsed = time.time() - start
+        marker = "tcp_16_20" if (
+            TCP_BLOCK_RANGE_MIN <= bytes_received <= TCP_BLOCK_RANGE_MAX
+        ) else "rst"
+        kbps = (bytes_received / 1024.0) / max(elapsed, 0.001)
+        return SingleTestResult(
+            target=url,
+            test_type=TestType.HTTP.value,
+            status=TestStatus.FAILED.value,
+            error="TCP_16_20" if marker == "tcp_16_20" else "RST",
+            latency_ms=round(elapsed * 1000, 2),
+            details="%s (получено %d B)" % (str(e)[:80], bytes_received),
+            raw_data={
+                "bytes_received": bytes_received,
+                "kbps": round(kbps, 1),
+                "status_code": status_code,
+                "dpi_marker": marker,
+            },
+        )
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/web/js/pages/scan.js
+++ b/web/js/pages/scan.js
@@ -312,8 +312,11 @@ const ScanPage = (() => {
             if (rate) parts.push('Успешность: ' + rate);
             if (elapsed) parts.push('Время: ' + elapsed);
             if (report.best_strategy) {
-                parts.push('Лучшая: ' + escapeHtml(report.best_strategy.strategy_name)
-                    + ' (' + Math.round(report.best_strategy.latency_ms) + ' ms)');
+                const b = report.best_strategy;
+                const bk = b.throughput_kbps ? `, ${b.throughput_kbps.toFixed(1)} KB/s` : '';
+                const bs = b.score != null ? `, score ${Math.round(b.score)}` : '';
+                parts.push('Лучшая: ' + escapeHtml(b.strategy_name)
+                    + ' (' + Math.round(b.latency_ms) + ' ms' + bk + bs + ')');
             }
             summaryEl.innerHTML = parts.join(' · ');
         }
@@ -330,6 +333,9 @@ const ScanPage = (() => {
             return;
         }
 
+        // Бэкенд сортирует results по score (см. strategy_scanner._build_report).
+        // НЕ пересортировываем здесь — иначе indexes для apply_strategy(idx)
+        // разъедутся с порядком в массиве working на стороне сервера.
         el.innerHTML = working.map((w, i) => {
             const latency = w.latency_ms ? Math.round(w.latency_ms) + ' ms' : '';
             const name = escapeHtml(w.strategy_name || w.strategy_id || 'Стратегия #' + (i + 1));
@@ -340,15 +346,39 @@ const ScanPage = (() => {
             const sourceFile = (w.raw_data && w.raw_data.source_file) || '';
             const level = (w.raw_data && w.raw_data.level) || '';
             const label = (w.raw_data && w.raw_data.label) || '';
+            const isFullPreset = !!(w.raw_data && w.raw_data.is_full_preset);
+
+            // Метрики глубокой пробы
+            const score = w.score != null ? Math.round(w.score) : 0;
+            const kbps = w.throughput_kbps || 0;
+            const bodyPassed = !!w.body_passed;
+            const successRate = w.success_rate != null
+                ? Math.round((w.success_rate || 0) * 100) + '%'
+                : '';
+
+            // Бейдж "16-20 KB" если стратегия пускает только пол-страницы
+            const perHost = (w.raw_data && w.raw_data.probe_per_host) || [];
+            const has16_20 = perHost.some(h => h && h.dpi_marker === 'tcp_16_20');
 
             // Мета-информация
             const metaParts = [];
+            if (isFullPreset) metaParts.push('full preset');
             if (level) metaParts.push(level);
             if (sourceFile) metaParts.push(sourceFile);
             if (label) metaParts.push(label);
             const metaStr = metaParts.length > 0
                 ? '<span style="color:var(--text-muted); font-size:11px;">' + escapeHtml(metaParts.join(' · ')) + '</span>'
                 : '';
+
+            // Метрики строкой
+            const metricsParts = [];
+            metricsParts.push(`<span style="color:var(--accent); font-weight:600;">score ${score}</span>`);
+            if (kbps > 0) metricsParts.push(`<span style="color:var(--text-secondary);">${kbps.toFixed(1)} KB/s</span>`);
+            if (latency) metricsParts.push(`<span style="color:var(--text-muted);">${latency}</span>`);
+            if (successRate) metricsParts.push(`<span style="color:var(--text-muted);">${successRate} проб</span>`);
+            if (bodyPassed) metricsParts.push('<span class="bc-badge bc-badge-ok" style="font-size:10px;">body OK</span>');
+            else if (has16_20) metricsParts.push('<span class="bc-badge" style="background:rgba(239,68,68,0.15); color:var(--error); font-size:10px; padding:1px 6px;">16-20 KB block</span>');
+            const metricsStr = metricsParts.join(' · ');
 
             return `
                 <div class="scan-result-item">
@@ -357,15 +387,16 @@ const ScanPage = (() => {
                             <span class="bc-badge bc-badge-ok">#${i + 1}</span>
                             ${name}
                             ${label === 'recommended' ? '<span class="bc-badge" style="background:rgba(34,197,94,0.15); color:var(--success); font-size:10px; padding:1px 6px;">recommended</span>' : ''}
+                            ${isFullPreset ? '<span class="bc-badge" style="background:rgba(59,130,246,0.15); color:var(--accent); font-size:10px; padding:1px 6px;">full preset</span>' : ''}
                         </div>
                         <div class="scan-result-meta">
-                            ${latency ? `<span style="color:var(--text-muted); font-size:12px;">${latency}</span>` : ''}
                             <button class="btn btn-primary btn-sm" onclick="ScanPage.applyStrategy(${i})">
                                 Применить
                             </button>
                         </div>
                     </div>
-                    ${metaStr ? '<div style="margin:4px 0 2px 28px;">' + metaStr + '</div>' : ''}
+                    <div style="margin:4px 0 2px 28px; font-size:12px;">${metricsStr}</div>
+                    ${metaStr ? '<div style="margin:2px 0 2px 28px;">' + metaStr + '</div>' : ''}
                     ${argsPreview ? `<div class="scan-result-args">${argsPreview}</div>` : ''}
                 </div>
             `;


### PR DESCRIPTION
## Summary

This PR introduces intelligent target profiling and deep HTTP body probing to the strategy scanner, replacing simple TLS-only checks with comprehensive multi-host testing that detects DPI 16-20 KB blocking patterns.

## Key Changes

### New Target Profile System (`core/scan_targets.py`)
- Added `ScanTarget` dataclass to define profiles for popular services (YouTube, Discord, Telegram, Instagram, Twitter, Facebook, Google)
- Each profile includes:
  - Primary and test hosts for multi-host validation
  - Service-specific TCP/UDP ports and L7 filters
  - Expected hostlist files and probe URLs
  - Automatic detection via domain hints with fallback to generic profiles
- Enables scanner to build accurate temporary hostlists matching actual SNI/Host headers that nfqws2 requires

### Deep Body Probing (`core/testers/body_tester.py`)
- New `probe_body()` function downloads ≥64 KB of HTTP response body
- Detects DPI 16-20 KB blocking: when connection drops between 15-21 KB (common DPI pattern)
- Classifies outcomes: SUCCESS (≥21 KB), TCP_16_20 (DPI block), SHORT_BODY, TIMEOUT
- Calculates throughput (KB/s) for quality metrics

### Enhanced Strategy Scanner (`core/strategy_scanner.py`)
- **Timeout optimization**: Reduced PROBE_TIMEOUT from 10s to 6s, STABILIZATION_DELAY from 2s to 1s
- **Multi-host testing**: Tests 1 host (quick), 2 hosts (standard), up to 4 hosts (full mode)
- **Composite scoring**: Replaces simple latency ranking with `score = success_rate × (kbps/latency)` to avoid false positives from pseudo-successes
- **Trick vs Full Preset distinction**:
  - Full presets (builtin level): used as-is with their own filters/hostlists
  - Tricks (basic/advanced/direct): wrapped with target-specific `--filter-l7`, `--payload`, and temporary hostlist
- **Strategy prioritization**: Full presets tested first (higher success rate), then recommended tricks, then others
- **Temporary hostlist management**: Creates `/tmp/zapret-gui-scan-target.txt` with target domains, materializes to permanent file for applied strategies
- **Per-host result tracking**: Stores detailed results per test host including TLS/body status, throughput, DPI markers

### Model Updates (`core/models.py`)
- Extended `StrategyProbeResult` with new fields:
  - `throughput_kbps`: Body download speed
  - `body_passed`: Whether body probe succeeded
  - `success_rate`: Weighted TLS/body success ratio
  - `score`: Composite ranking metric

### UI Improvements (`web/js/pages/scan.js`)
- Display throughput and score in best strategy summary
- Results sorted by score (highest first) for better visibility of truly working strategies
- Preserved server-side sort order to maintain consistency with apply_strategy indices

## Implementation Details

- **DPI Detection**: 16-20 KB range (TCP_BLOCK_RANGE_MIN/MAX) identifies common DPI blocking patterns where initial handshake succeeds but body transfer is cut short
- **Hostlist Precision**: Temporary hostlist ensures nfqws2 SNI/Host matching works correctly; permanent copy created for applied strategies
- **Timeout Tuning**: Reduced timeouts compensate for multi-host testing overhead while maintaining responsiveness
- **Backward Compatibility**: Generic profile fallback for unknown targets; full presets unaffected by new wrapping logic

https://claude.ai/code/session_014wGHFuwhMjr2tqnYUyiX6F