### PR TITLE
Add selective routing engine for AmneziaWG tunnels

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -24,6 +24,7 @@ def register_routes(app):
     from api.gui_update import register as reg_gui_update
     from api.catalog_update import register as reg_catalog_update
     from api.awg import register as reg_awg
+    from api.routing import register as reg_routing
 
     reg_status(app)
     reg_logs(app)
@@ -43,3 +44,4 @@ def register_routes(app):
     reg_gui_update(app)
     reg_catalog_update(app)
     reg_awg(app)
+    reg_routing(app)

--- a/api/routing.py
+++ b/api/routing.py
@@ -1,0 +1,123 @@
+# api/routing.py
+"""
+REST API для selective routing.
+
+Маршруты:
+  GET    /api/routing/rules               — список всех правил
+  POST   /api/routing/rules               — создать правило
+                                              (поле type: cidr|domain|device)
+  GET    /api/routing/rules/<id>          — одно правило
+  PUT    /api/routing/rules/<id>          — обновить правило
+  DELETE /api/routing/rules/<id>          — удалить правило
+  POST   /api/routing/apply               — переприменить все правила
+"""
+
+from bottle import request, response
+
+
+def register(app):
+
+    @app.route("/api/routing/rules")
+    def routing_list():
+        response.content_type = "application/json; charset=utf-8"
+        from core.routing import get_routing_manager
+        try:
+            iface_filter = (request.params.get("iface") or "").strip()
+            rules = get_routing_manager().list_rules_dict()
+            if iface_filter:
+                rules = [r for r in rules
+                         if r.get("target_iface") == iface_filter]
+            return {"ok": True, "rules": rules}
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
+    @app.route("/api/routing/rules", method="POST")
+    def routing_create():
+        response.content_type = "application/json; charset=utf-8"
+        from core.routing import get_routing_manager, rule_from_dict
+
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+
+        if not isinstance(body, dict) or not body.get("type"):
+            response.status = 400
+            return {"ok": False,
+                    "error": "Тело должно содержать поле 'type'"}
+
+        # Не даём клиенту навязать id — генерируем сами
+        body.pop("id", None)
+
+        try:
+            rule = rule_from_dict(body)
+        except (ValueError, TypeError) as e:
+            response.status = 400
+            return {"ok": False, "error": str(e)}
+
+        try:
+            return get_routing_manager().add_rule(rule)
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
+    @app.route("/api/routing/rules/<rid>")
+    def routing_get(rid):
+        response.content_type = "application/json; charset=utf-8"
+        from core.routing import get_routing_manager
+        rule = get_routing_manager().get_rule(rid)
+        if rule is None:
+            response.status = 404
+            return {"ok": False, "error": "Правило не найдено"}
+        return {"ok": True, "rule": rule.to_dict()}
+
+    @app.route("/api/routing/rules/<rid>", method="PUT")
+    def routing_update(rid):
+        response.content_type = "application/json; charset=utf-8"
+        from core.routing import get_routing_manager, rule_from_dict
+
+        existing = get_routing_manager().get_rule(rid)
+        if existing is None:
+            response.status = 404
+            return {"ok": False, "error": "Правило не найдено"}
+
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        body["id"] = rid
+        # Тип меняем тоже из body, если передан, иначе берём существующий
+        if not body.get("type"):
+            body["type"] = existing.type_name
+
+        try:
+            rule = rule_from_dict(body)
+        except (ValueError, TypeError) as e:
+            response.status = 400
+            return {"ok": False, "error": str(e)}
+
+        try:
+            return get_routing_manager().update_rule(rule)
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
+    @app.route("/api/routing/rules/<rid>", method="DELETE")
+    def routing_delete(rid):
+        response.content_type = "application/json; charset=utf-8"
+        from core.routing import get_routing_manager
+        result = get_routing_manager().remove_rule(rid)
+        if not result.get("ok"):
+            response.status = 404 if "не найдено" in result.get("error", "") else 500
+        return result
+
+    @app.route("/api/routing/apply", method="POST")
+    def routing_apply():
+        response.content_type = "application/json; charset=utf-8"
+        from core.routing import get_routing_manager
+        try:
+            return get_routing_manager().reapply_all()
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}

--- a/core/awg_manager.py
+++ b/core/awg_manager.py
@@ -435,6 +435,14 @@ class AwgManager:
         for cmd in _as_list(iface.get("PostUp")):
             self._run_hook(cmd, ifname, "PostUp")
 
