### PR TITLE
Add systemd support for autostart on Ubuntu/Debian systems

### DIFF
--- a/api/config_api.py
+++ b/api/config_api.py
@@ -64,7 +64,34 @@ def register(app):
             log.info(f"Конфигурация обновлена: {', '.join(updated)}",
                      source="config")
 
-        return {"ok": True, "updated": updated}
+        # Если поменяли host/port в gui — переписываем systemd unit,
+        # чтобы он не подсовывал свои --host/--port из времени установки.
+        # Без этого изменение порта в UI не применяется к реальному
+        # сервису (старый порт сохранён в ExecStart unit-файла).
+        info = {}
+        gui_section = body.get("gui") if isinstance(body, dict) else None
+        if isinstance(gui_section, dict) and (
+            "host" in gui_section or "port" in gui_section
+        ):
+            try:
+                from core.autostart_manager import (
+                    regenerate_systemd_unit_if_needed,
+                )
+                result = regenerate_systemd_unit_if_needed()
+                if result.get("changed"):
+                    info["systemd_unit_updated"] = True
+                    info["restart_required"] = True
+                    info["restart_hint"] = (
+                        "Для применения нового порта/хоста перезапустите "
+                        "сервис: systemctl restart zapret-gui"
+                    )
+            except Exception as e:
+                log.warning(
+                    f"Не удалось обновить systemd unit: {e}",
+                    source="config",
+                )
+
+        return {"ok": True, "updated": updated, **info}
 
     @app.post("/api/config/reset")
     def api_config_reset():

--- a/api/strategies.py
+++ b/api/strategies.py
@@ -273,6 +273,22 @@ def register(app):
         cfg.set("strategy", "current_name", strategy["name"])
         cfg.save()
 
