### PR TITLE
fix(firewall,gui-update): adapt iptables -w form + auto-restart on GU…

### DIFF
--- a/core/firewall.py
+++ b/core/firewall.py
@@ -92,6 +92,10 @@ class FirewallManager:
     из конфига (с fallback на auto-detect) и применяет/снимает правила.
     """
 
+    # Кэш формы -w флага по бинарнику. iptables ≥1.6 принимает «-w SECONDS»,
+    # iptables ≤1.4.x (Entware/Keenetic) — только «-w» без значения.
+    _wait_flag_cache: dict = {}
+
     def __init__(self):
         self._lock = threading.Lock()
         self._applied = False
@@ -571,18 +575,67 @@ class FirewallManager:
 
     # ──────────────── utils ────────────────
 
+    @classmethod
+    def _iptables_wait_flag(cls, ipt_path: str) -> list:
+        """Подобрать форму -w для конкретного бинарника iptables/ip6tables.
+
+        Возвращает один из вариантов:
+          ["-w", "5"]  — современный iptables (≥1.6), таймаут 5 секунд
+          ["-w"]       — старый iptables (Entware/Keenetic 1.4.x), boolean
+          []           — `-w` совсем не поддерживается; шансов меньше, но
+                         продолжаем без него (есть риск xtables-lock).
+
+        Результат кэшируется по абсолютному пути бинарника.
+        """
+        cached = cls._wait_flag_cache.get(ipt_path)
+        if cached is not None:
+            return list(cached)
+
+        flag: list = []
+        try:
+            res = subprocess.run(
+                [ipt_path, "--help"],
+                capture_output=True, text=True, timeout=3,
+            )
+            help_text = (res.stdout or "") + (res.stderr or "")
+            # iptables ≥1.6: "  --wait -w [seconds]" / "-w[SECONDS]" / похожее
+            if re.search(r"-w\s*\[\s*seconds?\s*\]", help_text, re.IGNORECASE):
+                flag = ["-w", "5"]
+            # iptables 1.4.x: "--wait -w  wait for the xtables lock"
+            elif re.search(r"--wait\b|\b-w\b", help_text):
+                flag = ["-w"]
+            else:
+                flag = []
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            flag = []
+
+        cls._wait_flag_cache[ipt_path] = list(flag)
+        log.debug(
+            "iptables wait flag для %s: %s" % (
+                ipt_path, " ".join(flag) or "(не поддерживается)"
+            ),
+            source="firewall",
+        )
+        return list(flag)
+
     @staticmethod
     def _run_cmd(cmd) -> bool:
         """Выполнить команду. True если успешно.
 
-        Для iptables/ip6tables подмешиваем `-w 5` сразу после имени бинарника:
+        Для iptables/ip6tables подмешиваем `-w` сразу после имени бинарника:
         иначе сканер, быстро снимающий и применяющий правила, упирается в
         xtables-lock и получает «Another app is currently holding the xtables
