### PR TITLE
fix(ipsets): show imported ipsets in GUI; bump version to v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## v0.17.0 — Подбор стратегий: глубокая проба и ранжирование по КПД
+
+### Исправлено
+- **Сканер находил «псевдо-успехи» или ничего не находил для youtube.com**
+  Раньше каждой стратегии без своего `--hostlist=` принудительно
+  подставлялся `lists/other.txt`, в котором не было youtube-доменов
+  (только `rtmps.youtube.com`). nfqws2 при наличии `--hostlist`
+  десинхронизирует только пакеты с SNI/Host из файла — youtube-трафик
+  уходил «как есть», DPI его резал, проба TLS падала по 10-секундному
+  таймауту. Отсюда же «очень медленно»: 30 стратегий × ~17 с холостого
+  хода. Теперь под цель генерится временный hostlist
+  `/tmp/zapret-gui-scan-target.txt` со всеми её доменами; при применении
+  стратегии этот hostlist материализуется в
+  `<lists_path>/zapret-gui-target-<key>.txt`.
+- **`catalogs/builtin/winws2_presets.txt` (85 готовых пресетов) был
+  исключён из сканирования** через `_SCANNER_EXCLUDED_LEVELS`, хотя
+  именно у них уже готовые `--filter-*/--hostlist=/--blob=/--ipset=/
+  --new`. Теперь они идут первыми — у них шанс попадания максимальный.
+- **Импортированные `ipset-*.txt` не отображались в GUI.**
+  asset_importer (v0.16) кладёт ipset'ы в `<base>/ipset/`, а
+  IPSetManager читал из `<base>/lists/`. IPSetManager переключён на
+  `ipset_path`; добавлена однократная миграция файлов из `lists_path`
+  → `ipset_path` (без перезаписи). Расширен namespace ipset-имён
+  (теперь видны `cloudflare-ipset`, `russia-discord-ipset`, ...);
+  hostlist_manager синхронно их исключает из своего списка.
+
+### Добавлено
+- **Профили целей** `core/scan_targets.py` — youtube, discord, telegram,
+  instagram, twitter, facebook, google. Каждой цели — свои `test_hosts`,
+  `hostlist_domains`, порты TCP/UDP, `--filter-l7=` и `--payload=`.
+  Незнакомая цель → generic-профиль с её доменом.
+- **Глубокая body-проба** `core/testers/body_tester.py` — GET ≥64 КБ
+  через TLS с детектом обрыва в диапазоне 15 000…21 000 байт
+  (DPI часто пускает первые 16-20 КБ и режет; обычные автоподборщики
+  на это попадаются).
+- **Композитный score** `success_rate × min(kbps, 2048) / latency`.
+  Лучшая стратегия выбирается по score (а не по latency); список в UI
+  отсортирован по score. В карточке стратегии видны `score`, `KB/s`,
+  `latency`, `success_rate` и бейджи `body OK` / `16-20 KB block` /
+  `full preset`.
+- **TLS+body на нескольких хостах**: 1 хост в quick, 2 в standard,
+  до 4 в full. Без body-успеха стратегия не считается рабочей.
+
+### Изменено
+- `core/strategy_scanner.py` — переписаны `_select_strategies()`,
+  `_build_strategy_args()` (две ветки: full preset как-есть vs trick →
+  оборачивание в шаблон цели), `_probe_one_strategy()` (новый
+  `_deep_probe()`).
+- `core/models.py` — `StrategyProbeResult` расширен полями
+  `throughput_kbps`, `body_passed`, `success_rate`, `score`.
+- `core/catalog_loader.py` — снят `_SCANNER_EXCLUDED_LEVELS = {builtin}`.
+- `core/ipset_manager.py` — `lists_path` → `ipset_path`, миграция,
+  расширенный namespace.
+- `core/hostlist_manager.py` — расширен `IPSET_NAME_RE` для исключения
+  импортированных ipset-файлов.
+- `web/js/pages/scan.js` — новые колонки и бейджи.
+- **Таймауты**: STABILIZATION 2.0 → 1.0, PROBE 10 → 6,
+  INTER_STRATEGY 0.5 → 0.3, добавлен BODY_PROBE = 8 с.
+
+### Зачем
+Главный приоритет: «найти из имеющегося набора стратегий, скриптов,
+блобов и хостлистов **реально рабочие** для youtube/discord и
+ранжировать по КПД». До v0.17 сканер этого не делал из-за двух багов
+выше — теперь делает.
+
 ## v0.16.0 — Импорт bundled-ассетов (blobs/lua/lists) и дополнительных каталогов стратегий
 
 ### Добавлено

--- a/core/hostlist_manager.py
+++ b/core/hostlist_manager.py
@@ -109,9 +109,18 @@ NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 # Имена, принадлежащие namespace'у IP-списков (ipset_manager): такие файлы
 # не должны показываться в hostlists и не могут быть созданы как hostlist.