+        # Если автозапуск включён — пересобираем скрипт автозапуска,
+        # чтобы после перезагрузки системы стартовала именно эта
+        # стратегия, а не та, что была активной на момент включения
+        # автозапуска. На systemd regenerate() — no-op (стратегия
+        # подхватывается из конфига при старте GUI).
+        if cfg.get("autostart", "enabled", default=False):
+            try:
+                from core.autostart_manager import get_autostart_manager
+                am = get_autostart_manager()
+                am.regenerate()
+            except Exception as e:
+                log.warning(
+                    "Не удалось обновить автозапуск: %s" % e,
+                    source="strategies",
+                )
+
         log.success(
             "Стратегия применена: %s" % strategy["name"],
             source="strategies"

--- a/app.py
+++ b/app.py
@@ -67,6 +67,122 @@ class ThreadedWSGIServer(ServerAdapter):
         srv.serve_forever()
 
 
+def _apply_saved_strategy_on_boot():
+    """
+    Автоприменение сохранённой стратегии при старте GUI.
+
+    На платформах без отдельного init.d-скрипта nfqws2 (например, Ubuntu
+    с systemd) сам GUI-сервис должен запустить nfqws2 с сохранённой
+    стратегией после перезагрузки системы. На Entware это делает
+    отдельный init.d/S99zapret — в этом случае пропускаем, чтобы
+    не запустить второй экземпляр nfqws2.
+
+    Вызывается в фоновом потоке, чтобы не блокировать подъём web-сервера.
+    """
+    import threading
+    import time
+
+    def _do_apply():
+        try:
+            # Даём web-серверу подняться, чтобы статус был доступен
+            time.sleep(1.0)
+
+            from core.config_manager import get_config_manager
+            from core.log_buffer import log
+
+            cfg = get_config_manager()
+            if not cfg.get("autostart", "enabled", default=False):
+                return
+
+            # На Entware есть отдельный init.d/S99zapret — он сам
+            # запускает nfqws2. GUI не должен дублировать.
+            if os.path.isfile("/opt/etc/init.d/S99zapret"):
+                log.info(
+                    "init.d/S99zapret установлен — автозапуск nfqws2 "
+                    "выполняется им, GUI пропускает",
+                    source="autostart",
+                )
+                return
+
+            strategy_id = cfg.get("strategy", "current_id")
+            if not strategy_id:
+                log.info(
+                    "Автозапуск включён, но активная стратегия не выбрана",
+                    source="autostart",
+                )
+                return
+
+            from core.nfqws_manager import get_nfqws_manager
+            mgr = get_nfqws_manager()
+
+            # Если nfqws2 уже запущен (например, после restart GUI без
+            # перезагрузки системы) — ничего не делаем.
+            if mgr.is_running():
+                log.info(
+                    "nfqws2 уже запущен — пропуск автоприменения стратегии",
+                    source="autostart",
+                )
+                return
+
+            from core.strategy_builder import get_strategy_manager
+            sm = get_strategy_manager()
+            strategy = sm.get_strategy(strategy_id)
+            if not strategy:
+                log.warning(
+                    "Сохранённая стратегия не найдена: %s" % strategy_id,
+                    source="autostart",
+                )
+                return
+
+            args = sm.build_nfqws_args(strategy)
+            if not args:
+                log.warning(
+                    "Стратегия %s не содержит включённых профилей"
+                    % strategy_id,
+                    source="autostart",
+                )
+                return
+
+            log.info(
+                "Автоприменение сохранённой стратегии: %s"
+                % strategy.get("name", strategy_id),
+                source="autostart",
+            )
+
+            # Применяем правила firewall
+            try:
+                from core.firewall import get_firewall_manager
+                fw = get_firewall_manager()
+                if cfg.get("firewall", "apply_on_start", default=True):
+                    fw.remove_rules()
+                    fw.apply_rules()
+            except Exception as e:
+                log.warning(
+                    "Не удалось применить правила firewall: %s" % e,
+                    source="autostart",
+                )
+
+            if mgr.start(args):
+                log.success(
+                    "Стратегия применена при автозапуске",
+                    source="autostart",
+                )
+            else:
+                log.error(
+                    "Не удалось применить стратегию при автозапуске",
+                    source="autostart",
+                )
+        except Exception as e:
+            try:
+                from core.log_buffer import log
+                log.error("Ошибка автозапуска: %s" % e, source="autostart")
+            except Exception:
+                pass
+
+    t = threading.Thread(target=_do_apply, daemon=True, name="autostart-boot")
+    t.start()
+
+
 def create_app(config_dir: str = None) -> Bottle:
     """
     Создать и настроить Bottle-приложение.
@@ -155,6 +271,10 @@ def create_app(config_dir: str = None) -> Bottle:
         return '<h1>Внутренняя ошибка сервера</h1><p>%s</p>' % str(error)
 
     log.success("Web-GUI инициализирован", source="app")
+
+    # Автоприменение сохранённой стратегии при старте
+    # (для платформ без отдельного nfqws2-init: Ubuntu/systemd и пр.)
+    _apply_saved_strategy_on_boot()
 
     return app
 

--- a/core/autostart_manager.py
+++ b/core/autostart_manager.py
@@ -2,8 +2,16 @@
 """
 Менеджер автозапуска.
 
-Генерирует init.d-скрипт (S99zapret) для Entware,
-устанавливает/удаляет его из /opt/etc/init.d/.
+Поддерживает две модели автозапуска:
+
+  1) Entware: генерирует отдельный init.d/S99zapret, который запускает
+     nfqws2 независимо от GUI. Это исторический путь.
+
+  2) systemd (Ubuntu, Debian и пр.): отдельный init для nfqws2 не
+     создаётся. Автозапуск реализован тем, что systemd автоматически
+     стартует zapret-gui.service, а GUI при старте применяет
+     сохранённую стратегию (см. app._apply_saved_strategy_on_boot).
+     В этом случае enable/disable только обновляют флаг в конфиге.
 
 Использование:
     from core.autostart_manager import get_autostart_manager
@@ -16,8 +24,10 @@
 """
 
 import os
+import re
 import stat
 import shutil
+import subprocess
 import threading
 
 from core.log_buffer import log
@@ -28,9 +38,24 @@ INIT_DIR = "/opt/etc/init.d"
 SCRIPT_NAME = "S99zapret"
 SCRIPT_PATH = os.path.join(INIT_DIR, SCRIPT_NAME)
 
+# systemd unit-файл GUI-сервиса (создаётся install.sh)
+SYSTEMD_UNIT_PATH = "/etc/systemd/system/zapret-gui.service"
+
 # Путь к локальной копии скрипта (в директории проекта)
 LOCAL_INIT_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "init.d")
 LOCAL_SCRIPT_PATH = os.path.join(LOCAL_INIT_DIR, SCRIPT_NAME)
+
+
+def _is_entware() -> bool:
+    """Запущены ли мы на Entware (есть /opt/etc/init.d)."""
+    return os.path.isdir(INIT_DIR)
+
+
+def _is_systemd() -> bool:
+    """Доступен ли systemd."""
+    return shutil.which("systemctl") is not None and os.path.isdir(
+        "/etc/systemd/system"
+    )
 
 # Singleton
 _instance = None
@@ -50,25 +75,41 @@ class AutostartManager:
         Получить полный статус автозапуска.
 
         Returns:
-            dict с полями: enabled, script_exists, script_path, strategy_name, strategy_id
+            dict с полями: enabled, script_exists, script_path, strategy_name, strategy_id, method
         """
         from core.config_manager import get_config_manager
         cfg = get_config_manager()
 
