### PR TITLE
Add AWG platform abstraction and environment detector (Prompt 2)

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -23,6 +23,7 @@ def register_routes(app):
     from api.scan import register as reg_scan
     from api.gui_update import register as reg_gui_update
     from api.catalog_update import register as reg_catalog_update
+    from api.awg import register as reg_awg
 
     reg_status(app)
     reg_logs(app)
@@ -41,3 +42,4 @@ def register_routes(app):
     reg_scan(app)
     reg_gui_update(app)
     reg_catalog_update(app)
+    reg_awg(app)

--- a/api/awg.py
+++ b/api/awg.py
@@ -1,0 +1,37 @@
+# api/awg.py
+"""
+REST API для интеграции amneziawg-go.
+
+Маршруты:
+  GET  /api/awg/environment  — полный отчёт об окружении
+  POST /api/awg/environment/refresh — сбросить кэш и пересканировать
+"""
+
+from bottle import response
+
+
+def register(app):
+
+    @app.route("/api/awg/environment")
+    def awg_environment():
+        """
+        Полный отчёт об окружении для AWG:
+          platform     — платформа и её возможности
+          architecture — uname / opkg-arch / artifact_arch
+          tun          — доступность TUN
+          existing     — уже установленные бинарники, конфиги, интерфейсы
+          prerequisites — что нужно для работы и что пока не выполнено
+          ready        — true если все обязательные prerequisites выполнены
+        """
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_detector import get_awg_detector
+        det = get_awg_detector()
+        return det.get_environment_report()
+
+    @app.route("/api/awg/environment/refresh", method="POST")
+    def awg_environment_refresh():
+        """Сбросить кэш детекта и вернуть свежий отчёт."""
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_detector import get_awg_detector
+        det = get_awg_detector()
+        return det.get_environment_report(force=True)