-# Условие: "ipset-base", "my-ipset", либо любой префикс "ipset-" / "ipset_"
-# (например "ipset-cloudflare").
-IPSET_NAME_RE = re.compile(r"^(?:ipset[-_][a-zA-Z0-9_-]*|my-ipset)$")
+# Покрываем все формы: "ipset-base", "my-ipset", префиксы "ipset-/ipset_/
+# my-ipset-/my-ipset_*" и суффиксы "*-ipset/*-ipset_*" (для импортируемых
+# upstream-файлов вроде "cloudflare-ipset", "russia-discord-ipset").
+# Список синхронизирован с core/ipset_manager.IPSET_NAMESPACE_RE.
+IPSET_NAME_RE = re.compile(
+    r"^(?:"
+    r"ipset-base|my-ipset|"
+    r"ipset[-_][a-zA-Z0-9_-]*|"
+    r"my-ipset[-_][a-zA-Z0-9_-]*|"
+    r"[a-zA-Z0-9][a-zA-Z0-9_-]*-ipset(?:[-_][a-zA-Z0-9_-]+)?"
+    r")$"
+)
 
 
 def _is_ipset_name(name):

--- a/core/ipset_manager.py
+++ b/core/ipset_manager.py
@@ -2,20 +2,24 @@
 """
 Менеджер IP-списков (ipsets).
 
-Управляет файлами в директории lists_path:
+Управляет файлами в директории ipset_path (обычно /opt/zapret2/ipset/):
   - ipset-base.txt — базовые IP-адреса (Cloudflare DNS и др.)
   - my-ipset.txt   — пользовательские IP/подсети
   - ipset-*.txt    — произвольные пользовательские IP-списки
   - my-ipset-*.txt — пользовательские IP-списки (альтернативный префикс)
+  - *-ipset.txt    — импортируемые из upstream'а (cloudflare-ipset.txt,
+                     russia-discord-ipset.txt, ...). asset_importer
+                     раскладывает такие файлы в ipset_path.
 
 Имя файла должно удовлетворять одному из условий:
   - встроенное имя ("ipset-base", "my-ipset");
   - начинается с "ipset-", "ipset_", "my-ipset-" или "my-ipset_";
+  - заканчивается на "-ipset" либо содержит "-ipset_" / "-ipset.";
   - длина 1..64 символа, допустимые символы — [a-zA-Z0-9_-].
 
-Таким образом IP-списки и hostlists живут в одной директории, но имеют
-разделённые namespaces: файлы IP-списков ВСЕГДА начинаются с "ipset" либо
-равны "my-ipset".
+ВАЖНО: ipset_path и lists_path — это РАЗНЫЕ директории zapret2.
+hostlist_manager работает с lists_path (хостлисты), ipset_manager —
+с ipset_path. asset_importer разделяет их при импорте.
 
 Поддерживает загрузку IP-диапазонов по ASN через RIPE API.
 
@@ -78,10 +82,17 @@ DESCRIPTIONS = {
 _NAME_CHARS_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 # Паттерн namespace'а IP-списков: имя либо встроенное, либо начинается с
-# одного из префиксов ipset- / ipset_ / my-ipset- / my-ipset_ (для
-# произвольных кастомных IP-списков).
+# префикса ipset- / ipset_ / my-ipset- / my-ipset_, ЛИБО заканчивается
+# на -ipset / -ipset_<suffix> (для импортированных upstream-файлов вроде
+# "cloudflare-ipset", "cloudflare-ipset_v6", "russia-discord-ipset").
+# Список вариантов синхронизирован с core/asset_importer._is_ipset_filename.
 IPSET_NAMESPACE_RE = re.compile(
-    r"^(?:ipset-base|my-ipset|ipset[-_][a-zA-Z0-9_-]+|my-ipset[-_][a-zA-Z0-9_-]+)$"
+    r"^(?:"
+    r"ipset-base|my-ipset|"
+    r"ipset[-_][a-zA-Z0-9_-]+|"
+    r"my-ipset[-_][a-zA-Z0-9_-]+|"
+    r"[a-zA-Z0-9][a-zA-Z0-9_-]*-ipset(?:[-_][a-zA-Z0-9_-]+)?"
+    r")$"
 )
 
 # ═══════════════════ Валидация IP ═══════════════════
@@ -186,24 +197,31 @@ class IPSetManager:
 
     def __init__(self):
         self._lock = threading.Lock()
+        self._migrated = False  # ленивая миграция из lists_path
+
+    @property
+    def ipset_path(self):
+        """Путь к директории IP-списков (отдельно от hostlists)."""
+        cfg = get_config_manager()
+        return cfg.get("zapret", "ipset_path", default="/opt/zapret2/ipset")
 
     @property
     def lists_path(self):
-        """Путь к директории списков."""
+        """Путь к hostlists (для миграции старых ipset-файлов)."""
         cfg = get_config_manager()
         return cfg.get("zapret", "lists_path", default="/opt/zapret2/lists")
 
     def _file_path(self, name):
         """Полный путь к файлу списка."""
-        return os.path.join(self.lists_path, name + ".txt")
+        return os.path.join(self.ipset_path, name + ".txt")
 
     def _ensure_dir(self):
-        """Создать директорию списков если не существует."""
-        path = self.lists_path
+        """Создать директорию ipset'ов если не существует."""
+        path = self.ipset_path
         if not os.path.isdir(path):
             try:
                 os.makedirs(path, exist_ok=True)
