### PR TITLE
Implement WARP-in-WARP double tunnel feature

### DIFF
--- a/api/awg.py
+++ b/api/awg.py
@@ -30,6 +30,10 @@ REST API для интеграции amneziawg-go.
 
   POST   /api/awg/warp/import           — импорт готового WARP .conf
   POST   /api/awg/warp/generate         — нативная генерация AWG-WARP
+
+  GET    /api/awg/warp-in-warp          — статус WARP-in-WARP
+  POST   /api/awg/warp-in-warp          — поднять (body: outer, inner)
+  DELETE /api/awg/warp-in-warp          — отключить
 """
 
 import threading
@@ -403,6 +407,53 @@ def register(app):
         except Exception as e:
             response.status = 500
             return {"ok": False, "error": "Внутренняя ошибка: %s" % e}
+
+    # ─────────── WARP-in-WARP ─────────────────────────────────
+
+    @app.route("/api/awg/warp-in-warp")
+    def awg_wiw_status():
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_warp_in_warp import status as wiw_status
+        try:
+            return wiw_status()
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
+    @app.route("/api/awg/warp-in-warp", method="POST")
+    def awg_wiw_setup():
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_warp_in_warp import setup as wiw_setup
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        outer = (body.get("outer") or "").strip()
+        inner = (body.get("inner") or "").strip()
+        if not outer or not inner:
+            response.status = 400
+            return {"ok": False, "error": "outer и inner обязательны"}
+        try:
+            result = wiw_setup(outer, inner)
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+        if not result.get("ok"):
+            response.status = 400
+        return result
+
+    @app.route("/api/awg/warp-in-warp", method="DELETE")
+    def awg_wiw_teardown():
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_warp_in_warp import teardown as wiw_teardown
+        try:
+            result = wiw_teardown()
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+        if not result.get("ok"):
+            response.status = 500
+        return result
 
     @app.route("/api/awg/keypair", method="POST")
     def awg_keypair():

--- a/core/awg_warp_in_warp.py
+++ b/core/awg_warp_in_warp.py
@@ -1,0 +1,450 @@
+# core/awg_warp_in_warp.py
+"""
+WARP-in-WARP: двойной туннель.
+
+Идея:
+  * outer — первый AWG-WARP интерфейс. Его endpoint доступен через
+    физический WAN (обычное поведение).
+  * inner — второй AWG-WARP интерфейс. Его endpoint мы принудительно
+    маршрутизируем через outer, чтобы handshake/keepalive пакеты
+    inner'а проходили внутри outer-туннеля.
+  * Пользовательский трафик идёт через inner.
+
+Технически:
+  1) Поднимаем outer. AwgManager._add_default_via() кладёт default
+     маршрут в отдельную таблицу T_outer и добавляет ip rule
+     «not fwmark T_outer → T_outer».
+  2) Резолвим IP endpoint'а inner-конфига.
+  3) В main-таблицу добавляем /32 route на inner_endpoint_ip через
+     dev <outer>. Это гарантирует, что handshake-пакеты inner'а,
+     помеченные его fwmark и потому не попадающие в его собственную
+     таблицу, всё равно находят дорогу — через outer.
+  4) Поднимаем inner. Его ip rule имеет более высокий приоритет
+     (добавлен позже) — весь незамаркированный трафик уходит через
+     inner.
+
+Состояние сохраняем в settings.json (config["awg"]["warp_in_warp"]):
+  {
+    "active":               bool,
+    "outer":                "<имя>",
+    "inner":                "<имя>",
+    "inner_endpoint_ip":    "1.2.3.4",
+    "inner_endpoint_v6":    "" | "...",
+    "outer_started_by_us":  bool,
+    "inner_started_by_us":  bool,
+    "started_at":           int,
+  }
+"""
+
+import ipaddress
+import socket
+import subprocess
+import threading
+import time
+
+from core.awg_config import parse_conf
+from core.awg_manager import get_awg_manager
+from core.config_manager import get_config_manager
+from core.log_buffer import log
+
+
+# ───────────────────────── helpers ──────────────────────────────────
+
+def _run(args, timeout=10):
+    try:
+        r = subprocess.run(args, capture_output=True, text=True,
+                           timeout=timeout)
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+    except subprocess.TimeoutExpired as e:
+        return 124, "", "timeout: %s" % e
+    except OSError as e:
+        return 1, "", str(e)
+
+
+def _split_endpoint(endpoint: str):
+    """'host:port' / '[ipv6]:port' → (host, port)."""
+    if not endpoint:
+        return "", ""
+    s = str(endpoint).strip()
+    if s.startswith("["):
+        rb = s.find("]")
+        if rb > 0 and len(s) > rb + 1 and s[rb + 1] == ":":
+            return s[1:rb], s[rb + 2:]
+        return "", ""
+    if ":" in s:
+        host, _, port = s.rpartition(":")
+        return host, port
+    return s, ""
+
+
+def _resolve_endpoint(host: str):
+    """
+    Резолвим хост → (ipv4 или None, ipv6 или None). Если уже IP —
+    возвращаем сам IP в соответствующее поле.
+    """
+    if not host:
+        return None, None
+    try:
+        ip = ipaddress.ip_address(host)
+        if isinstance(ip, ipaddress.IPv4Address):
+            return host, None
+        return None, host
+    except ValueError:
+        pass
+
+    v4 = None
+    v6 = None
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_DGRAM)
+    except (socket.gaierror, OSError):
+        return None, None
+
+    for fam, _t, _p, _c, sa in infos:
+        if fam == socket.AF_INET and v4 is None:
+            v4 = sa[0]
+        elif fam == socket.AF_INET6 and v6 is None:
+            v6 = sa[0]
+    return v4, v6
+
+
+def _read_inner_endpoint(name: str):
+    """
+    Прочитать endpoint первого peer'а из конфига. Возвращает
+    (host, port_str). Бросает ValueError если конфиг невалиден.
+    """
+    mgr = get_awg_manager()
+    cfg = mgr.get_config(name)  # бросит FileNotFoundError если нет
+    parsed = cfg.get("parsed") or parse_conf(cfg.get("text") or "")
+    peers = parsed.get("peers") or []
+    if not peers:
+        raise ValueError("В конфиге %s нет [Peer]" % name)
+    endpoint = (peers[0] or {}).get("Endpoint") or ""
+    host, port = _split_endpoint(endpoint)
+    if not host:
+        raise ValueError("Не удалось разобрать Endpoint конфига %s" % name)
+    return host, port
+
+
+def _route_exists(family: str, dest: str, dev: str) -> bool:
+    rc, out, _ = _run(["ip", family, "route", "show", dest], timeout=5)
+    if rc != 0 or not out:
+        return False
+    for line in out.splitlines():
+        # строка вида: "1.2.3.4 dev awg-outer scope link"
+        parts = line.split()
+        if "dev" in parts:
+            i = parts.index("dev")
+            if i + 1 < len(parts) and parts[i + 1] == dev:
+                return True
+    return False
+
+
+# ───────────────────────── state ────────────────────────────────────
+
+DEFAULT_STATE = {
+    "active":              False,
+    "outer":               "",
+    "inner":               "",
+    "inner_endpoint_ip":   "",
+    "inner_endpoint_v6":   "",
+    "outer_started_by_us": False,
+    "inner_started_by_us": False,
+    "started_at":          0,
+}
+
+
+def _state() -> dict:
+    cm = get_config_manager()
+    raw = cm.get("awg", "warp_in_warp") or {}
+    out = dict(DEFAULT_STATE)
+    if isinstance(raw, dict):
+        for k, v in raw.items():
+            out[k] = v
+    return out
+
+
+def _save_state(st: dict):
+    cm = get_config_manager()
+    cm.set("awg", "warp_in_warp", st)
+    cm.save()
+
+
+def _clear_state():
+    _save_state(dict(DEFAULT_STATE))
+
+
+# ───────────────────────── core API ─────────────────────────────────
+
+_lock = threading.Lock()
+
+
+def setup(outer: str, inner: str) -> dict:
+    """
+    Сконфигурировать WARP-in-WARP. Если оба интерфейса уже
+    подняты — мы только пины маршрут и фиксируем состояние.
+    """
+    with _lock:
+        return _do_setup(outer, inner)
+
+
+def teardown() -> dict:
+    """
+    Разобрать WARP-in-WARP: убрать /32 route, опустить интерфейсы
+    (только те, которые мы поднимали).
+    """
+    with _lock:
+        return _do_teardown()
+
+
+def status() -> dict:
+    """Текущий статус (state + проверка интерфейсов и маршрута)."""
+    with _lock:
+        return _do_status()
+
+
+# ───────────────────────── implementation ───────────────────────────
+
+def _do_setup(outer: str, inner: str) -> dict:
+    if not outer or not inner:
+        return {"ok": False, "error": "Нужно указать outer и inner"}
+    if outer == inner:
+        return {"ok": False, "error": "outer и inner должны различаться"}
+
+    cur = _state()
+    if cur["active"]:
+        return {"ok": False, "error":
+                "WARP-in-WARP уже активен (%s → %s). "
+                "Сначала отключите." % (cur.get("outer"), cur.get("inner"))}
+
+    mgr = get_awg_manager()
+
+    # Проверим, что оба конфига существуют
+    try:
+        outer_cfg = mgr.get_config(outer)
+        inner_cfg = mgr.get_config(inner)
+    except FileNotFoundError as e:
+        return {"ok": False,
+                "error": "Конфиг %s не найден" % e.args[0]}
+    except ValueError as e:
+        return {"ok": False, "error": str(e)}
+
+    if outer_cfg.get("errors"):
+        return {"ok": False, "error":
+                "Outer-конфиг содержит ошибки: " +
+                "; ".join(outer_cfg["errors"])}
+    if inner_cfg.get("errors"):
+        return {"ok": False, "error":
+                "Inner-конфиг содержит ошибки: " +
+                "; ".join(inner_cfg["errors"])}
+
+    # Резолвим endpoint inner ДО поднятия чего-либо: если outer
+    # перехватит DNS — резолв может оказаться сложнее.
+    try:
+        host, _port = _read_inner_endpoint(inner)
+    except (ValueError, FileNotFoundError) as e:
+        return {"ok": False, "error": str(e)}
+
+    inner_v4, inner_v6 = _resolve_endpoint(host)
+    if not inner_v4 and not inner_v6:
+        return {"ok": False, "error":
+                "Не удалось резолвить endpoint inner (%s)" % host}
+
+    log.info("WiW: inner endpoint %s → v4=%s v6=%s" %
+             (host, inner_v4, inner_v6), source="awg_wiw")
+
+    # 1) Поднять outer (если ещё не поднят)
+    outer_was_up = mgr.is_running(outer)
+    outer_started_by_us = False
+    if not outer_was_up:
+        res_o = mgr.up(outer)
+        if not res_o.get("ok"):
+            return {"ok": False, "error":
+                    "Не удалось поднять outer: %s" %
+                    res_o.get("message", "ошибка")}
+        outer_started_by_us = True
+        # дать туннелю установиться
+        time.sleep(0.5)
+
+    # 2) /32 route на inner endpoint через outer iface
+    pinned = []
+    if inner_v4:
+        rc, _o, err = _run(["ip", "-4", "route", "add",
+                            "%s/32" % inner_v4, "dev", outer])
+        if rc == 0:
+            pinned.append(("v4", "%s/32" % inner_v4))
+        else:
+            # Возможно маршрут уже есть (например, после неудачного
+            # предыдущего setup) — попробуем replace.
+            rc2, _o2, err2 = _run(["ip", "-4", "route", "replace",
+                                   "%s/32" % inner_v4, "dev", outer])
+            if rc2 != 0:
+                _rollback_setup(outer, outer_started_by_us, pinned)
+                return {"ok": False, "error":
+                        "Не удалось добавить маршрут %s через %s: %s" %
+                        (inner_v4, outer, (err2 or err).strip())}
+            pinned.append(("v4", "%s/32" % inner_v4))
+
+    if inner_v6:
+        rc, _o, err = _run(["ip", "-6", "route", "add",
+                            "%s/128" % inner_v6, "dev", outer])
+        if rc == 0:
+            pinned.append(("v6", "%s/128" % inner_v6))
+        else:
+            rc2, _o2, err2 = _run(["ip", "-6", "route", "replace",
+                                   "%s/128" % inner_v6, "dev", outer])
+            if rc2 == 0:
+                pinned.append(("v6", "%s/128" % inner_v6))
+            # IPv6 — не критично, не откатываемся
+
+    # 3) Поднять inner
+    inner_was_up = mgr.is_running(inner)
+    inner_started_by_us = False
+    if not inner_was_up:
+        res_i = mgr.up(inner)
+        if not res_i.get("ok"):
+            # откат: убрать маршрут, опустить outer (если поднимали мы)
+            for fam, dest in pinned:
+                _run(["ip", "-4" if fam == "v4" else "-6",
+                      "route", "del", dest, "dev", outer])
+            if outer_started_by_us:
+                mgr.down(outer)
+            return {"ok": False, "error":
+                    "Не удалось поднять inner: %s" %
+                    res_i.get("message", "ошибка")}
+        inner_started_by_us = True
+
+    # 4) Сохранить state
+    new_state = {
+        "active":              True,
+        "outer":               outer,
+        "inner":               inner,
+        "inner_endpoint_ip":   inner_v4 or "",
+        "inner_endpoint_v6":   inner_v6 or "",
+        "outer_started_by_us": outer_started_by_us,
+        "inner_started_by_us": inner_started_by_us,
+        "started_at":          int(time.time()),
+    }
+    _save_state(new_state)
+
+    log.success("WARP-in-WARP активен: %s → %s" % (outer, inner),
+                source="awg_wiw")
+    return {
+        "ok":      True,
+        "message": "WARP-in-WARP активен",
+        "state":   new_state,
+    }
+
+
+def _rollback_setup(outer: str, outer_started_by_us: bool,
+                    pinned: list):
+    """Откат части setup при ошибке между шагами."""
+    for fam, dest in pinned:
+        _run(["ip", "-4" if fam == "v4" else "-6",
+              "route", "del", dest, "dev", outer])
+    if outer_started_by_us:
+        try:
+            get_awg_manager().down(outer)
+        except Exception:
+            pass
+
+
+def _do_teardown() -> dict:
+    cur = _state()
+    if not cur.get("active"):
+        return {"ok": True, "message": "WARP-in-WARP не активен"}
+
+    outer = cur.get("outer") or ""
+    inner = cur.get("inner") or ""
+    mgr = get_awg_manager()
+
+    errors = []
+
+    # 1) Опустить inner (если поднимали мы)
+    if inner and cur.get("inner_started_by_us"):
+        res = mgr.down(inner)
+        if not res.get("ok"):
+            errors.append("inner: %s" % res.get("message", "ошибка"))
+
+    # 2) Убрать /32 route. dev может уже не существовать — просто
+    # пробуем оба варианта.
+    v4 = cur.get("inner_endpoint_ip") or ""
+    v6 = cur.get("inner_endpoint_v6") or ""
+    if outer:
+        if v4:
+            _run(["ip", "-4", "route", "del",
+                  "%s/32" % v4, "dev", outer])
+        if v6:
+            _run(["ip", "-6", "route", "del",
+                  "%s/128" % v6, "dev", outer])
+
+    # 3) Опустить outer (если поднимали мы)
+    if outer and cur.get("outer_started_by_us"):
+        res = mgr.down(outer)
+        if not res.get("ok"):
+            errors.append("outer: %s" % res.get("message", "ошибка"))
+
+    _clear_state()
+
+    log.info("WARP-in-WARP отключён", source="awg_wiw")
+    if errors:
+        return {"ok": False, "error": "; ".join(errors),
+                "message": "Отключено с ошибками"}
+    return {"ok": True, "message": "WARP-in-WARP отключён"}
+
+
+def _do_status() -> dict:
+    cur = _state()
+    out = {
+        "ok":     True,
+        "active": bool(cur.get("active")),
+        "state":  cur,
+    }
+
+    if not cur.get("active"):
+        return out
+
+    mgr = get_awg_manager()
+    outer = cur.get("outer") or ""
+    inner = cur.get("inner") or ""
+
+    outer_running = bool(outer) and mgr.is_running(outer)
+    inner_running = bool(inner) and mgr.is_running(inner)
+
+    v4 = cur.get("inner_endpoint_ip") or ""
+    v6 = cur.get("inner_endpoint_v6") or ""
+    route_v4_ok = bool(v4 and outer and _route_exists("-4", v4, outer))
+    route_v6_ok = bool(v6 and outer and _route_exists("-6", v6, outer))
+
+    healthy = outer_running and inner_running and (
+        route_v4_ok if v4 else (route_v6_ok if v6 else False)
+    )
+
+    # Дополнительная инфа: статусы peer'ов и handshake
+    try:
+        outer_status = mgr.status(outer) if outer else {}
+    except Exception:
+        outer_status = {}
+    try:
+        inner_status = mgr.status(inner) if inner else {}
+    except Exception:
+        inner_status = {}
+
+    out.update({
+        "outer_running": outer_running,
+        "inner_running": inner_running,
+        "route_v4_ok":   route_v4_ok,
+        "route_v6_ok":   route_v6_ok,
+        "healthy":       healthy,
+        "outer_status":  outer_status,
+        "inner_status":  inner_status,
+    })
+    return out
+
+
+# ───────────────────────── public helpers ───────────────────────────
+
+def get_state() -> dict:
+    """Текущее сохранённое состояние без проверок."""
+    return _state()

--- a/web/js/pages/awg_warp.js
+++ b/web/js/pages/awg_warp.js
@@ -2,9 +2,9 @@
  * awg_warp.js — Импорт и нативная генерация AWG-WARP конфигов.
  *
  * Табы:
- *   - Импорт      (готовый .conf от стороннего генератора)
- *   - Генерация   (нативно через Cloudflare WARP API)
- *   - WARP-in-WARP (заглушка, будет в следующем промте)
+ *   - Импорт       (готовый .conf от стороннего генератора)
+ *   - Генерация    (нативно через Cloudflare WARP API)
+ *   - WARP-in-WARP (двойной туннель: outer → inner)
  */
 
 const AwgWarpPage = (() => {
@@ -19,6 +19,15 @@ const AwgWarpPage = (() => {
     let genLicense  = '';
     let genName     = '';
     let savingGen   = false;
+
+    // ── WARP-in-WARP tab state ─────────────────────────────────────
+    let wiwLoading      = false;
+    let wiwBusy         = false;     // setup/teardown в процессе
+    let wiwStatus       = null;      // последний ответ /api/awg/warp-in-warp
+    let wiwConfigs      = [];        // список существующих AWG-конфигов
+    let wiwOuter        = '';        // выбранное имя outer
+    let wiwInner        = '';        // выбранное имя inner
+    let wiwRefreshTimer = null;
 
     // ══════════════ render ══════════════
 
@@ -61,7 +70,9 @@ const AwgWarpPage = (() => {
         renderTab();
     }
 
-    function destroy() {}
+    function destroy() {
+        stopWiwRefresh();
+    }
 
     // ══════════════ tabs ══════════════
 
@@ -75,6 +86,15 @@ const AwgWarpPage = (() => {
         const idx = map[tab];
         const btns = document.querySelectorAll('.tabs-bar .tab-btn');
         if (btns[idx]) btns[idx].classList.add('active');
+
+        // На WiW-табе включаем периодический рефреш статуса.
+        if (tab === 'wiw') {
+            loadWiwData();
+            startWiwRefresh();
+        } else {
+            stopWiwRefresh();
+        }
+
         renderTab();
     }
 
@@ -83,7 +103,7 @@ const AwgWarpPage = (() => {
         if (!box) return;
         if (activeTab === 'import')   return renderImportTab(box);
         if (activeTab === 'generate') return renderGenerateTab(box);
-        if (activeTab === 'wiw')      return renderWiwStub(box);
+        if (activeTab === 'wiw')      return renderWiwTab(box);
     }
 
     // ══════════════ tab: Импорт ══════════════
@@ -268,12 +288,334 @@ const AwgWarpPage = (() => {
         `;
     }
 
-    function renderWiwStub(box) {
-        box.innerHTML = `
-            <div class="text-muted" style="padding: 32px; text-align: center;">
-                WARP-in-WARP (двойной туннель) появится в следующем обновлении.
+    // ══════════════ tab: WARP-in-WARP ══════════════
+
+    function renderWiwTab(box) {
+        if (wiwLoading && !wiwStatus) {
+            box.innerHTML = `
+                <div class="text-muted" style="padding: 32px; text-align: center;">
+                    Загрузка...
+                </div>`;
+            return;
+        }
+
+        const active = !!(wiwStatus && wiwStatus.active);
+
+        const intro = `
+            <p class="text-muted" style="margin: 0 0 12px 0;">
+                Двойной туннель: пользовательский трафик идёт сначала
+                через <strong>outer</strong> (первый WARP), а внутри
+                него — через <strong>inner</strong> (второй WARP).
+                Это меняет внешний IP дважды и помогает обойти ограничения,
+                настроенные под одиночный WARP.
+            </p>
+            <p class="text-muted" style="margin: 0 0 16px 0; font-size: 12px;">
+                Рекомендуется заранее сгенерировать или импортировать
+                два разных WARP-конфига на вкладках «Импорт» / «Генерация».
+            </p>
+        `;
+
+        if (active) {
+            box.innerHTML = intro + renderWiwActiveBlock(wiwStatus);
+        } else {
+            box.innerHTML = intro + renderWiwSetupBlock();
+        }
+    }
+
+    function renderWiwSetupBlock() {
+        const opts = wiwConfigs
+            .map(c => `<option value="${escapeHtml(c.name)}">${escapeHtml(c.name)}</option>`)
+            .join('');
+
+        if (!wiwConfigs.length) {
+            return `
+                <div style="padding: 12px; background: rgba(211, 158, 0, 0.10);
+                            border-left: 3px solid #d39e00; font-size: 13px;
+                            margin-bottom: 12px;">
+                    Нет ни одного WARP-конфига. Создайте хотя бы два — на
+                    вкладках «Импорт» или «Генерация» — а потом возвращайтесь сюда.
+                </div>`;
+        }
+
+        return `
+            <div style="display:flex; flex-wrap:wrap; gap:12px; margin-bottom: 12px;">
+                <div style="display:flex; flex-direction:column; gap:4px; min-width: 220px;">
+                    <label class="form-label" style="margin:0;">
+                        Outer (первый туннель, через WAN)
+                    </label>
+                    <select class="form-input" id="awg-wiw-outer"
+                            ${wiwBusy ? 'disabled' : ''}
+                            onchange="AwgWarpPage.onWiwOuterChange()">
+                        <option value="">— выберите —</option>
+                        ${opts}
+                    </select>
+                </div>
+                <div style="display:flex; flex-direction:column; gap:4px; min-width: 220px;">
+                    <label class="form-label" style="margin:0;">
+                        Inner (второй туннель, через outer)
+                    </label>
+                    <select class="form-input" id="awg-wiw-inner"
+                            ${wiwBusy ? 'disabled' : ''}
+                            onchange="AwgWarpPage.onWiwInnerChange()">
+                        <option value="">— выберите —</option>
+                        ${opts}
+                    </select>
+                </div>
+            </div>
+
+            <div id="awg-wiw-status" style="margin-bottom: 8px;"></div>
+
+            <div style="display:flex; gap:8px;">
+                <button class="btn btn-primary"
+                        id="awg-wiw-setup-btn"
+                        onclick="AwgWarpPage.doWiwSetup()"
+                        ${wiwBusy ? 'disabled' : ''}>
+                    ${wiwBusy ? 'Запуск...' : 'Создать двойной туннель'}
+                </button>
+                <button class="btn btn-ghost btn-sm"
+                        onclick="AwgWarpPage.refreshWiw()"
+                        ${wiwBusy ? 'disabled' : ''}>
+                    Обновить
+                </button>
             </div>
         `;
+    }
+
+    function renderWiwActiveBlock(st) {
+        const outer = (st.state && st.state.outer) || '—';
+        const inner = (st.state && st.state.inner) || '—';
+        const ipV4  = (st.state && st.state.inner_endpoint_ip) || '';
+        const ipV6  = (st.state && st.state.inner_endpoint_v6) || '';
+
+        const dot = (ok) => `<span style="display:inline-block; width:8px; height:8px;
+            border-radius:50%; background: ${ok ? '#2ea043' : '#c0392b'};
+            margin-right: 6px;"></span>`;
+
+        const healthColor = st.healthy ? '#2ea043' : '#d39e00';
+        const healthText  = st.healthy ? 'Активен' : 'Активен с предупреждениями';
+
+        return `
+            <div style="padding: 10px 12px; background: rgba(46, 160, 67, 0.10);
+                        border-left: 3px solid ${healthColor};
+                        font-size: 13px; margin-bottom: 12px;">
+                <div style="font-weight: 600; color: ${healthColor};
+                            margin-bottom: 4px;">
+                    ${escapeHtml(healthText)}
+                </div>
+                <div style="display:grid; grid-template-columns: max-content 1fr;
+                            gap: 4px 12px; font-size: 12px;">
+                    <div>Outer:</div>
+                    <div>${dot(st.outer_running)}<strong>${escapeHtml(outer)}</strong></div>
+                    <div>Inner:</div>
+                    <div>${dot(st.inner_running)}<strong>${escapeHtml(inner)}</strong></div>
+                    ${ipV4 ? `
+                    <div>Маршрут IPv4:</div>
+                    <div>${dot(st.route_v4_ok)}${escapeHtml(ipV4)}/32 → ${escapeHtml(outer)}</div>` : ''}
+                    ${ipV6 ? `
+                    <div>Маршрут IPv6:</div>
+                    <div>${dot(st.route_v6_ok)}${escapeHtml(ipV6)}/128 → ${escapeHtml(outer)}</div>` : ''}
+                </div>
+            </div>
+
+            ${renderWiwPeerStats('Outer', st.outer_status)}
+            ${renderWiwPeerStats('Inner', st.inner_status)}
+
+            <div style="display:flex; gap:8px; margin-top: 12px;">
+                <button class="btn btn-danger"
+                        onclick="AwgWarpPage.doWiwTeardown()"
+                        ${wiwBusy ? 'disabled' : ''}>
+                    ${wiwBusy ? 'Отключение...' : 'Отключить'}
+                </button>
+                <button class="btn btn-ghost btn-sm"
+                        onclick="AwgWarpPage.refreshWiw()"
+                        ${wiwBusy ? 'disabled' : ''}>
+                    Обновить
+                </button>
+            </div>
+        `;
+    }
+
+    function renderWiwPeerStats(label, status) {
+        const peers = (status && status.peers) || [];
+        if (!peers.length) return '';
+        const rows = peers.map(p => {
+            const hs = p.latest_handshake
+                ? formatHandshake(p.latest_handshake) : 'нет';
+            const rx = formatBytes(p.rx_bytes || 0);
+            const tx = formatBytes(p.tx_bytes || 0);
+            return `
+                <tr>
+                    <td style="font-family: monospace; font-size: 11px;
+                               max-width: 220px; overflow: hidden;
+                               text-overflow: ellipsis; white-space: nowrap;">
+                        ${escapeHtml((p.public_key || '').slice(0, 20))}…
+                    </td>
+                    <td>${escapeHtml(hs)}</td>
+                    <td>↓ ${rx}</td>
+                    <td>↑ ${tx}</td>
+                </tr>`;
+        }).join('');
+        return `
+            <div style="margin-top: 8px;">
+                <div style="font-size: 12px; color: var(--text-secondary);
+                            margin-bottom: 4px;">${escapeHtml(label)}</div>
+                <table style="width:100%; font-size: 12px;
+                              border-collapse: collapse;">
+                    <thead>
+                        <tr style="color: var(--text-muted);">
+                            <th style="text-align:left;">Peer</th>
+                            <th style="text-align:left;">Handshake</th>
+                            <th style="text-align:left;">RX</th>
+                            <th style="text-align:left;">TX</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </div>`;
+    }
+
+    async function loadWiwData() {
+        wiwLoading = true;
+        try {
+            const [statusResp, configsResp] = await Promise.all([
+                API.get('/api/awg/warp-in-warp'),
+                API.get('/api/awg/configs'),
+            ]);
+            wiwStatus = statusResp || { ok: false, active: false };
+            wiwConfigs = (configsResp && configsResp.configs) || [];
+
+            // Если нет выбранных значений — взять из state, если активен
+            if (wiwStatus.active && wiwStatus.state) {
+                wiwOuter = wiwStatus.state.outer || wiwOuter;
+                wiwInner = wiwStatus.state.inner || wiwInner;
+            }
+        } catch (err) {
+            wiwStatus = { ok: false, active: false, error: err.message };
+        } finally {
+            wiwLoading = false;
+            if (activeTab === 'wiw') {
+                renderTab();
+                // восстановить значения <select> после рендера
+                const o = document.getElementById('awg-wiw-outer');
+                const i = document.getElementById('awg-wiw-inner');
+                if (o && wiwOuter) o.value = wiwOuter;
+                if (i && wiwInner) i.value = wiwInner;
+            }
+        }
+    }
+
+    function startWiwRefresh() {
+        stopWiwRefresh();
+        wiwRefreshTimer = setInterval(() => {
+            if (activeTab !== 'wiw' || wiwBusy) return;
+            loadWiwData();
+        }, 5000);
+    }
+
+    function stopWiwRefresh() {
+        if (wiwRefreshTimer) {
+            clearInterval(wiwRefreshTimer);
+            wiwRefreshTimer = null;
+        }
+    }
+
+    function refreshWiw() {
+        loadWiwData();
+    }
+
+    function onWiwOuterChange() {
+        const sel = document.getElementById('awg-wiw-outer');
+        wiwOuter = sel ? sel.value : '';
+    }
+
+    function onWiwInnerChange() {
+        const sel = document.getElementById('awg-wiw-inner');
+        wiwInner = sel ? sel.value : '';
+    }
+
+    async function doWiwSetup() {
+        if (wiwBusy) return;
+        if (!wiwOuter || !wiwInner) {
+            Toast.error('Выберите outer и inner');
+            return;
+        }
+        if (wiwOuter === wiwInner) {
+            Toast.error('Outer и inner должны различаться');
+            return;
+        }
+
+        const status = document.getElementById('awg-wiw-status');
+        if (status) {
+            status.innerHTML = `<span class="text-muted">
+                Поднимаем outer, пиним маршрут, поднимаем inner...
+            </span>`;
+        }
+
+        wiwBusy = true;
+        renderTab();
+
+        try {
+            const resp = await API.post('/api/awg/warp-in-warp', {
+                outer: wiwOuter,
+                inner: wiwInner,
+            });
+            if (!resp.ok) throw new Error(resp.error || 'Ошибка запуска');
+            Toast.success('WARP-in-WARP активен');
+            await loadWiwData();
+        } catch (err) {
+            Toast.error(err.message || 'Ошибка');
+            if (status) {
+                status.innerHTML = `
+                    <div style="padding: 8px 10px;
+                                background: rgba(192, 57, 43, 0.12);
+                                border-left: 3px solid #c0392b;
+                                font-size: 13px;">
+                        ${escapeHtml(err.message || 'Ошибка')}
+                    </div>`;
+            }
+        } finally {
+            wiwBusy = false;
+            renderTab();
+        }
+    }
+
+    async function doWiwTeardown() {
+        if (wiwBusy) return;
+        if (!confirm('Отключить WARP-in-WARP? Туннели, которые мы ' +
+                     'поднимали для этого режима, будут опущены.')) {
+            return;
+        }
+        wiwBusy = true;
+        renderTab();
+        try {
+            const resp = await API.delete('/api/awg/warp-in-warp');
+            if (!resp.ok) throw new Error(resp.error || 'Ошибка отключения');
+            Toast.success('WARP-in-WARP отключён');
+            await loadWiwData();
+        } catch (err) {
+            Toast.error(err.message || 'Ошибка');
+        } finally {
+            wiwBusy = false;
+            renderTab();
+        }
+    }
+
+    function formatBytes(n) {
+        n = Number(n) || 0;
+        if (n < 1024) return n + ' B';
+        if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+        if (n < 1024 * 1024 * 1024) return (n / 1024 / 1024).toFixed(1) + ' MB';
+        return (n / 1024 / 1024 / 1024).toFixed(2) + ' GB';
+    }
+
+    function formatHandshake(ts) {
+        const t = Number(ts) || 0;
+        if (!t) return 'нет';
+        const ago = Math.max(0, Math.floor(Date.now() / 1000) - t);
+        if (ago < 60) return ago + ' с назад';
+        if (ago < 3600) return Math.floor(ago / 60) + ' мин назад';
+        if (ago < 86400) return Math.floor(ago / 3600) + ' ч назад';
+        return Math.floor(ago / 86400) + ' д назад';
     }
 
     // ══════════════ events ══════════════
@@ -508,5 +850,8 @@ const AwgWarpPage = (() => {
         switchTab, onTextInput, onFile, doImport, clearText,
         onLicenseInput, onGenNameInput, doGenerate,
         doSaveGenerated, discardGenerated,
+        // WARP-in-WARP
+        onWiwOuterChange, onWiwInnerChange,
+        doWiwSetup, doWiwTeardown, refreshWiw,
     };
 })();


### PR DESCRIPTION
## Summary
Adds complete support for WARP-in-WARP (double tunnel) functionality, allowing users to chain two WireGuard-based WARP tunnels where user traffic flows through an outer tunnel and then through an inner tunnel. This provides double IP rotation and helps bypass restrictions configured for single WARP.

## Key Changes

### Backend Implementation (`core/awg_warp_in_warp.py`)
- New module implementing the WARP-in-WARP double tunnel logic
- **Setup flow**: 
  1. Validates both outer and inner configs exist and are error-free
  2. Resolves inner endpoint IP (IPv4/IPv6) before bringing up any interfaces
  3. Brings up outer tunnel (if not already running)
  4. Adds /32 (IPv4) and /128 (IPv6) routes to inner endpoint through outer interface
  5. Brings up inner tunnel (if not already running)
  6. Persists state to `settings.json`
- **Teardown flow**: Reverses setup steps, removing routes and bringing down only tunnels that were started by the setup process
- **Status monitoring**: Checks interface status, route existence, and peer handshake information
- Helper functions for endpoint parsing, DNS resolution, route verification, and subprocess execution
- Thread-safe operations using locks

### API Endpoints (`api/awg.py`)
- `GET /api/awg/warp-in-warp` — Returns current WARP-in-WARP status with interface health and peer statistics
- `POST /api/awg/warp-in-warp` — Initiates setup with `outer` and `inner` config names
- `DELETE /api/awg/warp-in-warp` — Tears down the double tunnel

### Frontend UI (`web/js/pages/awg_warp.js`)
- Replaces WARP-in-WARP stub with full functional tab
- **Setup view**: Dropdown selectors for outer/inner configs with validation
- **Active view**: Displays health status with visual indicators (green/red dots), shows:
  - Outer and inner tunnel status
  - IPv4/IPv6 route status
  - Peer statistics (handshake time, RX/TX bytes) for both tunnels
- Auto-refresh every 5 seconds when tab is active
- Manual refresh button
- Proper error handling and user feedback via Toast notifications
- Helper functions for formatting bytes and handshake timestamps

## Notable Implementation Details

- **State persistence**: Configuration stored in `settings.json` under `config["awg"]["warp_in_warp"]` with fields tracking which interfaces were started by the setup process
- **Graceful rollback**: If setup fails mid-process, automatically cleans up partial state (removes routes, brings down outer if needed)
- **DNS resolution before tunnel**: Resolves inner endpoint hostname before bringing up outer tunnel to avoid DNS interception issues
- **Route pinning**: Uses `ip route add/replace` to ensure inner endpoint traffic is routed through outer interface, bypassing inner's own routing table
- **IPv6 support**: Handles both IPv4 and IPv6 endpoints, though IPv6 route failures are non-critical
- **Health monitoring**: Status endpoint checks both interface running state and actual route existence to detect configuration drift

https://claude.ai/code/session_01G6en6rX17wdNhrtWquV54L