### PR TITLE
Skip unavailable address families in baseline network test

### DIFF
--- a/core/strategy_scanner.py
+++ b/core/strategy_scanner.py
@@ -1336,6 +1336,12 @@ class StrategyScanner:
         # TCP: пробуем IPv4 и IPv6 раздельно
         from core.testers.tls_tester import test_tls
 
+        # Системные ошибки сети (нет маршрута/DNS) — стратегия DPI это не лечит,
+        # такой AF исключаем из карты, как и SKIPPED.
+        UNAVAILABLE_ERRS = {
+            "NET_UNREACH", "HOST_UNREACH", "DNS_ERR", "RESOLVE_ERR",
+        }
+
         per_af: dict[str, bool] = {}
         for af in ("ipv4", "ipv6"):
             try:
@@ -1351,6 +1357,18 @@ class StrategyScanner:
                 continue
             # SKIPPED = нет адресов этого семейства, пропускаем (не кладём в map)
             if res.status == TestStatus.SKIPPED.value:
+                continue
+            # Сетевая недоступность (нет IPv6-маршрута и т.п.) — не DPI,
+            # стратегия не сможет это починить. Исключаем AF из карты,
+            # чтобы пробы стратегий не гонялись по неработающему семейству.
+            if res.error in UNAVAILABLE_ERRS:
+                log.info(
+                    "Baseline %s: недоступно (%s, %.0f ms) — "
+                    "AF исключён из сканирования стратегий" % (
+                        af, res.error, res.latency_ms,
+                    ),
+                    source="scanner",
+                )
                 continue
             per_af[af] = (res.status == TestStatus.SUCCESS.value)
             log.info(


### PR DESCRIPTION
## Summary
Improved baseline network testing to exclude address families (IPv4/IPv6) that are unavailable due to network configuration issues, preventing unnecessary strategy probe attempts on non-functional network paths.

## Key Changes
- Added `UNAVAILABLE_ERRS` set to identify network-level errors that cannot be resolved by DPI strategies (NET_UNREACH, HOST_UNREACH, DNS_ERR, RESOLVE_ERR)
- Added error checking in baseline test to skip address families with unavailable network conditions
- Added informative logging when an address family is excluded due to network unavailability, including error type and latency

## Implementation Details
- Network unavailability errors are now treated similarly to SKIPPED status—the affected address family is excluded from the strategy scanning map
- This prevents wasting resources on strategy probes for address families that have fundamental network connectivity issues (e.g., missing IPv6 routes)
- The distinction is made clear: these are system-level network errors, not DPI-related issues that strategies could potentially mitigate

https://claude.ai/code/session_01Kdgf1fkjb9c9sPpvtAdYRF