### PR TITLE
Fix Lua editor positioning with calc-based width instead of right/bottom

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -3727,8 +3727,8 @@ input:focus, textarea:focus, select:focus {
     position: absolute;
     top: 0;
     left: 48px;
-    right: 0;
-    bottom: 0;
+    width: calc(100% - 48px);
+    height: 100%;
     overflow: hidden;
     pointer-events: none;
     color: var(--text-primary);
@@ -3745,10 +3745,8 @@ input:focus, textarea:focus, select:focus {
     position: absolute;
     top: 0;
     left: 48px;
-    right: 0;
-    bottom: 0;
-    width: auto;
-    height: auto;
+    width: calc(100% - 48px);
+    height: 100%;
     z-index: 1;
     overflow: auto;
     color: transparent;
@@ -3868,6 +3866,7 @@ input:focus, textarea:focus, select:focus {
     .lua-highlight,
     .lua-editor {
         left: 36px;
+        width: calc(100% - 36px);
     }
     .lua-editor-wrap {
         height: 55vh;


### PR DESCRIPTION
## Summary
Refactored the CSS positioning of Lua editor components to use `calc()`-based width and height properties instead of relying on `right: 0` and `bottom: 0` positioning. This improves layout consistency and predictability.

## Key Changes
- Replaced `right: 0; bottom: 0;` with `width: calc(100% - 48px); height: 100%;` for `.lua-highlight` element
- Replaced `right: 0; bottom: 0; width: auto; height: auto;` with `width: calc(100% - 48px); height: 100%;` for `.lua-editor` element
- Updated mobile breakpoint (36px) to include corresponding `width: calc(100% - 36px);` for both `.lua-highlight` and `.lua-editor`

## Implementation Details
- All elements maintain `position: absolute` with `left: 48px` (36px on mobile) as the starting point
- Width is now explicitly calculated as `100% - 48px` (or `100% - 36px` on mobile) to account for the left offset
- Height is set to `100%` for consistent vertical sizing
- This approach provides more explicit control over element dimensions and improves browser rendering consistency

https://claude.ai/code/session_011MdaJTzKh2cNhRfJ6wzNw3