-        lock».
+        lock». Старые сборки iptables (Entware/Keenetic, 1.4.x) принимают
+        `-w` как **boolean без аргумента** — `-w 5` для них означает «ждать
+        + первая позиционная опция = 5», что отдаёт «Bad argument `5'».
+        Поэтому форму выбираем по детекции (см. _iptables_wait_flag).
         """
-        if cmd and os.path.basename(cmd[0]) in ("iptables", "ip6tables"):
-            if "-w" not in cmd:
-                cmd = [cmd[0], "-w", "5"] + cmd[1:]
+        is_iptables = (
+            cmd and os.path.basename(cmd[0]) in ("iptables", "ip6tables")
+        )
+        if is_iptables and "-w" not in cmd:
+            wait_flag = FirewallManager._iptables_wait_flag(cmd[0])
+            cmd = [cmd[0]] + wait_flag + cmd[1:]
 
         try:
             result = subprocess.run(
@@ -590,6 +643,31 @@ class FirewallManager:
             )
             if result.returncode != 0:
                 stderr = result.stderr.strip()
+
+                # Runtime-fallback: старые iptables (Entware/Keenetic 1.4.x)
+                # принимают «-w» только как boolean. Если сейчас передали
+                # `-w 5` и получили «Bad argument `5'» — понижаем форму до
+                # «-w» и пробуем ещё раз. Кэш снижается до конца жизни
+                # процесса.
+                if (is_iptables and "Bad argument" in stderr
+                        and "-w" in cmd and "5" in cmd):
+                    log.info(
+                        "iptables не принимает «-w 5», переходим на «-w»",
+                        source="firewall",
+                    )
+                    FirewallManager._wait_flag_cache[cmd[0]] = ["-w"]
+                    fixed = [a for a in cmd if a != "5"]
+                    try:
+                        result = subprocess.run(
+                            fixed, capture_output=True, text=True, timeout=10,
+                        )
+                        if result.returncode == 0:
+                            return True
+                        stderr = result.stderr.strip()
+                        cmd = fixed
+                    except (subprocess.TimeoutExpired, FileNotFoundError):
+                        pass
+
                 if "No such file" not in stderr \
                         and "does not exist" not in stderr:
                     log.warning("Команда %s: %s" % (

--- a/core/gui_updater.py
+++ b/core/gui_updater.py
@@ -10,6 +10,8 @@
 Singleton: get_gui_updater()
 """
 
+from __future__ import annotations
+
 import json
 import os
 import shutil
@@ -35,6 +37,13 @@ REMOTE_VERSION_CACHE_TTL = 300  # 5 минут
 
 # Автоопределение пути установки GUI
 _APP_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Кандидаты init-скриптов сервиса. Первый существующий и исполняемый —
+# побеждает (Entware → S99zapret-gui, OpenWrt → /etc/init.d/zapret-gui).
+_SERVICE_INIT_SCRIPTS = [
+    "/opt/etc/init.d/S99zapret-gui",
+    "/etc/init.d/zapret-gui",
+]
 
 
 class GuiUpdater:
@@ -295,15 +304,39 @@ class GuiUpdater:
                 source="gui-updater",
             )
 
+            # Скопированные файлы лежат на диске, но текущий Python-процесс
+            # продолжает работать со старым кодом в памяти. Без перезапуска
+            # сервиса GUI продолжит показывать прежнюю версию даже после
+            # F5 в браузере. Планируем рестарт через init-скрипт в
+            # detached-режиме — HTTP-ответ успеет уйти клиенту до того,
+            # как сервис убьёт сам себя.
+            restart_scheduled = self._schedule_service_restart()
+
+            if restart_scheduled:
+                msg = (
+                    "GUI обновлён до версии %s. Сервис автоматически "
+                    "перезапустится через несколько секунд — обновите "
+                    "страницу (F5) после этого."
+                    % (new_version or "?")
+                )
+            else:
+                # Не нашли init-скрипт — пользователь должен рестартануть
+                # сервис вручную, иначе обновление не применится.
+                msg = (
+                    "GUI обновлён до версии %s, файлы на диске, но "
+                    "init-скрипт не найден — перезапустите сервис "
+                    "вручную (S99zapret-gui restart / "
+                    "/etc/init.d/zapret-gui restart). Без рестарта "
+                    "продолжит работать старый код."
+                    % (new_version or "?")
+                )
+
             return {
                 "ok": True,
-                "message": (
-                    "GUI обновлён до версии %s. "
-                    "Перезагрузите страницу (F5) для применения."
-                    % (new_version or "?")
-                ),
+                "message": msg,
                 "version": new_version,
                 "restart_required": True,
+                "restart_scheduled": restart_scheduled,
             }
 
         except Exception as e:
@@ -316,6 +349,61 @@ class GuiUpdater:
         finally:
             # Очистка tmp
             shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    @staticmethod
+    def _find_init_script() -> str | None:
+        """Найти исполняемый init-скрипт сервиса GUI."""
+        for path in _SERVICE_INIT_SCRIPTS:
+            if os.path.isfile(path) and os.access(path, os.X_OK):
+                return path
+        return None
+
+    def _schedule_service_restart(self, delay_seconds: int = 3) -> bool:
+        """Запланировать рестарт сервиса в detached-shell.
+
+        Запускает `(sleep N && <init> restart) &` через nohup так, чтобы:
+          1) текущий HTTP-ответ успел уйти клиенту;
+          2) при kill старого Python-процесса детачед-shell не умер вместе
+             с ним (start_new_session + nohup);
+          3) после паузы init-скрипт сделал stop + start (PID-файл,
+             pgrep, очистка stale __pycache__ — всё его).
+        """
+        init_script = self._find_init_script()
+        if not init_script:
+            log.warning(
+                "init-скрипт сервиса не найден, авто-рестарт пропущен. "
+                "Перезапустите вручную: S99zapret-gui restart",
+                source="gui-updater",
+            )
+            return False
+
+        # Каскад «sleep + restart» в новой сессии. Перенаправляем потоки
+        # в /dev/null — иначе шелл унаследует трубы Python и умрёт при
+        # первой попытке записи после нашего exit.
+        cmd_str = "sleep %d && %s restart" % (
+            int(delay_seconds), init_script,
+        )
+        try:
+            subprocess.Popen(
+                ["sh", "-c", cmd_str],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+            log.info(
+                "Запланирован рестарт сервиса через %d сек: %s restart"
+                % (delay_seconds, init_script),
+                source="gui-updater",
+            )
+            return True
+        except OSError as e:
+            log.error(
+                "Не удалось запланировать рестарт: %s" % e,
+                source="gui-updater",
+            )
+            return False
 
     def _safe_update_config_dir(self, src: str, dst: str) -> None:
         """