-                log.info(f"Создана директория списков: {path}", source="ipsets")
+                log.info(f"Создана директория ipset: {path}", source="ipsets")
             except OSError as e:
                 log.error(f"Не удалось создать директорию: {e}", source="ipsets")
 
@@ -221,13 +239,17 @@ class IPSetManager:
 
     def list_names(self):
         """
-        Список имён всех ipset-файлов в директории.
+        Список имён всех ipset-файлов в директории ipset_path.
 
         Всегда включает встроенные имена, плюс любые *.txt файлы,
         удовлетворяющие namespace'у IP-списков.
         """
+        # Однократная миграция: до v0.16 ipset-файлы лежали в lists_path,
+        # а теперь должны быть в ipset_path.
+        self._migrate_from_lists_if_needed()
+
         names = set(BUILTIN_NAMES)
-        path = self.lists_path
+        path = self.ipset_path
         try:
             if os.path.isdir(path):
                 for entry in os.listdir(path):
@@ -242,6 +264,60 @@ class IPSetManager:
         builtin_order = [n for n in BUILTIN_NAMES if n in names]
         custom = sorted(n for n in names if n not in BUILTIN_NAMES)
         return builtin_order + custom
+
+    def _migrate_from_lists_if_needed(self):
+        """
+        Однократно скопировать ipset-файлы из lists_path в ipset_path.
+
+        До v0.16 IPSetManager писал в lists_path; начиная с v0.16
+        asset_importer и catalog_loader ожидают ipset-файлы в ipset_path.
+        Чтобы пользователь не потерял свои IP-списки и чтобы импортированные
+        upstream-файлы стали видны в UI, переносим их.
+
+        Не перезаписываем уже существующие в ipset_path файлы.
+        """
+        with self._lock:
+            if self._migrated:
+                return
+            self._migrated = True
+
+        old_dir = self.lists_path
+        new_dir = self.ipset_path
+
+        if not os.path.isdir(old_dir) or os.path.realpath(old_dir) == \
+                os.path.realpath(new_dir):
+            return
+
+        try:
+            os.makedirs(new_dir, exist_ok=True)
+        except OSError:
+            return
+
+        copied = 0
+        for entry in os.listdir(old_dir):
+            if not entry.endswith(".txt"):
+                continue
+            stem = entry[:-4]
+            if not self._validate_name(stem):
+                continue
+            src = os.path.join(old_dir, entry)
+            dst = os.path.join(new_dir, entry)
+            if os.path.exists(dst):
+                continue  # не перезаписываем
+            try:
+                with open(src, "rb") as r, open(dst, "wb") as w:
+                    w.write(r.read())
+                copied += 1
+            except OSError as e:
+                log.debug(
+                    f"ipset migrate {entry}: {e}", source="ipsets",
+                )
+
+        if copied > 0:
+            log.info(
+                f"ipset: перенесено {copied} файлов из {old_dir} в {new_dir}",
+                source="ipsets",
+            )
 
     def get_ipset(self, name):
         """

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.16.4"
+GUI_VERSION = "0.17.0"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.16.4"
+VERSION="0.17.0"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"


### PR DESCRIPTION
asset_importer (v0.16) кладёт ipset-файлы в <base>/ipset/, а IPSetManager читал из <base>/lists/ → файлы не появлялись в UI. Дополнительно namespace ipset-имён покрывал только ipset-/ipset_/ my-ipset-/my-ipset_, но не *-ipset/*-ipset_<suffix>, поэтому импортированные cloudflare-ipset.txt, russia-discord-ipset.txt, *-ipset_v6.txt вообще не считались ipset'ами.

Изменения:

▸ core/ipset_manager.py
  • lists_path → ipset_path (cfg.zapret.ipset_path,
    дефолт /opt/zapret2/ipset).
  • Расширен IPSET_NAMESPACE_RE: добавлена форма "[name]-ipset" и
    "[name]-ipset_[suffix]" — синхронизировано с
    asset_importer._is_ipset_filename.
  • Добавлена однократная миграция: list_names() при первом вызове
    копирует подходящие *.txt из старого lists_path в ipset_path
    без перезаписи существующих файлов. Это спасает пользовательский
    my-ipset.txt (оставшийся от v0.15) и одновременно показывает
    impорт-файлы, ранее пропускавшиеся.

▸ core/hostlist_manager.py
  • IPSET_NAME_RE расширен теми же формами, чтобы импортированные
    ipset-файлы корректно исключались из списка hostlists (если
    каким-то путём окажутся в lists_path).

▸ core/version.py, install.sh, CHANGELOG.md
  • Версия 0.16.4 → 0.17.0 — для тегирования релиза, в котором
    также живёт переработка сканера стратегий из предыдущего
    коммита.

https://claude.ai/code/session_014wGHFuwhMjr2tqnYUyiX6F