### PR TITLE
chore: bump version to v0.18.0 + sync install.sh from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ release:
 	fi
 	@echo "── Обновление версии до $(VERSION) ──"
 	@sed -i 's/GUI_VERSION = .*/GUI_VERSION = "$(VERSION)"/' core/version.py
-	@git add core/version.py
+	@sed -i 's/^VERSION="[^"]*"/VERSION="$(VERSION)"/' install.sh
+	@git add core/version.py install.sh
 	@git diff --cached --quiet \
 		&& echo "Версия уже актуальна, коммит не нужен" \
 		|| git commit -m "chore: bump version to v$(VERSION)"

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.17.0"
+GUI_VERSION = "0.18.0"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.17.0"
+VERSION="0.18.0"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"


### PR DESCRIPTION
- Bump GUI_VERSION 0.17.0 → 0.18.0 (per-AF baseline / ISP markers / granular DPI codes / nfqws crash-retry — see prior commit 3cbb172).
- Bump install.sh VERSION accordingly. Until now `make release VERSION=…` only updated core/version.py, so install.sh kept the previous tag and pulled the wrong tarball at line 416. Makefile's release target now seds both files via the same target.