--- a/core/awg_detector.py
+++ b/core/awg_detector.py
@@ -1,0 +1,372 @@
+# core/awg_detector.py
+"""
+Детект окружения для интеграции amneziawg-go.
+
+Определяет: платформу, архитектуру, наличие TUN, существующие
+установки AWG (бинарники, конфиги, активные интерфейсы).
+
+Использование:
+    from core.awg_detector import get_awg_detector
+    det = get_awg_detector()
+    report = det.get_environment_report()
+"""
+
+import os
+import re
+import subprocess
+import threading
+
+from core.awg_platform import (
+    AwgPlatform,
+    KeeneticPlatform,
+    OpenWrtPlatform,
+    GenericLinuxPlatform,
+)
+from core.log_buffer import log
+
+# ─────────────────────── helpers ─────────────────────────────────────
+
+def _cmd_out(args, timeout=5):
+    try:
+        r = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout
+        )
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+def _cmd_ok(args, timeout=5):
+    try:
+        r = subprocess.run(args, capture_output=True, timeout=timeout)
+        return r.returncode == 0
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _read_file(path):
+    try:
+        with open(path, "r") as f:
+            return f.read()
+    except (IOError, OSError):
+        return ""
+
+
+def _find_binary(names, extra_dirs=()):
+    """Поиск бинарника по именам в стандартных PATH + extra_dirs."""
+    dirs = list(extra_dirs) + [
+        "/opt/usr/sbin", "/opt/usr/bin", "/opt/bin", "/opt/sbin",
+        "/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin",
+        "/sbin", "/bin",
+    ]
+    for d in dirs:
+        for name in names:
+            p = os.path.join(d, name)
+            if os.path.isfile(p) and os.access(p, os.X_OK):
+                return p
+    return ""
+
+
+# ─────────────────────── AwgDetector ─────────────────────────────────
+
+class AwgDetector:
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._cache = None
+
+    # ── публичный API ─────────────────────────────────────────────
+
+    def get_environment_report(self, force=False):
+        """
+        Возвращает полный dict-отчёт об окружении.
+        Кэшируется до следующего вызова с force=True или перезапуска.
+        """
+        with self._lock:
+            if self._cache is not None and not force:
+                return self._cache
+            try:
+                self._cache = self._build_report()
+            except Exception as e:
+                log(f"[awg_detector] ошибка при сборе отчёта: {e}", level="error")
+                self._cache = {"ok": False, "error": str(e)}
+            return self._cache
+
+    def detect_platform(self) -> AwgPlatform:
+        """Вернуть экземпляр AwgPlatform для текущей системы."""
+        if self._is_keenetic():
+            ver = self.detect_keenos_version()
+            return KeeneticPlatform(keenos_version=ver)
+        if self._is_openwrt():
+            return OpenWrtPlatform()
+        return GenericLinuxPlatform()
+
+    def detect_keenos_version(self):
+        """
+        Пытается определить версию KeenOS.
+        Возвращает строку вида '5.4.1' или '' если не Keenetic.
+        """
+        # Ndm-команда (доступна на новых прошивках)
+        ndm = _cmd_out(["ndmq", "-p", "show version"], timeout=3)
+        if ndm:
+            m = re.search(r'"version"\s*:\s*"([\d.]+)"', ndm)
+            if m:
+                return m.group(1)
+
+        # /proc/version — содержит строку вида "Keenetic X.Y.Z"
+        proc_ver = _read_file("/proc/version")
+        m = re.search(r"Keenetic[^\d]*([\d]+\.[\d]+\.[\d]+)", proc_ver, re.I)
+        if m:
+            return m.group(1)
+
+        # /etc/openwrt_release на Keenetic с OpenWrt основой
+        rel = _read_file("/etc/openwrt_release")
+        m = re.search(r'DISTRIB_DESCRIPTION="[^"]*Keenetic[^"]*?([\d]+\.[\d]+\.[\d]+)', rel, re.I)
+        if m:
+            return m.group(1)
+
+        return ""
+
+    def detect_architecture(self):
+        """
+        Возвращает dict с архитектурными данными, совместимыми
+        с именами артефактов нашего workflow.
+        """
+        uname_m = _cmd_out(["uname", "-m"]) or _read_file("/proc/sys/kernel/arch").strip()
+
+        # Опkg print-architecture — более точно на Entware
+        opkg_arch = ""
+        opkg_out = _cmd_out(["opkg", "print-architecture"])
+        if opkg_out:
+            # Первая непустая строка вида "arch mipsel-3.4 10"
+            for line in opkg_out.splitlines():
+                parts = line.strip().split()
+                if len(parts) >= 2 and parts[0] == "arch":
+                    opkg_arch = parts[1]
+                    break
+
+        artifact_arch = self._map_to_artifact_arch(uname_m, opkg_arch)
+        return {
+            "uname_m":       uname_m,
+            "opkg_arch":     opkg_arch,
+            "artifact_arch": artifact_arch,   # mipsel-softfloat | aarch64 | ...
+        }
+
+    def detect_tun(self):
+        """Наличие TUN, загруженность модуля."""
+        dev_tun = os.path.exists("/dev/net/tun") or os.path.exists("/dev/tun")
+        lsmod   = _cmd_out(["lsmod"])
+        tun_mod = "tun" in lsmod.lower() if lsmod else False
+        return {"device": dev_tun, "kernel_module": tun_mod, "available": dev_tun}
+
+    def detect_existing_awg(self):
+        """
+        Ищет уже установленный amneziawg-go: бинарники, конфиги,
+        запущенные интерфейсы. Ничего не трогает.
+        """
+        bin_awg_go  = _find_binary(["amneziawg-go"])
+        bin_awg     = _find_binary(["awg", "wg"])
+        config_dirs = self._find_config_dirs()
+        interfaces  = self._find_awg_interfaces()
+
+        return {
+            "binary_awg_go":    bin_awg_go,
+            "binary_awg":       bin_awg,
+            "config_dirs":      config_dirs,
+            "configs":          self._find_configs(config_dirs),
+            "active_interfaces": interfaces,
+            "has_existing":     bool(bin_awg_go or interfaces or any(d["configs"] for d in config_dirs)),
+        }
+
+    # ── внутренние методы ─────────────────────────────────────────
+
+    def _build_report(self):
+        platform = self.detect_platform()
+        arch     = self.detect_architecture()
+        tun      = self.detect_tun()
+        existing = self.detect_existing_awg()
+
+        # Проверяем что нужно для работы AWG на данной платформе
+        prerequisites = self._check_prerequisites(platform, tun)
+
+        return {
+            "ok":            True,
+            "platform":      platform.as_dict(),
+            "architecture":  arch,
+            "tun":           tun,
+            "existing":      existing,
+            "prerequisites": prerequisites,
+            "ready":         prerequisites["all_met"],
+        }
+
+    def _check_prerequisites(self, platform: AwgPlatform, tun: dict):
+        items = []
+
+        # TUN
+        items.append({
+            "id":      "tun",
+            "label":   "TUN-интерфейс (/dev/net/tun)",
+            "met":     tun["available"],
+            "blocker": not tun["available"],
+            "hint":    platform.opkg_tun_instructions()
+                       if isinstance(platform, KeeneticPlatform)
+                          and not tun["available"]
+                       else "",
+        })
+
+        # OpkgTun на Keenetic 5.x
+        if isinstance(platform, KeeneticPlatform):
+            keenos_maj = 0
+            try:
+                keenos_maj = int(platform._keenos_version.split(".")[0])
+            except (ValueError, IndexError):
+                pass
+            if keenos_maj >= 5:
+                opkg_tun = platform.has_opkg_tun()
+                items.append({
+                    "id":      "opkg_tun",
+                    "label":   "Компонент OpkgTun",
+                    "met":     opkg_tun,
+                    "blocker": not opkg_tun,
+                    "hint":    platform.opkg_tun_instructions() if not opkg_tun else "",
+                })
+
+        # ip-утилита из iproute2
+        has_ip = bool(_cmd_out(["ip", "link"]))
+        items.append({
+            "id":      "iproute2",
+            "label":   "ip (iproute2)",
+            "met":     has_ip,
+            "blocker": not has_ip,
+            "hint":    "Установите пакет iproute2 или ip" if not has_ip else "",
+        })
+
+        blockers = [i for i in items if i["blocker"] and not i["met"]]
+        return {
+            "items":    items,
+            "all_met":  len(blockers) == 0,
+            "blockers": [i["id"] for i in blockers],
+        }
+
+    def _is_keenetic(self):
+        pv = _read_file("/proc/version").lower()
+        if "keenetic" in pv:
+            return True
+        if os.path.exists("/opt/etc/init.d") and _cmd_ok(["ndmq", "--help"]):
+            return True
+        rel = _read_file("/etc/openwrt_release").lower()
+        return "keenetic" in rel
+
+    def _is_openwrt(self):
+        return os.path.exists("/etc/openwrt_release") or \
+               os.path.exists("/etc/openwrt_version")
+
+    def _map_to_artifact_arch(self, uname_m: str, opkg_arch: str) -> str:
+        """
+        Маппинг в имена артефактов из нашего workflow:
+        mipsel-softfloat | mips-softfloat | aarch64 | armv7 | x86_64
+        """
+        ua = uname_m.lower()
+        oa = opkg_arch.lower()
+
+        if "mips" in ua or "mips" in oa:
+            # softfloat → почти все Entware-роутеры
+            if "el" in ua or "mips32el" in oa or "mipsel" in oa:
+                return "mipsel-softfloat"
+            return "mips-softfloat"
+
+        if ua in ("aarch64", "arm64") or "aarch64" in oa:
+            return "aarch64"
+
+        if ua.startswith("armv7") or "armv7" in oa:
+            return "armv7"
+
+        if ua in ("x86_64", "amd64"):
+            return "x86_64"
+
+        # Неизвестная арх — возвращаем uname как есть
+        return uname_m
+
+    def _find_config_dirs(self):
+        candidates = [
+            "/opt/etc/amneziawg",
+            "/opt/etc/amnezia/awg",
+            "/opt/etc/wireguard",
+            "/etc/amneziawg",
+            "/etc/amnezia/awg",
+            "/etc/wireguard",
+        ]
+        found = []
+        for d in candidates:
+            if os.path.isdir(d):
+                confs = [
+                    f for f in os.listdir(d)
+                    if f.endswith(".conf") and os.path.isfile(os.path.join(d, f))
+                ]
+                found.append({"path": d, "configs": confs})
+        return found
+
+    def _find_configs(self, config_dirs):
+        result = []
+        for entry in config_dirs:
+            for name in entry["configs"]:
+                result.append({
+                    "name": name[:-5],   # без .conf
+                    "path": os.path.join(entry["path"], name),
+                })
+        return result
+
+    def _find_awg_interfaces(self):
+        """
+        Активные AWG/WireGuard интерфейсы: через wg show и ip link.
+        """
+        interfaces = []
+        seen = set()
+
+        # Способ 1: wg show (или awg show)
+        for binary in ("awg", "wg"):
+            out = _cmd_out([binary, "show", "interfaces"])
+            if out:
+                for iface in out.split():
+                    if iface and iface not in seen:
+                        seen.add(iface)
+                        interfaces.append({"name": iface, "source": "wg_show"})
+                break
+
+        # Способ 2: ip link show type wireguard
+        out = _cmd_out(["ip", "link", "show", "type", "wireguard"])
+        if out:
+            for line in out.splitlines():
+                m = re.match(r"\d+:\s+(\S+?)[@:]", line)
+                if m:
+                    iface = m.group(1)
+                    if iface not in seen:
+                        seen.add(iface)
+                        interfaces.append({"name": iface, "source": "ip_link"})
+
+        # Способ 3: поиск UAPI-сокетов amneziawg-go в userspace-режиме
+        uapi_dir = "/var/run/wireguard"
+        if os.path.isdir(uapi_dir):
+            for entry in os.listdir(uapi_dir):
+                if entry.endswith(".sock"):
+                    iface = entry[:-5]
+                    if iface not in seen:
+                        seen.add(iface)
+                        interfaces.append({"name": iface, "source": "uapi_sock"})
+
+        return interfaces
+
+
+# ─────────────────────── Singleton ───────────────────────────────────
+
+_detector = None
+_detector_lock = threading.Lock()
+
+
+def get_awg_detector() -> AwgDetector:
+    global _detector
+    if _detector is None:
+        with _detector_lock:
+            if _detector is None:
+                _detector = AwgDetector()
+    return _detector