-        installed = self._is_installed()
         enabled = cfg.get("autostart", "enabled", default=False)
+        installed = self._is_installed()
 
-        # Если конфиг говорит enabled, но скрипта нет — рассинхронизация
-        if enabled and not installed:
-            log.warning("Автозапуск включён в конфиге, но скрипт не установлен",
-                        source="autostart")
+        if _is_entware():
+            method = "initd"
+            effective_enabled = enabled and installed
+            # Рассинхронизация — флаг есть, скрипта нет
+            if enabled and not installed:
+                log.warning(
+                    "Автозапуск включён в конфиге, но init.d-скрипт "
+                    "не установлен",
+                    source="autostart",
+                )
+        elif _is_systemd():
+            # На systemd скрипт init.d не нужен — стратегию применяет
+            # сам GUI при старте.
+            method = "systemd"
+            effective_enabled = enabled and os.path.isfile(SYSTEMD_UNIT_PATH)
+        else:
+            method = "unsupported"
+            effective_enabled = False
 
         return {
-            "enabled": enabled and installed,
+            "enabled": effective_enabled,
             "config_enabled": enabled,
             "script_exists": installed,
             "script_path": SCRIPT_PATH,
             "init_dir_exists": os.path.isdir(INIT_DIR),
+            "method": method,
+            "systemd_unit_exists": os.path.isfile(SYSTEMD_UNIT_PATH),
             "strategy_id": cfg.get("strategy", "current_id"),
             "strategy_name": cfg.get("strategy", "current_name") or "Не выбрана",
         }
@@ -136,17 +177,58 @@ class AutostartManager:
         from core.config_manager import get_config_manager
         cfg = get_config_manager()
 
-        # Проверяем директорию init.d
-        if not os.path.isdir(INIT_DIR):
-            msg = "Директория %s не найдена. Entware установлен?" % INIT_DIR
-            log.error(msg, source="autostart")
-            return {"ok": False, "message": msg}
-
         # Проверяем что есть активная стратегия
         strategy_id = cfg.get("strategy", "current_id")
         if not strategy_id:
             msg = "Нет активной стратегии. Сначала примените стратегию."
             log.warning(msg, source="autostart")
+            return {"ok": False, "message": msg}
+
+        # На systemd-системах отдельный init для nfqws2 не создаётся:
+        # стратегию применяет сам GUI при старте (см. app.py).
+        # Достаточно убедиться, что unit-файл GUI существует и enabled.
+        if not _is_entware() and _is_systemd():
+            if not os.path.isfile(SYSTEMD_UNIT_PATH):
+                msg = (
+                    "Systemd unit %s не найден. Установите zapret-gui "
+                    "через install.sh." % SYSTEMD_UNIT_PATH
+                )
+                log.error(msg, source="autostart")
+                return {"ok": False, "message": msg}
+
+            # На всякий случай enable unit (idempotent)
+            try:
+                subprocess.run(
+                    ["systemctl", "enable", "zapret-gui"],
+                    check=False, timeout=10,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                pass
+
+            cfg.set("autostart", "enabled", True)
+            cfg.set("autostart", "method", "systemd")
+            cfg.save()
+
+            strategy_name = cfg.get("strategy", "current_name") or strategy_id
+            log.success(
+                "Автозапуск включён через systemd "
+                "(стратегия: %s применится при загрузке)" % strategy_name,
+                source="autostart",
+            )
+            return {
+                "ok": True,
+                "message": "Автозапуск включён. Сохранённая стратегия "
+                           "будет применена при загрузке системы.",
+            }
+
+        # Дальше — путь Entware с init.d-скриптом
+        if not os.path.isdir(INIT_DIR):
+            msg = (
+                "Не удалось включить автозапуск: ни init.d (%s), "
+                "ни systemd не доступны." % INIT_DIR
+            )
+            log.error(msg, source="autostart")
             return {"ok": False, "message": msg}
 
         # Генерируем скрипт
@@ -186,20 +268,20 @@ class AutostartManager:
         from core.config_manager import get_config_manager
         cfg = get_config_manager()
 
-        # Удаляем скрипт
+        # Удаляем init.d-скрипт если он есть (Entware-режим)
         removed = self._remove_script()
 
-        # Обновляем конфиг в любом случае
+        # Обновляем конфиг в любом случае. На systemd этого достаточно:
+        # GUI при старте проверит флаг и не будет применять стратегию.
         cfg.set("autostart", "enabled", False)
         cfg.save()
 
         if removed:
-            log.success("Автозапуск выключен, скрипт удалён", source="autostart")
-            return {"ok": True, "message": "Автозапуск выключен"}
+            log.success("Автозапуск выключен, init.d-скрипт удалён",
+                        source="autostart")
         else:
-            log.info("Автозапуск выключен (скрипт не был установлен)",
-                     source="autostart")
-            return {"ok": True, "message": "Автозапуск выключен"}
+            log.info("Автозапуск выключен", source="autostart")
+        return {"ok": True, "message": "Автозапуск выключен"}
 
     def _regenerate_locked(self) -> dict:
         """Пересоздать скрипт (под lock)."""
@@ -212,6 +294,15 @@ class AutostartManager:
         strategy_id = cfg.get("strategy", "current_id")
         if not strategy_id:
             return {"ok": False, "message": "Нет активной стратегии"}
+
+        # На systemd init.d-скрипт не нужен — стратегия применяется
+        # самим GUI при старте, а сохранённый id уже в конфиге.
+        if not _is_entware() and _is_systemd():
+            return {
+                "ok": True,
+                "message": "Systemd-режим: отдельный скрипт не требуется, "
+                           "сохранённая стратегия применится при загрузке.",
+            }
 
         # Генерируем заново
         script = self._generate_script()
@@ -528,6 +619,90 @@ exit 0
         )
 
         return script