+        # Применить routing-правила, привязанные к этому интерфейсу
+        try:
+            from core.routing.applier import apply_all_on_interface_up
+            apply_all_on_interface_up(ifname)
+        except Exception as e:
+            log.warning("routing apply on up %s: %s" % (ifname, e),
+                        source="awg_manager")
+
         log.success("Интерфейс %s поднят" % ifname, source="awg_manager")
         return {
             "ok":      True,
@@ -504,6 +512,14 @@ class AwgManager:
         if cfg:
             for cmd in _as_list(cfg["interface"].get("PreDown")):
                 self._run_hook(cmd, ifname, "PreDown")
+
+        # Снять routing-правила, привязанные к этому интерфейсу
+        try:
+            from core.routing.applier import remove_all_on_interface_down
+            remove_all_on_interface_down(ifname)
+        except Exception as e:
+            log.warning("routing remove on down %s: %s" % (ifname, e),
+                        source="awg_manager")
 
         # Удалить добавленные нами маршруты/правила
         self._remove_added_routes(ifname)

--- a/core/routing/__init__.py
+++ b/core/routing/__init__.py
@@ -1,0 +1,49 @@
+# core/routing/__init__.py
+"""
+Selective routing engine.
+
+Универсальный движок selective routing: маршрутизация трафика
+в произвольный сетевой интерфейс по разным критериям (CIDR,
+домены, устройства).
+
+Архитектурно не привязан к AmneziaWG — будет переиспользоваться
+будущей Sing-box интеграцией.
+
+Поверхностный API:
+    from core.routing import (
+        get_routing_manager,
+        CidrRoutingRule,
+        DomainRoutingRule,
+        DeviceRoutingRule,
+    )
+
+    mgr = get_routing_manager()
+    rule = CidrRoutingRule(target_iface="warp1", cidrs=["1.2.3.0/24"])
+    mgr.add_rule(rule)
+    mgr.apply_rule(rule)
+"""
+
+from core.routing.rules import (
+    RoutingRule,
+    CidrRoutingRule,
+    DomainRoutingRule,
+    DeviceRoutingRule,
+    rule_from_dict,
+)
+from core.routing.manager import RoutingManager, get_routing_manager
+from core.routing.applier import (
+    apply_all_on_interface_up,
+    remove_all_on_interface_down,
+)
+
+__all__ = [
+    "RoutingRule",
+    "CidrRoutingRule",
+    "DomainRoutingRule",
+    "DeviceRoutingRule",
+    "rule_from_dict",
+    "RoutingManager",
+    "get_routing_manager",
+    "apply_all_on_interface_up",
+    "remove_all_on_interface_down",
+]

--- a/core/routing/applier.py
+++ b/core/routing/applier.py
@@ -1,0 +1,37 @@
+# core/routing/applier.py
+"""
+Хуки для применения/снятия routing-правил при подъёме/опускании
+сетевых интерфейсов.
+
+Подключается из core/awg_manager.py:
+    from core.routing.applier import (
+        apply_all_on_interface_up,
+        remove_all_on_interface_down,
+    )
+
+Делает безопасный try/except — ошибки не должны мешать up/down.
+"""
+
+from core.log_buffer import log
+
+
+def apply_all_on_interface_up(ifname: str) -> dict:
+    """Применить все правила, целевой iface которых = ifname."""
+    try:
+        from core.routing.manager import get_routing_manager
+        return get_routing_manager().apply_all_for_iface(ifname)
+    except Exception as e:
+        log.warning("routing applier (up %s): %s" % (ifname, e),
+                    source="routing")
+        return {"ok": False, "error": str(e)}
+
+
+def remove_all_on_interface_down(ifname: str) -> dict:
+    """Снять все правила, целевой iface которых = ifname."""
+    try:
+        from core.routing.manager import get_routing_manager
+        return get_routing_manager().remove_all_for_iface(ifname)
+    except Exception as e:
+        log.warning("routing applier (down %s): %s" % (ifname, e),
+                    source="routing")
+        return {"ok": False, "error": str(e)}

--- a/core/routing/manager.py
+++ b/core/routing/manager.py
@@ -1,0 +1,324 @@
+# core/routing/manager.py
+"""
+RoutingManager — оркестратор selective routing.
+
+Применение правил:
+  - Каждому целевому интерфейсу выделяется отдельная таблица
+    маршрутизации (ID = 100 + hash(name) % 900). В этой таблице
+    лежит default-route на интерфейс.
+  - Под каждое CIDR-правило добавляется ip rule:
+        ip rule add to <cidr> lookup <table> priority <prio>
+    Это гарантирует, что трафик к указанным CIDR уходит через
+    нужный интерфейс независимо от AllowedIPs.
+
+Идемпотентность: повторное применение того же правила не должно
+порождать дубликатов — перед `add` мы делаем `del` (best-effort).
+
+Зависимости — только subprocess + ip(8). Никаких новых пакетов.
+"""
+
+import subprocess
+import threading
+
+from core.log_buffer import log
+from core.routing.rules import (
+    RoutingRule,
+    CidrRoutingRule,
+    DomainRoutingRule,
+    DeviceRoutingRule,
+)
+from core.routing import storage
+
+
+# ───────────────────────── helpers ──────────────────────────────────
+
+def _run(args, timeout=10):
+    try:
+        r = subprocess.run(args, capture_output=True, text=True,
+                           timeout=timeout)
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+    except subprocess.TimeoutExpired as e:
+        return 124, "", "timeout: %s" % e
+    except OSError as e:
+        return 1, "", str(e)
+
+
+def table_id_for(ifname: str) -> int:
+    """
+    Стабильный id таблицы из имени интерфейса (100..999).
+
+    ВАЖНО: тот же алгоритм, что и в core/awg_manager.py:_table_id_for —
+    чтобы default-route, добавленный AwgManager при AllowedIPs=0/0,
+    лежал в той же таблице, к которой будут адресовать наши ip rule.
+    """
+    h = 0
+    for ch in ifname:
+        h = (h * 31 + ord(ch)) & 0xFFFFFFFF
+    return 100 + (h % 900)
+
+
+def _iface_exists(ifname: str) -> bool:
+    rc, _o, _e = _run(["ip", "link", "show", "dev", ifname])
+    return rc == 0
+
+
+def _table_has_default(family: str, table: int, ifname: str) -> bool:
+    """Проверить, есть ли в таблице default-route на наш iface."""
+    rc, out, _e = _run(["ip", family, "route", "show", "table", str(table),
+                        "default"])
+    if rc != 0 or not out:
+        return False
+    for line in out.splitlines():
+        parts = line.split()
+        if "dev" in parts:
+            i = parts.index("dev")
+            if i + 1 < len(parts) and parts[i + 1] == ifname:
+                return True
+    return False
+
+
+# ───────────────────────── manager ───────────────────────────────────
+
+class RoutingManager:
+    """Применение/откат правил routing. Тонкий слой над ip(8)."""
+
+    # Базовый приоритет для наших ip rule (между fwmark-rule и main).
+    # main-таблица = 32766; suppress_prefixlength fwmark-rule, который
+    # ставит wg-quick / awg_manager._add_default_via — обычно >= 32760.
+    # Берём 1000 + offset, чтобы наши правила отрабатывали раньше main.
+    BASE_PRIORITY = 10000
+
+    def __init__(self):
+        self._lock = threading.Lock()
+
+    # ─────────── CRUD ───────────
+
+    def list_rules(self) -> list:
+        """Все правила (объекты RoutingRule)."""
+        return storage.load_rules()
+
+    def list_rules_dict(self) -> list:
+        """Все правила в виде dict (для API/UI)."""
+        return [r.to_dict() for r in self.list_rules()]
+
+    def get_rule(self, rule_id: str):
+        return storage.get_rule(rule_id)
+
+    def add_rule(self, rule: RoutingRule, apply_now: bool = True) -> dict:
+        """Сохранить и (опционально) применить правило."""
+        with self._lock:
+            storage.add_rule(rule)
+            if apply_now and rule.enabled:
+                applied = self._apply(rule)
+                return {"ok": applied.get("ok", True),
+                        "rule": rule.to_dict(),
+                        "applied": applied}
+            return {"ok": True, "rule": rule.to_dict()}
+
+    def update_rule(self, rule: RoutingRule, apply_now: bool = True) -> dict:
+        """Обновить правило (сначала откатываем старое, потом ставим новое)."""
+        with self._lock:
+            old = storage.get_rule(rule.id)
+            if old is not None:
+                self._remove(old)
+            storage.update_rule(rule)
+            if apply_now and rule.enabled:
+                applied = self._apply(rule)
+                return {"ok": applied.get("ok", True),
+                        "rule": rule.to_dict(),
+                        "applied": applied}
+            return {"ok": True, "rule": rule.to_dict()}
+
+    def remove_rule(self, rule_id: str) -> dict:
+        """Откатить и удалить правило по id."""
+        with self._lock:
+            rule = storage.get_rule(rule_id)
+            if rule is None:
+                return {"ok": False, "error": "Правило не найдено"}
+            self._remove(rule)
+            storage.remove_rule(rule_id)
+            return {"ok": True, "id": rule_id}
+
+    # ─────────── apply / remove (одно правило) ───────────
+
+    def apply_rule(self, rule_id: str) -> dict:
+        """Применить уже сохранённое правило по id."""
+        rule = storage.get_rule(rule_id)
+        if rule is None:
+            return {"ok": False, "error": "Правило не найдено"}
+        return self._apply(rule)
+
+    def remove_applied_rule(self, rule_id: str) -> dict:
+        """Снять применённое правило (без удаления из хранилища)."""
+        rule = storage.get_rule(rule_id)
+        if rule is None:
+            return {"ok": False, "error": "Правило не найдено"}
+        return self._remove(rule)
+
+    def _apply(self, rule: RoutingRule) -> dict:
+        if isinstance(rule, CidrRoutingRule):
+            return self._apply_cidr(rule)
+        if isinstance(rule, DomainRoutingRule):
+            return {"ok": False, "skipped": True,
+                    "message": "Domain-правила появятся в следующем промте"}
+        if isinstance(rule, DeviceRoutingRule):
+            return {"ok": False, "skipped": True,
+                    "message": "Device-правила появятся в следующем промте"}
+        return {"ok": False, "error": "Неизвестный тип правила"}
+
+    def _remove(self, rule: RoutingRule) -> dict:
+        if isinstance(rule, CidrRoutingRule):
+            return self._remove_cidr(rule)
+        return {"ok": True, "skipped": True}
+
+    # ─────────── apply ALL on iface up/down ───────────
+
+    def apply_all_for_iface(self, ifname: str) -> dict:
+        """Применить все правила, привязанные к интерфейсу."""
+        results = []
+        for rule in self.list_rules():
+            if rule.target_iface != ifname or not rule.enabled:
+                continue
+            results.append({
+                "id":     rule.id,
+                "type":   rule.type_name,
+                "result": self._apply(rule),
+            })
+        return {"ok": True, "iface": ifname, "applied": results}
+
+    def remove_all_for_iface(self, ifname: str) -> dict:
+        """Снять все правила интерфейса (не удаляя их из хранилища)."""
+        results = []
+        for rule in self.list_rules():
+            if rule.target_iface != ifname:
+                continue
+            results.append({
+                "id":     rule.id,
+                "type":   rule.type_name,
+                "result": self._remove(rule),
+            })
+        return {"ok": True, "iface": ifname, "removed": results}
+
+    def reapply_all(self) -> dict:
+        """
+        Снять и заново применить все правила. Полезно после ручных
+        изменений в системе или при отладке.
+        """
+        results = []
+        for rule in self.list_rules():
+            self._remove(rule)
+            if rule.enabled:
+                results.append({
+                    "id":     rule.id,
+                    "type":   rule.type_name,
+                    "result": self._apply(rule),
+                })
+        return {"ok": True, "applied": results}
+
+    # ─────────── CIDR backend ───────────
+
+    def _ensure_table_default(self, ifname: str, family: str, table: int) -> bool:
+        """
+        Гарантировать default-route в таблице ifname. Возвращает True
+        если маршрут уже был или мы его добавили.
+        """
+        if _table_has_default(family, table, ifname):
+            return True
+        if not _iface_exists(ifname):
+            return False
+        rc, _o, err = _run(["ip", family, "route", "add", "default",
+                            "dev", ifname, "table", str(table)])
+        if rc != 0:
+            # Может быть RTNETLINK answers: File exists — это не ошибка
+            if "File exists" in (err or ""):
+                return True
+            log.warning("routing: не удалось добавить default %s в table %d: %s"
+                        % (ifname, table, err.strip()),
+                        source="routing")
+            return False
+        return True
+
+    def _apply_cidr(self, rule: CidrRoutingRule) -> dict:
+        ifname = rule.target_iface
+        table = table_id_for(ifname)
+
+        if not _iface_exists(ifname):
+            return {"ok": False,
+                    "deferred": True,
+                    "message": "Интерфейс %s ещё не поднят — правило"
+                               " будет применено при старте" % ifname}
+
+        added = []
+        errors = []
+
+        for cidr, fam in rule.cidr_families():
+            if rule.ip_version != "auto" and fam != rule.ip_version:
+                continue
+
+            family = "-6" if fam == "v6" else "-4"
+            if not self._ensure_table_default(ifname, family, table):
+                errors.append("default-route в table %d не создан (%s)"
+                              % (table, family))
+                continue
+
+            # Сначала чистим возможный дубликат, чтобы apply был идемпотентным
+            _run(["ip", family, "rule", "del", "to", cidr,
+                  "lookup", str(table)])
+
+            rc, _o, err = _run(["ip", family, "rule", "add", "to", cidr,
+                                "lookup", str(table),
+                                "priority", str(self.BASE_PRIORITY)])
+            if rc != 0:
+                errors.append("ip rule add to %s: %s" % (cidr, err.strip()))
+                continue
+            added.append({"family": family, "cidr": cidr, "table": table})
+
+        ok = bool(added) and not errors
+        log_msg = "routing: применено %d/%d CIDR для %s" % (
+            len(added), len(rule.cidrs), ifname)
+        if errors:
+            log.warning(log_msg + "; ошибки: " + "; ".join(errors),
+                        source="routing")
+        else:
+            log.info(log_msg, source="routing")
+
+        return {
+            "ok":     ok or (not added and not errors),
+            "added":  added,
+            "errors": errors,
+        }
+
+    def _remove_cidr(self, rule: CidrRoutingRule) -> dict:
+        ifname = rule.target_iface
+        table = table_id_for(ifname)
+        removed = []
+
+        for cidr, fam in rule.cidr_families():
+            if rule.ip_version != "auto" and fam != rule.ip_version:
+                continue
+            family = "-6" if fam == "v6" else "-4"
+            rc, _o, _e = _run(["ip", family, "rule", "del", "to", cidr,
+                               "lookup", str(table)])
+            if rc == 0:
+                removed.append({"family": family, "cidr": cidr})
+
+        log.info("routing: снят CIDR-rule %s (%d записей)" %
+                 (rule.id, len(removed)), source="routing")
+        return {"ok": True, "removed": removed}
+
+
+# ───────────────────────── singleton ─────────────────────────────────
+
+_manager = None
+_manager_lock = threading.Lock()
+
+
+def get_routing_manager() -> RoutingManager:
+    global _manager
+    if _manager is None:
+        with _manager_lock:
+            if _manager is None:
+                _manager = RoutingManager()
+    return _manager

--- a/core/routing/rules.py
+++ b/core/routing/rules.py
@@ -1,0 +1,230 @@
+# core/routing/rules.py
+"""
+Типы правил selective routing.
+
+Каждое правило знает свой тип, целевой интерфейс и параметры.
+Сериализуется в dict для хранения в settings.json.
+"""
+
+import ipaddress
+import re
+import time
+import uuid
+
+
+# Допустимые имена интерфейсов: то же ограничение, что и в awg_manager.
+_IFACE_NAME_RE = re.compile(r"^[A-Za-z0-9_.\-]{1,15}$")
+
+
+def _valid_iface_name(name: str) -> bool:
+    return bool(name) and bool(_IFACE_NAME_RE.match(name))
+
+
+def _detect_family(cidr: str) -> str:
+    """Вернуть 'v4' или 'v6' для CIDR-строки."""
+    try:
+        net = ipaddress.ip_network(cidr, strict=False)
+    except (ValueError, TypeError):
+        raise ValueError("Некорректный CIDR: %s" % cidr)
+    return "v6" if net.version == 6 else "v4"
+
+
+def _normalize_cidr(cidr: str) -> str:
+    """Нормализовать CIDR (lowercase, with_prefixlen)."""
+    s = (cidr or "").strip()
+    if not s:
+        raise ValueError("Пустой CIDR")
+    # Поддержим одиночный IP без маски — превращаем в /32 или /128
+    if "/" not in s:
+        try:
+            ip = ipaddress.ip_address(s)
+        except ValueError:
+            raise ValueError("Некорректный IP/CIDR: %s" % cidr)
+        return "%s/%d" % (str(ip), 32 if ip.version == 4 else 128)
+    try:
+        return str(ipaddress.ip_network(s, strict=False))
+    except ValueError:
+        raise ValueError("Некорректный CIDR: %s" % cidr)
+
+
+# ───────────────────────── base ──────────────────────────────────────
+
+class RoutingRule:
+    """Базовый класс правила. Не использовать напрямую."""
+
+    type_name = "base"
+
+    def __init__(self, target_iface: str = "", description: str = "",
+                 enabled: bool = True, rule_id: str = "",
+                 priority: int = 0, created_at: int = 0):
+        if not _valid_iface_name(target_iface):
+            raise ValueError("Имя целевого интерфейса некорректно")
+        self.id          = rule_id or self._make_id()
+        self.target_iface = target_iface
+        self.description  = (description or "").strip()
+        self.enabled      = bool(enabled)
+        self.priority     = int(priority) if priority else 0
+        self.created_at   = int(created_at) if created_at else int(time.time())
+
+    def _make_id(self) -> str:
+        return "%s-%s" % (self.type_name, uuid.uuid4().hex[:8])
+
+    def to_dict(self) -> dict:
+        return {
+            "id":           self.id,
+            "type":         self.type_name,
+            "target_iface": self.target_iface,
+            "description":  self.description,
+            "enabled":      self.enabled,
+            "priority":     self.priority,
+            "created_at":   self.created_at,
+        }
+
+    def __repr__(self):
+        return "<%s id=%s iface=%s>" % (self.__class__.__name__,
+                                        self.id, self.target_iface)
+
+
+# ───────────────────────── CIDR ──────────────────────────────────────
+
+class CidrRoutingRule(RoutingRule):
+    """
+    Маршрутизация по CIDR.
+
+    Все запросы к адресам из `cidrs` уходят через `target_iface`.
+    Если `ip_version` = "auto" — определяется по каждому CIDR.
+    """
+
+    type_name = "cidr"
+
+    def __init__(self, target_iface: str, cidrs=None, ip_version: str = "auto",
+                 **kwargs):
+        super().__init__(target_iface=target_iface, **kwargs)
+
+        raw = cidrs or []
+        if isinstance(raw, str):
+            raw = [raw]
+        norm = []
+        for c in raw:
+            if not str(c).strip():
+                continue
+            norm.append(_normalize_cidr(str(c)))
+        if not norm:
+            raise ValueError("Нужен хотя бы один CIDR")
+
+        if ip_version not in ("auto", "v4", "v6"):
+            raise ValueError("ip_version должен быть auto|v4|v6")
+
+        # Если зафиксирована версия — проверим, что все CIDR ей соответствуют
+        if ip_version != "auto":
+            for c in norm:
+                if _detect_family(c) != ip_version:
+                    raise ValueError(
+                        "CIDR %s не соответствует ip_version=%s" % (c, ip_version)
+                    )
+
+        self.cidrs       = norm
+        self.ip_version  = ip_version
+
+    def cidr_families(self):
+        """Список (cidr, 'v4'|'v6')."""
+        return [(c, _detect_family(c)) for c in self.cidrs]
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["cidrs"]      = list(self.cidrs)
+        d["ip_version"] = self.ip_version
+        return d
+
+
+# ───────────────────────── Domain (заглушка) ─────────────────────────
+
+class DomainRoutingRule(RoutingRule):
+    """
+    Маршрутизация по доменам через dnsmasq + ipset/nftset.
+    Полная реализация — в следующем промте.
+    """
+
+    type_name = "domain"
+
+    def __init__(self, target_iface: str, domains=None, **kwargs):
+        super().__init__(target_iface=target_iface, **kwargs)
+        self.domains = [str(d).strip() for d in (domains or []) if str(d).strip()]
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["domains"] = list(self.domains)
+        return d
+
+
+# ───────────────────────── Device (заглушка) ─────────────────────────
+
+class DeviceRoutingRule(RoutingRule):
+    """
+    Маршрутизация по устройству (per-device).
+    Полная реализация — в следующем промте.
+    """
+
+    type_name = "device"
+
+    def __init__(self, target_iface: str, source_ip: str = "",
+                 mac: str = "", hostname: str = "", **kwargs):
+        super().__init__(target_iface=target_iface, **kwargs)
+        self.source_ip = (source_ip or "").strip()
+        self.mac       = (mac or "").strip()
+        self.hostname  = (hostname or "").strip()
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["source_ip"] = self.source_ip
+        d["mac"]       = self.mac
+        d["hostname"]  = self.hostname
+        return d
+
+
+# ───────────────────────── factory ───────────────────────────────────
+
+_TYPE_REGISTRY = {
+    "cidr":   CidrRoutingRule,
+    "domain": DomainRoutingRule,
+    "device": DeviceRoutingRule,
+}
+
+
+def rule_from_dict(d: dict) -> RoutingRule:
+    """Десериализовать правило из dict."""
+    if not isinstance(d, dict):
+        raise ValueError("Правило должно быть объектом")
+    rtype = (d.get("type") or "").strip().lower()
+    cls = _TYPE_REGISTRY.get(rtype)
+    if cls is None:
+        raise ValueError("Неизвестный тип правила: %s" % rtype)
+
+    common = dict(
+        rule_id=d.get("id") or "",
+        target_iface=d.get("target_iface") or "",
+        description=d.get("description") or "",
+        enabled=bool(d.get("enabled", True)),
+        priority=int(d.get("priority") or 0),
+        created_at=int(d.get("created_at") or 0),
+    )
+
+    if cls is CidrRoutingRule:
+        return CidrRoutingRule(
+            cidrs=d.get("cidrs") or [],
+            ip_version=d.get("ip_version") or "auto",
+            **common,
+        )
+    if cls is DomainRoutingRule:
+        return DomainRoutingRule(
+            domains=d.get("domains") or [],
+            **common,
+        )
+    if cls is DeviceRoutingRule:
+        return DeviceRoutingRule(
+            source_ip=d.get("source_ip") or "",
+            mac=d.get("mac") or "",
+            hostname=d.get("hostname") or "",
+            **common,
+        )
+    raise ValueError("Неподдерживаемый тип: %s" % rtype)

--- a/core/routing/storage.py
+++ b/core/routing/storage.py
@@ -1,0 +1,90 @@
+# core/routing/storage.py
+"""
+Хранилище правил selective routing в settings.json.
+
+Структура в settings.json:
+    "routing": {
+        "rules": [ <rule.to_dict()>, ... ]
+    }
+"""
+
+import threading
+
+from core.config_manager import get_config_manager
+from core.routing.rules import RoutingRule, rule_from_dict
+
+
+_lock = threading.Lock()
+
+
+def _section() -> list:
+    """Получить копию списка правил из settings.json."""
+    cm = get_config_manager()
+    section = cm.get("routing") or {}
+    rules = section.get("rules") if isinstance(section, dict) else None
+    return list(rules) if isinstance(rules, list) else []
+
+
+def _save_section(rules_dicts: list):
+    cm = get_config_manager()
+    cur = cm.get("routing") or {}
+    if not isinstance(cur, dict):
+        cur = {}
+    cur["rules"] = list(rules_dicts)
+    cm.set("routing", cur)
+    cm.save()
+
+
+def load_rules() -> list:
+    """Загрузить все правила (десериализованные объекты RoutingRule)."""
+    out = []
+    for raw in _section():
+        try:
+            out.append(rule_from_dict(raw))
+        except (ValueError, TypeError):
+            # Битое правило — пропускаем, но не теряем; логировать здесь
+            # не будем, чтобы не тащить лог в storage.
+            continue
+    return out
+
+
+def save_rules(rules):
+    """Полностью перезаписать список правил."""
+    with _lock:
+        _save_section([r.to_dict() for r in rules])
+
+
+def add_rule(rule: RoutingRule):
+    """Добавить правило (если id уже есть — заменить)."""
+    with _lock:
+        existing = _section()
+        existing = [r for r in existing if r.get("id") != rule.id]
+        existing.append(rule.to_dict())
+        _save_section(existing)
+
+
+def remove_rule(rule_id: str) -> bool:
+    """Удалить правило по id. Возвращает True если что-то удалили."""
+    with _lock:
+        existing = _section()
+        new = [r for r in existing if r.get("id") != rule_id]
+        if len(new) == len(existing):
+            return False
+        _save_section(new)
+        return True
+
+
+def get_rule(rule_id: str):
+    """Получить одно правило по id."""
+    for raw in _section():
+        if raw.get("id") == rule_id:
+            try:
+                return rule_from_dict(raw)
+            except (ValueError, TypeError):
+                return None
+    return None
+
+
+def update_rule(rule: RoutingRule):
+    """Обновить существующее правило."""
+    add_rule(rule)

--- a/web/index.html
+++ b/web/index.html
@@ -87,6 +87,7 @@
     <script src="/js/pages/awg_dashboard.js"></script>
     <script src="/js/pages/awg_configs.js"></script>
     <script src="/js/pages/awg_warp.js"></script>
+    <script src="/js/pages/awg_routing.js"></script>
     <script src="/js/pages/settings.js"></script>
     <script src="/js/app.js"></script>
 </body>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -25,6 +25,7 @@ const App = (() => {
         awg:           AwgDashboardPage,
         'awg-configs': AwgConfigsPage,
         'awg-warp':    AwgWarpPage,
+        'awg-routing': AwgRoutingPage,
         'awg-setup':   AwgSetupPage,
         settings:    SettingsPage,
     };

--- a/web/js/components/sidebar.js
+++ b/web/js/components/sidebar.js
@@ -66,6 +66,7 @@ const Sidebar = (() => {
                 { id: 'awg',         label: 'AmneziaWG',  icon: 'awg' },
                 { id: 'awg-configs', label: 'Конфиги',    icon: 'lua' },
                 { id: 'awg-warp',    label: 'WARP',       icon: 'awg' },
+                { id: 'awg-routing', label: 'Routing',    icon: 'globe' },
                 { id: 'awg-setup',   label: 'Установка',  icon: 'settings' },
             ]
         },

--- a/web/js/pages/awg_routing.js
+++ b/web/js/pages/awg_routing.js
@@ -1,0 +1,370 @@
+/**
+ * awg_routing.js — Selective routing.
+ *
+ * Табы:
+ *   - По IP/CIDR  (реализовано)
+ *   - Домены      (заглушка — будет в следующем промте)
+ *   - Устройства  (заглушка — будет в следующем промте)
+ */
+
+const AwgRoutingPage = (() => {
+
+    let activeTab    = 'cidr';
+    let rules        = [];
+    let configs      = [];     // список AWG-конфигов
+    let environment  = null;   // отчёт детектора (для подсказок)
+    let busy         = false;
+
+    // Форма создания
+    let formIface    = '';
+    let formCidrs    = '';
+    let formIpVer    = 'auto';
+    let formDesc     = '';
+
+    // Фильтр списка
+    let filterIface  = '';
+
+    // ══════════════ render ══════════════
+
+    function render(container) {
+        container.innerHTML = `
+            <div class="page-header">
+                <div>
+                    <h1 class="page-title">Selective routing</h1>
+                    <p class="page-description">
+                        Какой трафик в какой туннель направлять.
+                    </p>
+                </div>
+                <div style="display:flex; gap:8px;">
+                    <button class="btn btn-ghost btn-sm" onclick="window.location.hash='awg'">
+                        ← Туннели
+                    </button>
+                    <button class="btn btn-ghost btn-sm"
+                            onclick="AwgRoutingPage.reapplyAll()">
+                        Переприменить все
+                    </button>
+                </div>
+            </div>
+
+            <div class="tabs-bar">
+                <button class="tab-btn ${activeTab === 'cidr' ? 'active' : ''}"
+                        onclick="AwgRoutingPage.switchTab('cidr')">
+                    По IP/CIDR
+                </button>
+                <button class="tab-btn ${activeTab === 'domain' ? 'active' : ''}"
+                        onclick="AwgRoutingPage.switchTab('domain')">
+                    Домены
+                </button>
+                <button class="tab-btn ${activeTab === 'device' ? 'active' : ''}"
+                        onclick="AwgRoutingPage.switchTab('device')">
+                    Устройства
+                </button>
+            </div>
+
+            <div class="card" style="border-top-left-radius:0; border-top-right-radius:0;">
+                <div id="awg-routing-tab-content">
+                    <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
+                </div>
+            </div>
+        `;
+
+        loadAll().then(renderTab);
+    }
+
+    function destroy() {}
+
+    // ══════════════ data ══════════════
+
+    async function loadAll() {
+        try {
+            const [rulesResp, cfgsResp, envResp] = await Promise.all([
+                API.get('/api/routing/rules'),
+                API.get('/api/awg/configs'),
+                API.get('/api/awg/environment').catch(() => null),
+            ]);
+            rules       = (rulesResp && rulesResp.rules)   || [];
+            configs     = (cfgsResp  && cfgsResp.configs)  || [];
+            environment = envResp || null;
+            if (!formIface && configs.length > 0) {
+                formIface = configs[0].name;
+            }
+        } catch (err) {
+            const box = document.getElementById('awg-routing-tab-content');
+            if (box) box.innerHTML = `<div class="text-muted">Ошибка: ${escapeHtml(err.message)}</div>`;
+        }
+    }
+
+    async function refresh() {
+        try {
+            const r = await API.get('/api/routing/rules');
+            rules = r.rules || [];
+            renderTab();
+        } catch (err) {
+            Toast.error(err.message);
+        }
+    }
+
+    // ══════════════ tabs ══════════════
+
+    function switchTab(tab) {
+        activeTab = tab;
+        document.querySelectorAll('.tabs-bar .tab-btn').forEach(btn => {
+            btn.classList.remove('active');
+        });
+        const map = { cidr: 0, domain: 1, device: 2 };
+        const btns = document.querySelectorAll('.tabs-bar .tab-btn');
+        if (btns[map[tab]]) btns[map[tab]].classList.add('active');
+        renderTab();
+    }
+
+    function renderTab() {
+        const box = document.getElementById('awg-routing-tab-content');
+        if (!box) return;
+        if (activeTab === 'cidr')   return renderCidrTab(box);
+        if (activeTab === 'domain') return renderPlaceholder(box, 'Домены',
+            'Маршрутизация по доменам через dnsmasq + ipset/nftset появится в следующей итерации.');
+        if (activeTab === 'device') return renderPlaceholder(box, 'Устройства',
+            'Per-device routing (по IP/MAC устройств LAN) появится в следующей итерации.');
+    }
+
+    function renderPlaceholder(box, title, desc) {
+        box.innerHTML = `
+            <h3 style="margin: 4px 0 12px 0;">${escapeHtml(title)}</h3>
+            <p class="text-muted">${escapeHtml(desc)}</p>
+        `;
+    }
+
+    // ══════════════ tab: CIDR ══════════════
+
+    function renderCidrTab(box) {
+        const cidrRules = rules.filter(r => r.type === 'cidr');
+        const visibleRules = filterIface
+            ? cidrRules.filter(r => r.target_iface === filterIface)
+            : cidrRules;
+
+        const ifacesInRules = Array.from(new Set(cidrRules.map(r => r.target_iface)));
+
+        const platformLine = environment && environment.platform
+            ? `<div class="text-muted" style="font-size:12px; margin-bottom:8px;">
+                    Платформа: <strong>${escapeHtml(environment.platform.name || '?')}</strong>,
+                    firewall: <strong>${escapeHtml((environment.platform.firewall_backend) || 'n/a')}</strong>
+               </div>`
+            : '';
+
+        const cfgOptions = configs.map(c =>
+            `<option value="${escapeAttr(c.name)}" ${c.name === formIface ? 'selected' : ''}>
+                ${escapeHtml(c.name)}${c.active ? ' (активен)' : ''}
+             </option>`
+        ).join('');
+
+        const filterOptions = ['<option value="">Все интерфейсы</option>'].concat(
+            ifacesInRules.map(i =>
+                `<option value="${escapeAttr(i)}" ${i === filterIface ? 'selected' : ''}>
+                    ${escapeHtml(i)}
+                 </option>`
+            )
+        ).join('');
+
+        box.innerHTML = `
+            ${platformLine}
+
+            <div class="card" style="margin-bottom: 12px;">
+                <div class="card-title">Добавить CIDR-правило</div>
+                ${configs.length === 0 ? `
+                    <p class="text-muted" style="margin-top: 8px;">
+                        Нет ни одного AWG-конфига. Сначала создайте туннель в разделе
+                        <a href="#awg-configs">Конфиги</a>.
+                    </p>
+                ` : `
+                    <div style="display: grid; grid-template-columns: 200px 1fr; gap: 8px 12px; margin-top: 8px; align-items: start;">
+                        <label class="text-muted" style="padding-top: 6px;">Интерфейс</label>
+                        <select id="rt-form-iface" onchange="AwgRoutingPage.setFormIface(this.value)"
+                                class="form-control" style="max-width: 280px;">
+                            ${cfgOptions}
+                        </select>
+
+                        <label class="text-muted" style="padding-top: 6px;">CIDR-список</label>
+                        <textarea id="rt-form-cidrs"
+                                  oninput="AwgRoutingPage.setFormCidrs(this.value)"
+                                  placeholder="По одному в строке или через запятую: 1.2.3.0/24, 10.0.0.0/8, ::/0"
+                                  rows="4"
+                                  style="font-family: monospace; width: 100%;">${escapeHtml(formCidrs)}</textarea>
+
+                        <label class="text-muted" style="padding-top: 6px;">IP-версия</label>
+                        <select id="rt-form-ipver" onchange="AwgRoutingPage.setFormIpVer(this.value)"
+                                class="form-control" style="max-width: 280px;">
+                            <option value="auto" ${formIpVer === 'auto' ? 'selected' : ''}>Авто</option>
+                            <option value="v4"   ${formIpVer === 'v4'   ? 'selected' : ''}>Только IPv4</option>
+                            <option value="v6"   ${formIpVer === 'v6'   ? 'selected' : ''}>Только IPv6</option>
+                        </select>
+
+                        <label class="text-muted" style="padding-top: 6px;">Описание</label>
+                        <input type="text" id="rt-form-desc"
+                               oninput="AwgRoutingPage.setFormDesc(this.value)"
+                               value="${escapeAttr(formDesc)}"
+                               placeholder="например: Telegram CIDR через WARP"
+                               class="form-control" style="max-width: 480px;">
+                    </div>
+                    <div style="margin-top: 12px;">
+                        <button class="btn btn-primary btn-sm" ${busy ? 'disabled' : ''}
+                                onclick="AwgRoutingPage.submitCidr()">
+                            Добавить правило
+                        </button>
+                    </div>
+                `}
+            </div>
+
+            <div class="card">
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <div class="card-title">CIDR-правила (${cidrRules.length})</div>
+                    <select onchange="AwgRoutingPage.setFilterIface(this.value)"
+                            class="form-control" style="max-width: 220px;">
+                        ${filterOptions}
+                    </select>
+                </div>
+
+                ${visibleRules.length === 0
+                    ? `<p class="text-muted" style="margin-top: 12px;">Правил пока нет.</p>`
+                    : `
+                <table class="table" style="margin-top: 8px;">
+                    <thead>
+                        <tr>
+                            <th style="width: 14%;">Интерфейс</th>
+                            <th>CIDR</th>
+                            <th style="width: 8%;">v</th>
+                            <th>Описание</th>
+                            <th style="width: 6%;"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${visibleRules.map(r => `
+                            <tr>
+                                <td><strong>${escapeHtml(r.target_iface)}</strong></td>
+                                <td style="font-family: monospace; font-size: 12px;">
+                                    ${(r.cidrs || []).map(c => escapeHtml(c)).join('<br>')}
+                                </td>
+                                <td>${escapeHtml(r.ip_version || 'auto')}</td>
+                                <td>${escapeHtml(r.description || '')}</td>
+                                <td style="text-align: right;">
+                                    <button class="btn btn-ghost btn-sm"
+                                            title="Удалить"
+                                            onclick="AwgRoutingPage.deleteRule('${escapeAttr(r.id)}')">
+                                        ✕
+                                    </button>
+                                </td>
+                            </tr>
+                        `).join('')}
+                    </tbody>
+                </table>`
+                }
+            </div>
+        `;
+    }
+
+    // ══════════════ form actions ══════════════
+
+    function setFormIface(v)  { formIface = v; }
+    function setFormCidrs(v)  { formCidrs = v; }
+    function setFormIpVer(v)  { formIpVer = v; }
+    function setFormDesc(v)   { formDesc  = v; }
+    function setFilterIface(v) { filterIface = v; renderTab(); }
+
+    function parseCidrs(text) {
+        return String(text || '')
+            .split(/[\s,;]+/)
+            .map(s => s.trim())
+            .filter(Boolean);
+    }
+
+    async function submitCidr() {
+        if (busy) return;
+        const cidrs = parseCidrs(formCidrs);
+        if (!formIface) {
+            Toast.error('Выберите интерфейс');
+            return;
+        }
+        if (cidrs.length === 0) {
+            Toast.error('Укажите хотя бы один CIDR');
+            return;
+        }
+
+        busy = true;
+        try {
+            const resp = await API.post('/api/routing/rules', {
+                type:         'cidr',
+                target_iface: formIface,
+                cidrs:        cidrs,
+                ip_version:   formIpVer,
+                description:  formDesc,
+                enabled:      true,
+            });
+            if (resp.ok) {
+                Toast.success('Правило добавлено');
+                if (resp.applied && resp.applied.deferred) {
+                    Toast.info('Интерфейс не поднят — правило применится при старте');
+                } else if (resp.applied && resp.applied.errors && resp.applied.errors.length) {
+                    Toast.error('Ошибки применения: ' + resp.applied.errors.join('; '));
+                }
+                formCidrs = '';
+                formDesc  = '';
+                await refresh();
+            } else {
+                Toast.error(resp.error || 'Ошибка добавления');
+            }
+        } catch (err) {
+            Toast.error(err.message);
+        } finally {
+            busy = false;
+        }
+    }
+
+    async function deleteRule(id) {
+        if (!confirm('Удалить правило?')) return;
+        try {
+            const r = await API.delete('/api/routing/rules/' + encodeURIComponent(id));
+            if (r.ok) {
+                Toast.success('Правило удалено');
+                await refresh();
+            } else {
+                Toast.error(r.error || 'Ошибка удаления');
+            }
+        } catch (err) {
+            Toast.error(err.message);
+        }
+    }
+
+    async function reapplyAll() {
+        try {
+            const r = await API.post('/api/routing/apply');
+            if (r.ok) {
+                Toast.success('Правила переприменены');
+                await refresh();
+            } else {
+                Toast.error(r.error || 'Ошибка');
+            }
+        } catch (err) {
+            Toast.error(err.message);
+        }
+    }
+
+    // ══════════════ helpers ══════════════
+
+    function escapeHtml(s) {
+        if (s === null || s === undefined) return '';
+        const div = document.createElement('div');
+        div.textContent = String(s);
+        return div.innerHTML;
+    }
+
+    function escapeAttr(s) {
+        return String(s || '').replace(/'/g, '&#39;').replace(/"/g, '&quot;');
+    }
+
+    return {
+        render, destroy,
+        switchTab,
+        setFormIface, setFormCidrs, setFormIpVer, setFormDesc,
+        setFilterIface,
+        submitCidr, deleteRule, reapplyAll,
+    };
+})();


### PR DESCRIPTION
## Summary
Implements a complete selective routing system that allows users to route traffic through specific AmneziaWG tunnels based on destination CIDR blocks. The system uses Linux `ip rule` and routing tables to ensure traffic matching configured CIDR ranges is directed through the appropriate tunnel interface.

## Key Changes

### Core Routing Engine
- **`core/routing/rules.py`**: Defines routing rule types (`CidrRoutingRule`, `DomainRoutingRule`, `DeviceRoutingRule`) with validation and serialization. Currently implements CIDR-based routing with placeholders for domain and device-based routing in future iterations.
- **`core/routing/manager.py`**: Orchestrates rule application using Linux `ip rule` and `ip route` commands. Implements idempotent rule application with automatic table ID generation based on interface names. Includes thread-safe CRUD operations and support for applying/removing rules on interface up/down events.
- **`core/routing/storage.py`**: Persists routing rules in `settings.json` under the `routing.rules` section with thread-safe access.
- **`core/routing/applier.py`**: Provides hooks for integration with interface lifecycle events (up/down) with safe error handling.

### API Layer
- **`api/routing.py`**: REST endpoints for managing routing rules:
  - `GET /api/routing/rules` - List all rules with optional interface filtering
  - `POST /api/routing/rules` - Create new rule
  - `GET/PUT/DELETE /api/routing/rules/<id>` - Manage individual rules
  - `POST /api/routing/apply` - Reapply all rules

### Frontend UI
- **`web/js/pages/awg_routing.js`**: Complete single-page application for selective routing management with:
  - Tabbed interface (CIDR, Domains, Devices) with CIDR tab fully implemented
  - Form for adding CIDR rules with interface selection, CIDR list input, IP version filtering, and descriptions
  - Rules table with filtering by interface and delete functionality
  - Platform detection display (shows detected firewall backend)
  - Reapply all rules button for manual synchronization

### Integration
- **`core/awg_manager.py`**: Hooks routing rule application when interfaces come up
- **`api/__init__.py`**: Registers routing API endpoints
- **`web/index.html`**: Includes routing page script
- **`web/js/app.js`**: Registers routing page in app router
- **`web/js/components/sidebar.js`**: Adds "Selective routing" menu item under AmneziaWG section

## Implementation Details

- **Table ID Generation**: Uses stable hash-based algorithm (`100 + hash(ifname) % 900`) matching the algorithm in `awg_manager.py` to ensure routing rules target the same tables as tunnel default routes
- **Idempotent Application**: Rules are removed before re-adding to prevent duplicates and ensure safe reapplication
- **CIDR Normalization**: Automatically converts single IPs to /32 or /128 and validates CIDR format
- **IP Version Filtering**: Supports auto-detection or explicit IPv4/IPv6-only filtering per rule
- **Error Handling**: Deferred application for interfaces not yet up, with user-friendly error messages
- **No New Dependencies**: Uses only subprocess and standard `ip(8)` command-line tool

## Future Work
Domain-based routing (via dnsmasq + ipset/nftset) and per-device routing are planned for subsequent iterations with placeholder UI tabs already in place.

https://claude.ai/code/session_01BEBfJJp8LrPyR4crJhJeEE