### PR TITLE
Default publish_release to true on workflow_dispatch

### DIFF
--- a/.github/workflows/build-awg-binaries.yml
+++ b/.github/workflows/build-awg-binaries.yml
@@ -28,7 +28,7 @@ on:
       publish_release:
         description: 'Опубликовать GitHub Release (true/false)'
         required: false
-        default: 'false'
+        default: 'true'
   push:
     tags:
       - 'awg-bin-*'


### PR DESCRIPTION
On manual runs you almost always want the release to be published. Change the default from false to true so the publish job is not silently skipped without explicitly unchecking the option.

https://claude.ai/code/session_013bwsBKG2AUYAwBiyv83hZz