+
+
+def regenerate_systemd_unit_if_needed() -> dict:
+    """
+    Если установлен systemd unit /etc/systemd/system/zapret-gui.service
+    с захардкоженными --port/--host — переписать ExecStart без этих
+    аргументов, чтобы app.py читал host/port из settings.json.
+
+    Это нужно потому, что прежняя версия install.sh инлайнила значения
+    GUI_PORT/GUI_HOST в ExecStart на момент установки. После смены порта
+    в UI настройка попадает в settings.json, но юнит остаётся со старым
+    портом — и сервис стартует на старом порту.
+
+    Возвращает dict { ok, changed, message }.
+    """
+    if not os.path.isfile(SYSTEMD_UNIT_PATH):
+        return {"ok": False, "changed": False,
+                "message": "Unit-файл не найден"}
+
+    try:
+        with open(SYSTEMD_UNIT_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, IOError) as e:
+        return {"ok": False, "changed": False,
+                "message": "Не удалось прочитать unit: %s" % e}
+
+    if "--port" not in content and "--host" not in content:
+        return {"ok": True, "changed": False, "message": "Unit актуален"}
+
+    m = re.search(r"^ExecStart=(.+)$", content, re.MULTILINE)
+    if not m:
+        return {"ok": False, "changed": False,
+                "message": "Не найдена строка ExecStart"}
+
+    parts = m.group(1).split()
+    # Убираем --host/--port вместе с их значениями
+    cleaned = []
+    skip = False
+    for p in parts:
+        if skip:
+            skip = False
+            continue
+        if p in ("--host", "--port"):
+            skip = True
+            continue
+        if p.startswith("--host=") or p.startswith("--port="):
+            continue
+        cleaned.append(p)
+
+    new_exec = "ExecStart=" + " ".join(cleaned)
+    new_content = re.sub(
+        r"^ExecStart=.+$", new_exec, content, count=1, flags=re.MULTILINE
+    )
+
+    try:
+        with open(SYSTEMD_UNIT_PATH, "w", encoding="utf-8") as f:
+            f.write(new_content)
+    except (OSError, IOError) as e:
+        return {"ok": False, "changed": False,
+                "message": "Не удалось записать unit (нужны root-права?): %s"
+                           % e}
+
+    # daemon-reload, чтобы systemd увидел изменения
+    try:
+        subprocess.run(
+            ["systemctl", "daemon-reload"],
+            check=False, timeout=10,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        pass
+
+    log.info(
+        "Systemd unit обновлён (убраны жёстко прописанные --port/--host). "
+        "Для применения нового порта/хоста перезапустите zapret-gui: "
+        "systemctl restart zapret-gui",
+        source="autostart",
+    )
+    return {
+        "ok": True,
+        "changed": True,
+        "message": "Systemd unit обновлён. Для применения нового порта "
+                   "выполните: systemctl restart zapret-gui",
+    }
 
 
 def get_autostart_manager() -> AutostartManager:

--- a/core/diagnostics.py
+++ b/core/diagnostics.py
@@ -500,51 +500,108 @@ def check_all_services():
 
 # ─────────────────────── Конфликты nfqws/tpws ───────────────────────
 
+# Известные PID-файлы nfqws2, которые GUI считает «своими»:
+#  - PID-файл нашего nfqws_manager (GUI запускает напрямую)
+#  - PID-файл init.d/S99zapret из Entware (создаётся autostart_manager'ом)
+_KNOWN_NFQWS_PID_FILES = (
+    "/var/run/zapret-gui-nfqws.pid",
+    "/var/run/zapret-nfqws.pid",
+)
+
+
+def _read_pid_file(path: str):
+    """Прочитать PID из файла; вернуть int или None."""
+    try:
+        with open(path, "r") as f:
+            return int(f.read().strip())
+    except (IOError, OSError, ValueError):
+        return None
+
+
+def _is_zombie(pid: int) -> bool:
+    """Зомби-процесс — /proc/<pid>/status начинается со State: Z."""
+    try:
+        with open("/proc/%d/status" % pid, "r") as f:
+            for line in f:
+                if line.startswith("State:"):
+                    return "Z" in line
+    except (IOError, OSError):
+        pass
+    return False
+
+
 def check_nfqws_conflicts():
     """
     Проверка конфликтующих процессов nfqws/tpws.
 
+    «Свой» процесс — это процесс, чей PID совпадает с:
+      - PID, который держит наш nfqws_manager;
+      - PID из любого известного PID-файла (см. _KNOWN_NFQWS_PID_FILES),
+        чтобы nfqws2, запущенный init.d/S99zapret на Entware, не
+        выглядел как «сторонний демон».
+
+    Кэширование убрано: проверка лёгкая (один обход /proc), а кэш
+    на 30 секунд приводил к тому, что GUI ещё долго после остановки
+    показывал предупреждение «уже запущенный демон».
+
     Returns:
         dict: { conflicts: [{pid, name, cmdline}...], has_conflicts }
     """
-    cache_key = "conflicts"
-    cached = _cache_get(cache_key)
-    if cached:
-        return cached
-
     conflicts = []
+
+    # Собираем «свои» PID
+    from core.nfqws_manager import get_nfqws_manager
+    mgr = get_nfqws_manager()
+    our_pids = set()
+    mgr_pid = mgr.get_pid()
+    if mgr_pid:
+        our_pids.add(int(mgr_pid))
+    for pf in _KNOWN_NFQWS_PID_FILES:
+        p = _read_pid_file(pf)
+        if p:
+            our_pids.add(p)
 
     # Ищем процессы nfqws/tpws через /proc
     try:
         for pid_dir in os.listdir("/proc"):
             if not pid_dir.isdigit():
                 continue
-            pid = int(pid_dir)
             try:
-                cmdline_path = f"/proc/{pid}/cmdline"
-                with open(cmdline_path, "r") as f:
-                    cmdline = f.read().replace("\x00", " ").strip()
-
-                if not cmdline:
-                    continue
-
-                # Проверяем имя процесса
-                exe_name = os.path.basename(cmdline.split()[0]) if cmdline.split() else ""
-
-                if exe_name in ("nfqws", "nfqws2", "tpws", "tpws2"):
-                    # Проверяем — не наш ли это процесс (от нашего GUI)
-                    from core.nfqws_manager import get_nfqws_manager
-                    mgr = get_nfqws_manager()
-                    our_pid = mgr.get_status().get("pid")
-
-                    if pid != our_pid:
-                        conflicts.append({
-                            "pid": pid,
-                            "name": exe_name,
-                            "cmdline": cmdline[:500],
-                        })
+                pid = int(pid_dir)
+            except ValueError:
+                continue
+            try:
+                with open("/proc/%d/cmdline" % pid, "rb") as f:
+                    raw = f.read()
             except (IOError, OSError, PermissionError):
                 continue
+
+            if not raw:
+                # Пустой cmdline — kthread или зомби, не учитываем
+                continue
+
+            argv = raw.split(b"\x00")
+            argv0 = argv[0].decode("utf-8", errors="replace")
+            if not argv0:
+                continue
+            exe_name = os.path.basename(argv0)
+            if exe_name not in ("nfqws", "nfqws2", "tpws", "tpws2"):
+                continue
+
+            if pid in our_pids:
+                continue
+
+            if _is_zombie(pid):
+                continue
+
+            cmdline = b" ".join(a for a in argv if a).decode(
+                "utf-8", errors="replace"
+            )
+            conflicts.append({
+                "pid": pid,
+                "name": exe_name,
+                "cmdline": cmdline[:500],
+            })
     except (IOError, OSError):
         pass
 
@@ -554,10 +611,6 @@ def check_nfqws_conflicts():
         if ps_bin:
             rc, stdout, _ = _run([ps_bin, "w"], timeout=5)
             if rc == 0 and stdout:
-                from core.nfqws_manager import get_nfqws_manager
-                mgr = get_nfqws_manager()
-                our_pid = mgr.get_status().get("pid")
-
                 for line in stdout.strip().split("\n")[1:]:
                     parts = line.split(None, 4)
                     if len(parts) < 5:
@@ -567,22 +620,26 @@ def check_nfqws_conflicts():
                     except ValueError:
                         continue
                     cmdline = parts[4] if len(parts) > 4 else ""
-                    exe_name = os.path.basename(cmdline.split()[0]) if cmdline.split() else ""
+                    parts_cmd = cmdline.split()
+                    exe_name = os.path.basename(parts_cmd[0]) if parts_cmd else ""
 
-                    if exe_name in ("nfqws", "nfqws2", "tpws", "tpws2") and pid != our_pid:
-                        conflicts.append({
-                            "pid": pid,
-                            "name": exe_name,
-                            "cmdline": cmdline[:500],
-                        })
+                    if exe_name not in ("nfqws", "nfqws2", "tpws", "tpws2"):
+                        continue
+                    if pid in our_pids:
+                        continue
+                    if _is_zombie(pid):
+                        continue
 
-    result = {
+                    conflicts.append({
+                        "pid": pid,
+                        "name": exe_name,
+                        "cmdline": cmdline[:500],
+                    })
+
+    return {
         "conflicts": conflicts,
         "has_conflicts": len(conflicts) > 0,
     }
-
-    _cache_set(cache_key, result)
-    return result
 
 
 # ─────────────────────── Статус Firewall ───────────────────────

--- a/core/nfqws_manager.py
+++ b/core/nfqws_manager.py
@@ -404,14 +404,30 @@ class NFQWSManager:
 
     @staticmethod
     def _check_pid_alive(pid: int) -> bool:
-        """Проверить что процесс с данным PID жив и это nfqws."""
+        """
+        Проверить что процесс с данным PID жив и это действительно nfqws.
+
+        Substring-проверка ('nfqws' in cmdline) даёт ложноположительные
+        срабатывания на чужих процессах (например, ``tail -f
+        /var/log/zapret-nfqws.log`` или ``grep nfqws``), особенно при
+        recycle PID. Сравниваем по basename исполняемого файла argv[0].
+        """
         try:
-            cmdline_path = "/proc/%d/cmdline" % pid
-            with open(cmdline_path, "r") as f:
-                cmdline = f.read()
-            return "nfqws" in cmdline
+            with open("/proc/%d/cmdline" % pid, "rb") as f:
+                raw = f.read()
         except (IOError, OSError):
             return False
+
+        if not raw:
+            # пустой cmdline — kthread или зомби
+            return False
+
+        # argv[0] до первого NUL, затем basename
+        argv0 = raw.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        if not argv0:
+            return False
+        name = os.path.basename(argv0)
+        return name in ("nfqws", "nfqws2")
 
     def _recover_pid(self):
         """Восстановить PID из PID-файла при инициализации."""

--- a/core/zapret_installer.py
+++ b/core/zapret_installer.py
@@ -615,23 +615,40 @@ class ZapretInstaller:
             return installed.lstrip("v") != latest.lstrip("v")
 
     def _find_nfqws_process(self) -> int:
-        """Найти PID работающего nfqws2 процесса в системе."""
+        """
+        Найти PID работающего nfqws2 процесса в системе.
+
+        Сравниваем по basename argv[0]: подстрочная проверка
+        ('nfqws2' in cmdline) ловит чужие процессы — ``tail -f
+        /var/log/zapret-nfqws.log``, ``grep nfqws2``, и пр., из-за чего
+        GUI выдавал ложные предупреждения о «уже запущенном» демоне.
+        """
         try:
             for pid_dir in os.listdir("/proc"):
                 if not pid_dir.isdigit():
                     continue
                 try:
-                    cmdline_path = "/proc/%s/cmdline" % pid_dir
-                    with open(cmdline_path, "r") as f:
-                        cmdline = f.read()
-                    if "nfqws2" in cmdline:
-                        return int(pid_dir)
-                except (IOError, OSError, ValueError):
+                    with open("/proc/%s/cmdline" % pid_dir, "rb") as f:
+                        raw = f.read()
+                except (IOError, OSError):
                     continue
+                if not raw:
+                    continue  # kthread / зомби
+                argv0 = raw.split(b"\x00", 1)[0].decode(
+                    "utf-8", errors="replace"
+                )
+                if not argv0:
+                    continue
+                name = os.path.basename(argv0)
+                if name in ("nfqws", "nfqws2"):
+                    try:
+                        return int(pid_dir)
+                    except ValueError:
+                        continue
         except (IOError, OSError):
             pass
 
-        # Fallback через pidof/pgrep
+        # Fallback через pidof/pgrep — оба требуют точного имени
         for cmd in [["pidof", "nfqws2"], ["pgrep", "-x", "nfqws2"]]:
             try:
                 result = subprocess.run(

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,12 @@ VERSION="0.18.2"
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"
 
+# Пользователь явно задал host/port? (через окружение или флаги)
+GUI_PORT_EXPLICIT=0
+GUI_HOST_EXPLICIT=0
+[ -n "$ZAPRET_GUI_PORT" ] && GUI_PORT_EXPLICIT=1
+[ -n "$ZAPRET_GUI_HOST" ] && GUI_HOST_EXPLICIT=1
+
 # Автоопределение окружения
 detect_env() {
     if [ -d "/opt/etc/init.d" ] && [ -d "/opt/lib" ]; then
@@ -570,6 +576,9 @@ INITEOF
         # Generic Linux с systemd
         info "Обнаружен systemd — создаём unit-файл..."
         local UNIT_FILE="/etc/systemd/system/zapret-gui.service"
+        # ВАЖНО: НЕ инлайним --host/--port в ExecStart. App.py читает
+        # их из settings.json. Иначе изменение порта/хоста через UI
+        # игнорируется — systemd-юнит подсовывает старые значения.
         cat > "$TMP_INIT" << UNITEOF
 [Unit]
 Description=Zapret Web-GUI
@@ -577,7 +586,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=$(command -v python3) $APP_DIR/app.py --host $GUI_HOST --port $GUI_PORT --config $CONFIG_DIR
+ExecStart=$(command -v python3) $APP_DIR/app.py --config $CONFIG_DIR
 Restart=on-failure
 RestartSec=5
 
@@ -587,16 +596,58 @@ UNITEOF
         $SUDO cp "$TMP_INIT" "$UNIT_FILE"
         $SUDO chmod 644 "$UNIT_FILE"
         rm -f "$TMP_INIT"
+
+        # Записываем host/port в settings.json. Если файла ещё нет —
+        # создаём с переданными (или дефолтными) значениями. Если файл
+        # существует и пользователь НЕ передавал --port/--host явно —
+        # не трогаем сохранённые значения (могли быть изменены через UI).
+        $SUDO mkdir -p "$CONFIG_DIR"
+        $SUDO env GUI_HOST="$GUI_HOST" GUI_PORT="$GUI_PORT" \
+                  GUI_HOST_EXPLICIT="$GUI_HOST_EXPLICIT" \
+                  GUI_PORT_EXPLICIT="$GUI_PORT_EXPLICIT" \
+                  python3 - "$CONFIG_DIR/settings.json" <<'PYEOF' || warn "Не удалось записать host/port в settings.json"
+import json, os, sys
+path = sys.argv[1]
+host = os.environ.get("GUI_HOST", "0.0.0.0")
+port = int(os.environ.get("GUI_PORT", "8080"))
+host_explicit = os.environ.get("GUI_HOST_EXPLICIT") == "1"
+port_explicit = os.environ.get("GUI_PORT_EXPLICIT") == "1"
+
+existed = os.path.isfile(path)
+data = {}
+if existed:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f) or {}
+    except Exception:
+        data = {}
+
+gui = data.get("gui") if isinstance(data.get("gui"), dict) else {}
+if not existed:
+    gui.setdefault("host", host)
+    gui.setdefault("port", port)
+if host_explicit:
+    gui["host"] = host
+if port_explicit:
+    gui["port"] = port
+data["gui"] = gui
+
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+PYEOF
+
         $SUDO systemctl daemon-reload
         $SUDO systemctl enable zapret-gui 2>/dev/null || true
         ok "Systemd unit: $UNIT_FILE"
 
-        # Файл конфига
+        # Файл конфига (для совместимости со скриптами/init.d)
         if [ ! -f "$CONFIG_DIR/server.conf" ]; then
             local TMP_CONF="/tmp/zapret-gui-conf-$$"
             cat > "$TMP_CONF" << CONFEOF
 # Настройки веб-сервера Zapret Web-GUI
-# Раскомментируйте и измените при необходимости:
+# Эти значения НЕ используются systemd-юнитом —
+# host/port читаются из settings.json (управляется через UI).
 #GUI_HOST=0.0.0.0
 #GUI_PORT=8080
 CONFEOF
@@ -820,10 +871,10 @@ while [ $# -gt 0 ]; do
             exit 0
             ;;
         --port)
-            shift; GUI_PORT="$1"
+            shift; GUI_PORT="$1"; GUI_PORT_EXPLICIT=1
             ;;
         --host)
-            shift; GUI_HOST="$1"
+            shift; GUI_HOST="$1"; GUI_HOST_EXPLICIT=1
             ;;
         --branch)
             shift; BRANCH="$1"


### PR DESCRIPTION
## Summary
This PR adds native systemd support for autostart functionality on Ubuntu, Debian, and other systemd-based Linux distributions, while maintaining backward compatibility with Entware's init.d approach. The GUI now intelligently detects the platform and applies the appropriate autostart mechanism.

## Key Changes

### Core Autostart Logic (`core/autostart_manager.py`)
- Added platform detection functions `_is_entware()` and `_is_systemd()` to determine available autostart mechanisms
- Implemented dual-mode autostart:
  - **Entware (init.d)**: Generates and manages `/opt/etc/init.d/S99zapret` script as before
  - **systemd**: Leverages existing `zapret-gui.service` unit; GUI applies saved strategy on boot via `_apply_saved_strategy_on_boot()`
- Added `regenerate_systemd_unit_if_needed()` function to clean up hardcoded `--port`/`--host` arguments from systemd unit files created by older install.sh versions, allowing dynamic port/host configuration via settings.json
- Updated `get_status()` to report autostart method and systemd unit status
- Modified enable/disable logic to handle both platforms appropriately

### Boot-time Strategy Application (`app.py`)
- Added `_apply_saved_strategy_on_boot()` function that:
  - Runs in background thread to avoid blocking web server startup
  - Applies saved strategy on systemd-based systems where no separate nfqws2 init script exists
  - Skips on Entware systems where init.d/S99zapret handles nfqws2 startup
  - Applies firewall rules if configured
  - Prevents duplicate nfqws2 instances

### Installation Script (`install.sh`)
- Modified systemd unit generation to NOT inline `--host`/`--port` in ExecStart (allows app.py to read from settings.json)
- Added logic to write host/port to `settings.json` during installation:
  - Creates settings.json if missing
  - Respects existing values if user didn't explicitly pass `--port`/`--host`
  - Allows UI-based port/host changes to persist across service restarts
- Tracks explicit port/host arguments via `GUI_PORT_EXPLICIT` and `GUI_HOST_EXPLICIT` flags

### Configuration API (`api/config_api.py`)
- Added automatic systemd unit regeneration when gui.host or gui.port settings change
- Returns hint to restart service when unit is updated

### Diagnostics Improvements (`core/diagnostics.py`)
- Refactored `check_nfqws_conflicts()` to properly identify "own" nfqws processes:
  - Checks against nfqws_manager's PID
  - Checks against known PID files (`/var/run/zapret-gui-nfqws.pid`, `/var/run/zapret-nfqws.pid`)
  - Filters out zombie processes
  - Removed substring matching that caused false positives (e.g., `grep nfqws2` appearing as conflict)
- Removed caching to provide real-time conflict detection

### Process Detection Fixes
- Updated `core/nfqws_manager.py` and `core/zapret_installer.py` to use basename matching instead of substring matching for process identification
- Prevents false positives from unrelated processes containing "nfqws" in their command line

### Strategy Application (`api/strategies.py`)
- When applying a strategy with autostart enabled, regenerates autostart configuration to ensure the new strategy persists across reboots

## Implementation Details
- Platform detection is non-invasive and graceful: if neither init.d nor systemd is available, autostart is marked as unsupported
- Systemd unit file updates are idempotent and safe (uses regex to clean old arguments)
- Settings are properly persisted in settings.json for systemd-based systems
- Backward compatibility maintained: existing Entware installations continue to work unchanged
- All process detection now uses basename comparison to avoid false positives from log monitoring tools or grep commands

https://claude.ai/code/session_0184Wo8cakZ86dWVts8r3ijr