--- a/core/awg_platform.py
+++ b/core/awg_platform.py
@@ -1,0 +1,222 @@
+# core/awg_platform.py
+"""
+Абстракция платформы для интеграции amneziawg-go.
+
+Каждая реализация знает:
+  - где хранятся бинарники и конфиги
+  - как называются init-скрипты и где они лежат
+  - какой firewall-бэкенд доступен
+  - специфику запуска AWG на данной платформе
+"""
+
+import os
+import subprocess
+
+
+def _cmd_ok(args, timeout=5):
+    try:
+        r = subprocess.run(args, capture_output=True, timeout=timeout)
+        return r.returncode == 0
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _cmd_out(args, timeout=5):
+    try:
+        r = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+# ───────────────────────── Base ──────────────────────────────────────
+
+class AwgPlatform:
+    name = "unknown"
+
+    # Пути
+    binary_dir = "/usr/local/bin"
+    config_dir = "/etc/amneziawg"
+    run_dir    = "/var/run/awg"
+    log_dir    = "/var/log"
+
+    # init.d
+    init_dir      = "/etc/init.d"
+    init_name     = "awg-gui"
+    init_priority = "S51"          # Entware-style: S<prio><name>
+
+    def binary_path(self, name="amneziawg-go"):
+        return os.path.join(self.binary_dir, name)
+
+    def awg_path(self):
+        """Путь к awg (wg-clone с поддержкой AmneziaWG параметров)."""
+        return self.binary_path("awg")
+
+    def config_path(self, name):
+        return os.path.join(self.config_dir, f"{name}.conf")
+
+    def pid_path(self, iface):
+        return os.path.join(self.run_dir, f"awg-{iface}.pid")
+
+    def uapi_path(self, iface):
+        """UAPI-сокет, создаваемый amneziawg-go в userspace-режиме."""
+        return f"/var/run/wireguard/{iface}.sock"
+
+    def init_script_path(self):
+        return os.path.join(self.init_dir, f"{self.init_priority}{self.init_name}")
+
+    # ── возможности платформы ──
+
+    def has_opkg_tun(self):
+        """OpkgTun — отдельный TUN-модуль для Entware на Keenetic KeenOS 5.x."""
+        return False
+
+    def supports_iptables_marks(self):
+        """Доступны ли iptables MARK + ip rule fwmark для per-device routing."""
+        return _cmd_ok(["iptables", "-t", "mangle", "-L", "-n"])
+
+    def supports_nftables(self):
+        return _cmd_ok(["nft", "list", "tables"])
+
+    def get_firewall_backend(self):
+        """Предпочитаемый firewall-бэкенд: 'nftables' | 'iptables' | 'none'."""
+        if self.supports_nftables():
+            return "nftables"
+        if _cmd_ok(["iptables", "-L", "-n"]):
+            return "iptables"
+        return "none"
+
+    def install_init_script(self, content: str):
+        """Записать init-скрипт и сделать исполняемым."""
+        path = self.init_script_path()
+        os.makedirs(self.init_dir, exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        os.chmod(path, 0o755)
+        return path
+
+    def remove_init_script(self):
+        path = self.init_script_path()
+        if os.path.exists(path):
+            os.remove(path)
+
+    def tun_available(self):
+        return os.path.exists("/dev/net/tun") or os.path.exists("/dev/tun")
+
+    def as_dict(self):
+        return {
+            "name":                   self.name,
+            "binary_dir":             self.binary_dir,
+            "config_dir":             self.config_dir,
+            "run_dir":                self.run_dir,
+            "init_dir":               self.init_dir,
+            "init_name":              self.init_name,
+            "init_priority":          self.init_priority,
+            "has_opkg_tun":           self.has_opkg_tun(),
+            "supports_iptables_marks": self.supports_iptables_marks(),
+            "firewall_backend":       self.get_firewall_backend(),
+            "tun_available":          self.tun_available(),
+        }
+
+
+# ───────────────────────── Keenetic / Entware ────────────────────────
+
+class KeeneticPlatform(AwgPlatform):
+    name = "keenetic"
+
+    binary_dir = "/opt/usr/sbin"
+    config_dir = "/opt/etc/amneziawg"
+    run_dir    = "/opt/var/run/awg"
+    log_dir    = "/opt/var/log"
+    init_dir   = "/opt/etc/init.d"
+    init_name  = "amneziawg-gui"
+    init_priority = "S51"
+
+    def __init__(self, keenos_version: str = ""):
+        self._keenos_version = keenos_version
+
+    def _version_major(self):
+        try:
+            return int(self._keenos_version.split(".")[0])
+        except (ValueError, IndexError):
+            return 0
+
+    def has_opkg_tun(self):
+        """OpkgTun нужен начиная с KeenOS 5.0."""
+        if self._version_major() >= 5:
+            return _cmd_ok(["opkg", "status", "opkg-tun"])
+        # На KeenOS < 5 TUN обычно доступен иначе
+        return self.tun_available()
+
+    def supports_iptables_marks(self):
+        # На Keenetic с OpkgTun iptables работает в Entware-цепочках
+        if not self.has_opkg_tun() and self._version_major() >= 5:
+            return False
+        return super().supports_iptables_marks()
+
+    def opkg_tun_instructions(self):
+        """Пошаговая инструкция по установке OpkgTun."""
+        return (
+            "Для работы AmneziaWG на KeenOS 5.x необходим компонент OpkgTun:\n"
+            "1. Откройте веб-интерфейс Keenetic (http://192.168.1.1)\n"
+            "2. Перейдите в Управление → Компоненты\n"
+            "3. В разделе OPKG найдите 'Поддержка TUN/TAP' (opkg-tun)\n"
+            "4. Установите компонент и перезагрузите роутер\n"
+            "5. После перезагрузки вернитесь сюда и повторите установку"
+        )
+
+    def as_dict(self):
+        d = super().as_dict()
+        d["keenos_version"] = self._keenos_version
+        d["opkg_tun_installed"] = self.has_opkg_tun()
+        if self._version_major() >= 5 and not self.has_opkg_tun():
+            d["opkg_tun_instructions"] = self.opkg_tun_instructions()
+        return d
+
+
+# ───────────────────────── OpenWrt ───────────────────────────────────
+
+class OpenWrtPlatform(AwgPlatform):
+    name = "openwrt"
+
+    binary_dir = "/usr/sbin"
+    config_dir = "/etc/amneziawg"
+    run_dir    = "/var/run/awg"
+    log_dir    = "/var/log"
+    init_dir   = "/etc/init.d"
+    init_name  = "awg-gui"
+    init_priority = ""   # procd init: нет S<N>-префикса
+
+    def init_script_path(self):
+        return os.path.join(self.init_dir, self.init_name)
+
+    def supports_nftables(self):
+        # OpenWrt 22.03+ использует nftables по умолчанию
+        return _cmd_ok(["nft", "list", "tables"])
+
+
+# ───────────────────────── Generic Linux ─────────────────────────────
+
+class GenericLinuxPlatform(AwgPlatform):
+    name = "linux"
+
+    binary_dir = "/usr/local/bin"
+    config_dir = "/etc/amneziawg"
+    run_dir    = "/var/run/awg"
+    log_dir    = "/var/log"
+    init_dir   = "/etc/systemd/system"
+    init_name  = "awg-gui"
+    init_priority = ""
+
+    def init_script_path(self):
+        return os.path.join(self.init_dir, f"{self.init_name}.service")
+
+    def install_init_script(self, content: str):
+        path = super().install_init_script(content)
+        _cmd_ok(["systemctl", "daemon-reload"])
+        return path
+
+    def remove_init_script(self):
+        _cmd_ok(["systemctl", "disable", self.init_name])
+        super().remove_init_script()
+        _cmd_ok(["systemctl", "daemon-reload"])


### PR DESCRIPTION
core/awg_platform.py:
  AwgPlatform base class with paths, init-script helpers, firewall
  backend detection, and TUN availability check.
  KeeneticPlatform (4.x/5.x, OpkgTun awareness + install instructions),
  OpenWrtPlatform (procd, nftables), GenericLinuxPlatform (systemd).

core/awg_detector.py:
  AwgDetector singleton that produces a full environment report:
  platform, architecture (uname + opkg, mapped to our artifact names),
  TUN state, existing installation scan (binaries in PATH, config
  dirs, active interfaces via wg show / ip link / UAPI sockets),
  prerequisites check with per-item hints for missing items.
  Thread-safe cached report, refreshable via force=True.

api/awg.py:
  GET  /api/awg/environment        -> cached environment report
  POST /api/awg/environment/refresh -> drop cache, rescan

api/__init__.py: register awg routes.

https://claude.ai/code/session_013bwsBKG2AUYAwBiyv83hZz