--- a/web/js/pages/zapret_manager.js
+++ b/web/js/pages/zapret_manager.js
@@ -697,7 +697,10 @@ const ZapretManagerPage = (() => {
                             showProgress('Обновление завершено!', 100, 'Обновление zapret-gui...');
                             setTimeout(() => {
                                 hideProgress();
-                                showGuiReloadPrompt();
+                                // Polling-фолбэк не знает финальный result —
+                                // показываем оптимистичный сценарий с авто-
+                                // поллингом и резервным ручным рестартом.
+                                showGuiReloadPrompt({ ok: true, restart_scheduled: true });
                             }, 1200);
                         }
                     }
@@ -760,25 +763,99 @@ const ZapretManagerPage = (() => {
         if (ver) ver.textContent = info.latest_version || '?';
     }
 
-    function showGuiReloadPrompt() {
+    function showGuiReloadPrompt(updateResult) {
+        // Сервер планирует рестарт сервиса в фоне. Ждём пока он перезапустится
+        // и сам подхватит новый код, потом перезагружаем страницу.
+        // Без рестарта старый Python-процесс продолжит держать прежний
+        // GUI_VERSION в памяти, и `location.reload()` ничего не изменит.
+        const restartScheduled = !!(updateResult && updateResult.restart_scheduled);
+        const newVersion = (updateResult && updateResult.version) || '';
         const banner = document.getElementById('gui-update-banner');
+
+        if (!restartScheduled) {
+            // Авто-рестарт не запланирован — пользователь должен сам.
+            if (banner) {
+                banner.classList.remove('hidden');
+                banner.innerHTML = `
+                    <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:8px;">
+                        <div>
+                            <span style="font-weight:600; color:var(--warning);">GUI обновлён, требуется ручной рестарт сервиса</span>
+                            <div style="color:var(--text-secondary); font-size:13px; margin-top:4px;">
+                                Выполните на роутере: <code>S99zapret-gui restart</code>
+                                (или <code>/etc/init.d/zapret-gui restart</code>),<br>
+                                затем перезагрузите страницу.
+                            </div>
+                        </div>
+                        <button class="btn btn-ghost btn-sm" onclick="location.reload()">Обновить страницу</button>
+                    </div>
+                `;
+            }
+            Toast.warning('Перезапустите сервис вручную, иначе обновление не применится.');
+            return;
+        }
+
         if (banner) {
             banner.classList.remove('hidden');
             banner.innerHTML = `
                 <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:8px;">
                     <div>
-                        <span style="font-weight:600; color:var(--success);">zapret-gui обновлён!</span>
-                        <span style="color:var(--text-secondary); font-size:13px; margin-left:8px;">
-                            Перезагрузите страницу для применения изменений
-                        </span>
+                        <span style="font-weight:600; color:var(--success);">zapret-gui обновлён${newVersion ? ' до v' + newVersion : ''}!</span>
+                        <div style="color:var(--text-secondary); font-size:13px; margin-top:4px;">
+                            <span id="gui-update-restart-status">Сервис перезапускается...</span>
+                        </div>
                     </div>
-                    <button class="btn btn-success btn-sm" onclick="location.reload()">
-                        Перезагрузить страницу
-                    </button>
+                    <button class="btn btn-ghost btn-sm" onclick="location.reload()">Перезагрузить вручную</button>
                 </div>
             `;
         }
-        Toast.success('GUI обновлён! Нажмите F5 или кнопку "Перезагрузить страницу".');
+        Toast.success('GUI обновлён, сервис перезапускается. Страница обновится автоматически.');
+
+        // Поллим /api/version (или /api/status) пока сервис не вернётся.
+        // Сервер уходит в перезапуск через ~3 сек, поднимается обычно
+        // за 1-3 сек после kill. Делаем первую попытку через 4 сек.
+        let attempts = 0;
+        const MAX_ATTEMPTS = 30;  // ~60 секунд при 2-сек интервале
+        const POLL_INTERVAL = 2000;
+        const FIRST_DELAY = 4000;
+
+        const statusEl = document.getElementById('gui-update-restart-status');
+
+        function pollServer() {
+            attempts++;
+            if (statusEl) {
+                statusEl.textContent = `Ожидание сервиса (${attempts}/${MAX_ATTEMPTS})...`;
+            }
+
+            fetch('/api/gui/version', { cache: 'no-store' })
+                .then(r => r.ok ? r.json() : Promise.reject(new Error('http ' + r.status)))
+                .then(data => {
+                    // Сервис ответил — если версия совпала с ожидаемой
+                    // или просто отвечает после рестарта, перезагружаем.
+                    const liveVer = data && (data.version || data.gui_version || '');
+                    const upgraded = !newVersion || liveVer === newVersion;
+                    if (upgraded) {
+                        if (statusEl) statusEl.textContent = 'Готово, перезагружаем...';
+                        setTimeout(() => location.reload(), 500);
+                    } else {
+                        // Сервис ещё со старым кодом — ждём дальше
+                        if (attempts < MAX_ATTEMPTS) {
+                            setTimeout(pollServer, POLL_INTERVAL);
+                        } else if (statusEl) {
+                            statusEl.textContent = 'Сервис не обновился — перезагрузите страницу вручную.';
+                        }
+                    }
+                })
+                .catch(() => {
+                    // Ошибка сети = сервис как раз перезапускается, продолжаем
+                    if (attempts < MAX_ATTEMPTS) {
+                        setTimeout(pollServer, POLL_INTERVAL);
+                    } else if (statusEl) {
+                        statusEl.textContent = 'Сервис не отвечает — проверьте состояние на роутере.';
+                    }
+                });
+        }
+
+        setTimeout(pollServer, FIRST_DELAY);
     }
 
     async function doGuiUpdate() {
@@ -800,7 +877,7 @@ const ZapretManagerPage = (() => {
                 showProgress('Обновление завершено!', 100, 'Обновление zapret-gui...');
                 setTimeout(() => {
                     hideProgress();
-                    showGuiReloadPrompt();
+                    showGuiReloadPrompt(result);
                 }, 1200);
             } else {
                 stopGuiProgressPolling();


### PR DESCRIPTION
…I update

iptables -w flag (Entware/Keenetic 1.4.x):
- Old iptables on Entware accepts -w only as boolean (no SECONDS argument). Passing "iptables -w 5 ..." gave "Bad argument `5'" → all firewall rule applies fail with FW_FAIL during scans (visible at strategies 30+ in user logs).
- Detect form once via "iptables --help" (regex on "[seconds]" or "-w "), cache per binary path. Empty cache means -w not supported at all.
- Runtime fallback: if "Bad argument" + cmd contains "-w 5", downgrade cache to "-w" and retry the command.

GUI auto-update (Перезагрузить страницу не помогает):
- Old behavior: copied files to disk + cleared __pycache__, told user to press F5. But the running Python process kept the old code in memory, so version reported via /api/gui/version stayed unchanged.
- Updater now schedules a detached service restart via the discovered init script (/opt/etc/init.d/S99zapret-gui or /etc/init.d/zapret-gui) after the HTTP response goes out: `sh -c "sleep 3 && <init> restart"` in start_new_session=True. The init script kills the old PID and brings up a fresh process with the new code.
- Response now carries restart_scheduled=True. Frontend (zapret_manager.js) shows "Сервис перезапускается..." status and polls /api/gui/version until either the version matches the expected new one or 60s timeout, then auto-reloads the page. Manual reload button is kept as a fallback.
- If no init script is found (atypical install), the response message tells the user to restart the service by hand instead of pretending everything worked.

