### PR TITLE
Implement per-device routing with LAN device discovery

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -25,6 +25,7 @@ def register_routes(app):
     from api.catalog_update import register as reg_catalog_update
     from api.awg import register as reg_awg
     from api.routing import register as reg_routing
+    from api.devices import register as reg_devices
 
     reg_status(app)
     reg_logs(app)
@@ -45,3 +46,4 @@ def register_routes(app):
     reg_catalog_update(app)
     reg_awg(app)
     reg_routing(app)
+    reg_devices(app)

--- a/api/devices.py
+++ b/api/devices.py
@@ -1,0 +1,36 @@
+# api/devices.py
+"""
+REST API для обнаружения устройств LAN.
+
+Маршруты:
+  GET /api/devices            — текущий список устройств
+                                  (DHCP-leases + ARP, merged)
+  GET /api/devices/sources    — диагностика источников
+"""
+
+from bottle import response
+
+
+def register(app):
+
+    @app.route("/api/devices")
+    def devices_list():
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            from core.devices_discovery import list_devices, sources_status
+            return {"ok": True,
+                    "devices": list_devices(),
+                    "sources": sources_status()}
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
+    @app.route("/api/devices/sources")
+    def devices_sources():
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            from core.devices_discovery import sources_status
+            return {"ok": True, "sources": sources_status()}
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}

--- a/core/devices_discovery.py
+++ b/core/devices_discovery.py
@@ -1,0 +1,229 @@
+# core/devices_discovery.py
+"""
+Обнаружение устройств в локальной сети для per-device routing.
+
+Источники данных (в порядке приоритета):
+  1. DHCP-leases dnsmasq:
+       /tmp/dhcp.leases           — Keenetic / OpenWrt / Entware
+       /var/lib/misc/dnsmasq.leases
+       /tmp/dnsmasq.leases
+       /opt/var/lib/misc/dnsmasq.leases
+  2. ARP-таблица: /proc/net/arp как fallback / дополнение
+
+Возвращает дедуплицированный список устройств:
+    {
+        "ip":         "192.168.1.42",
+        "mac":        "aa:bb:cc:dd:ee:ff",   # lowercase
+        "hostname":   "Galaxy-S21",
+        "source":     "leases" | "arp" | "leases+arp",
+        "expires_at": 1731234567 | 0,        # 0 если бессрочный/из ARP
+        "iface":      "br0" | ""             # только из ARP, опционально
+    }
+
+Никаких внешних команд, кроме чтения /proc и текстовых файлов —
+функция должна быть быстрой и устойчивой на любой платформе.
+"""
+
+import os
+import re
+
+
+# Кандидатные пути для dnsmasq leases.
+_LEASE_PATHS = (
+    "/tmp/dhcp.leases",
+    "/var/lib/misc/dnsmasq.leases",
+    "/tmp/dnsmasq.leases",
+    "/opt/var/lib/misc/dnsmasq.leases",
+    "/var/dhcp.leases",
+)
+
+# IPv4 в /proc/net/arp.
+_IPV4_RE = re.compile(r"^\d{1,3}(?:\.\d{1,3}){3}$")
+_MAC_RE  = re.compile(r"^([0-9a-f]{2}:){5}[0-9a-f]{2}$", re.IGNORECASE)
+
+
+# ───────────────────────── helpers ──────────────────────────────────
+
+def _normalize_mac(mac: str) -> str:
+    if not mac:
+        return ""
+    m = mac.strip().lower()
+    if not _MAC_RE.match(m):
+        return ""
+    return m
+
+
+def _is_valid_ip(ip: str) -> bool:
+    if not ip or not _IPV4_RE.match(ip):
+        return False
+    try:
+        return all(0 <= int(p) <= 255 for p in ip.split("."))
+    except ValueError:
+        return False
+
+
+def _read_file(path: str) -> str:
+    try:
+        with open(path, "r", errors="replace") as f:
+            return f.read()
+    except (OSError, IOError):
+        return ""
+
+
+# ───────────────────────── DHCP leases ──────────────────────────────
+
+def _parse_lease_line(line: str) -> dict:
+    """
+    Формат dnsmasq lease:
+        <expiry> <mac> <ip> <hostname|*> <client_id|*>
+
+    На некоторых платформах могут быть лишние поля — берём первые 4.
+    """
+    parts = line.split()
+    if len(parts) < 4:
+        return {}
+    try:
+        expires_at = int(parts[0])
+    except ValueError:
+        expires_at = 0
+    mac = _normalize_mac(parts[1])
+    ip  = parts[2].strip()
+    hostname = parts[3].strip()
+    if hostname == "*":
+        hostname = ""
+    if not mac or not _is_valid_ip(ip):
+        return {}
+    return {
+        "ip":         ip,
+        "mac":        mac,
+        "hostname":   hostname,
+        "source":     "leases",
+        "expires_at": expires_at,
+        "iface":      "",
+    }
+
+
+def _read_leases() -> list:
+    out = []
+    seen_ips = set()
+    for path in _LEASE_PATHS:
+        if not os.path.exists(path):
+            continue
+        text = _read_file(path)
+        if not text:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            d = _parse_lease_line(line)
+            if not d:
+                continue
+            if d["ip"] in seen_ips:
+                continue
+            seen_ips.add(d["ip"])
+            out.append(d)
+    return out
+
+
+# ───────────────────────── ARP ──────────────────────────────────────
+
+def _read_arp() -> list:
+    """
+    /proc/net/arp:
+        IP address       HW type     Flags       HW address            Mask     Device
+        192.168.1.42     0x1         0x2         aa:bb:cc:dd:ee:ff     *        br0
+    """
+    out = []
+    text = _read_file("/proc/net/arp")
+    if not text:
+        return out
+    lines = text.splitlines()
+    if len(lines) <= 1:
+        return out
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        ip    = parts[0].strip()
+        flags = parts[2].strip()
+        mac   = _normalize_mac(parts[3])
+        iface = parts[5].strip()
+        # Флаги 0x0 = incomplete, пропускаем.
+        if flags == "0x0":
+            continue
+        # MAC из нулей — невалидная запись.
+        if not mac or mac == "00:00:00:00:00:00":
+            continue
+        if not _is_valid_ip(ip):
+            continue
+        out.append({
+            "ip":         ip,
+            "mac":        mac,
+            "hostname":   "",
+            "source":     "arp",
+            "expires_at": 0,
+            "iface":      iface,
+        })
+    return out
+
+
+# ───────────────────────── public API ───────────────────────────────
+
+def list_devices() -> list:
+    """
+    Вернуть список всех видимых устройств LAN, сгруппированных по IP.
+    Записи из leases приоритетнее (hostname, expiry); из ARP добавляем
+    те, которых нет в leases.
+    """
+    leases = _read_leases()
+    arp    = _read_arp()
+
+    by_ip = {}
+    for d in leases:
+        by_ip[d["ip"]] = dict(d)
+
+    for d in arp:
+        if d["ip"] in by_ip:
+            cur = by_ip[d["ip"]]
+            # Дополним iface, если из leases он был пуст.
+            if not cur.get("iface"):
+                cur["iface"] = d.get("iface", "")
+            # Запомним, что устройство в данный момент онлайн (ARP видел).
+            cur["source"] = "leases+arp"
+            # MAC из leases считаем авторитетнее, но если был пуст —
+            # подменим из ARP.
+            if not cur.get("mac"):
+                cur["mac"] = d["mac"]
+        else:
+            by_ip[d["ip"]] = dict(d)
+
+    out = list(by_ip.values())
+    # Стабильная сортировка по IPv4 (числовая).
+    def _ip_key(rec):
+        try:
+            return tuple(int(p) for p in rec["ip"].split("."))
+        except ValueError:
+            return (999, 999, 999, 999)
+    out.sort(key=_ip_key)
+    return out
+
+
+def get_device_by_ip(ip: str) -> dict:
+    """Найти одно устройство по IP. Вернёт {} если нет."""
+    if not _is_valid_ip(ip):
+        return {}
+    for d in list_devices():
+        if d["ip"] == ip:
+            return d
+    return {}
+
+
+def sources_status() -> dict:
+    """Диагностика доступности источников (для UI)."""
+    leases_paths = [p for p in _LEASE_PATHS if os.path.exists(p)]
+    arp_ok = os.path.exists("/proc/net/arp")
+    return {
+        "leases_paths": leases_paths,
+        "arp_available": arp_ok,
+    }

--- a/core/routing/device_rule.py
+++ b/core/routing/device_rule.py
@@ -1,0 +1,178 @@
+# core/routing/device_rule.py
+"""
+Логика применения и снятия per-device routing-правил.
+
+Подход — source-IP based rule:
+    ip rule add from <source_ip>/32 lookup <table_for(iface)> priority N
+
+Универсально работает на любой платформе с iproute2 (Keenetic с
+OpkgTun, OpenWrt, обычный Linux), не требует iptables/nftables и
+не зависит от ipset/fwmark.
+
+При наличии iptables MARK на платформе и явном выборе пользователем
+маркировки (`use_fwmark=True` в самом правиле) — переключаемся на
+mangle PREROUTING + fwmark. Реализация fwmark-варианта оставлена
+на будущее (флаг учитывается, но в текущей версии используется
+только source-IP rule, т.к. он покрывает все целевые платформы).
+
+Идемпотентность: перед `ip rule add` всегда делаем `ip rule del`
+с теми же параметрами (best-effort) — повторное применение не
+плодит дубликатов.
+"""
+
+import ipaddress
+import threading
+
+from core.log_buffer import log
+from core.routing.rules import DeviceRoutingRule
+
+
+# Базовый приоритет для per-device правил. Выше CIDR (10000) и выше
+# fwmark domain-rule (10100) — устройство имеет приоритет: если
+# пользователь явно сказал «весь трафик с этого IP в туннель», это
+# должно перебить overlap по CIDR.
+DEVICE_PRIORITY = 10200
+
+
+_lock = threading.Lock()
+
+
+# ───────────────────────── helpers ──────────────────────────────────
+
+def _run(args, timeout=5):
+    import subprocess
+    try:
+        r = subprocess.run(args, capture_output=True, text=True,
+                           timeout=timeout)
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+    except subprocess.TimeoutExpired as e:
+        return 124, "", "timeout: %s" % e
+    except OSError as e:
+        return 1, "", str(e)
+
+
+def _iface_exists(ifname: str) -> bool:
+    rc, _o, _e = _run(["ip", "link", "show", "dev", ifname])
+    return rc == 0
+
+
+def _table_id_for(ifname: str) -> int:
+    """Тот же алгоритм, что и в manager.table_id_for / awg_manager."""
+    h = 0
+    for ch in ifname:
+        h = (h * 31 + ord(ch)) & 0xFFFFFFFF
+    return 100 + (h % 900)
+
+
+def _detect_family_and_normalize(ip: str):
+    """
+    Вернуть ('v4'|'v6', '<ip>/<prefix>') либо (None, None) если IP
+    некорректный.
+    """
+    s = (ip or "").strip()
+    if not s:
+        return None, None
+    # Может быть с маской или без.
+    try:
+        if "/" in s:
+            net = ipaddress.ip_network(s, strict=False)
+            fam = "v6" if net.version == 6 else "v4"
+            return fam, str(net)
+        addr = ipaddress.ip_address(s)
+        fam = "v6" if addr.version == 6 else "v4"
+        prefix = 128 if addr.version == 6 else 32
+        return fam, "%s/%d" % (str(addr), prefix)
+    except (ValueError, TypeError):
+        return None, None
+
+
+def _ensure_table_default(ifname: str, table: int, family: str) -> bool:
+    rc, out, _e = _run(["ip", family, "route", "show", "table", str(table),
+                        "default"])
+    if rc == 0 and out:
+        for line in out.splitlines():
+            parts = line.split()
+            if "dev" in parts:
+                i = parts.index("dev")
+                if i + 1 < len(parts) and parts[i + 1] == ifname:
+                    return True
+    rc, _o, err = _run(["ip", family, "route", "add", "default",
+                        "dev", ifname, "table", str(table)])
+    if rc == 0 or "File exists" in (err or ""):
+        return True
+    return False
+
+
+# ───────────────────────── public API ───────────────────────────────
+
+def apply_device_rule(rule: DeviceRoutingRule) -> dict:
+    """Применить одно device-правило."""
+    if not isinstance(rule, DeviceRoutingRule):
+        return {"ok": False, "error": "Не DeviceRoutingRule"}
+
+    fam, src = _detect_family_and_normalize(rule.source_ip)
+    if fam is None:
+        return {"ok": False,
+                "error": "Некорректный source_ip: %s" % rule.source_ip}
+
+    ifname = rule.target_iface
+    table = _table_id_for(ifname)
+
+    with _lock:
+        if not _iface_exists(ifname):
+            return {"ok": False, "deferred": True,
+                    "message": "Интерфейс %s ещё не поднят — правило"
+                               " будет применено при старте" % ifname}
+
+        family = "-6" if fam == "v6" else "-4"
+
+        if not _ensure_table_default(ifname, table, family):
+            return {"ok": False,
+                    "error": "default-route %s в table %d не создан"
+                             % (family, table)}
+
+        # Сначала чистим возможный дубликат, чтобы apply был идемпотентным
+        _run(["ip", family, "rule", "del", "from", src,
+              "lookup", str(table)])
+
+        rc, _o, err = _run(["ip", family, "rule", "add", "from", src,
+                            "lookup", str(table),
+                            "priority", str(DEVICE_PRIORITY)])
+        if rc != 0:
+            log.warning("routing: device-правило %s: ip rule add from %s: %s"
+                        % (rule.id, src, err.strip()),
+                        source="routing")
+            return {"ok": False,
+                    "error": "ip rule add from %s: %s" % (src, err.strip())}
+
+        log.info("routing: device-правило %s применено (src=%s → %s table %d)"
+                 % (rule.id, src, ifname, table),
+                 source="routing")
+
+        return {
+            "ok":     True,
+            "added":  [{"family": fam, "source": src, "table": table,
+                        "iface": ifname}],
+        }
+
+
+def remove_device_rule(rule: DeviceRoutingRule) -> dict:
+    """Снять одно device-правило (без удаления из storage)."""
+    if not isinstance(rule, DeviceRoutingRule):
+        return {"ok": False, "error": "Не DeviceRoutingRule"}
+
+    fam, src = _detect_family_and_normalize(rule.source_ip)
+    if fam is None:
+        return {"ok": True, "skipped": True}
+
+    family = "-6" if fam == "v6" else "-4"
+    table = _table_id_for(rule.target_iface)
+
+    with _lock:
+        rc, _o, _e = _run(["ip", family, "rule", "del", "from", src,
+                           "lookup", str(table)])
+        log.info("routing: device-правило %s снято (src=%s)"
+                 % (rule.id, src), source="routing")
+        return {"ok": True, "removed": (rc == 0)}

--- a/core/routing/manager.py
+++ b/core/routing/manager.py
@@ -164,8 +164,8 @@ class RoutingManager:
             from core.routing.domain_rule import apply_domain_rule
             return apply_domain_rule(rule)
         if isinstance(rule, DeviceRoutingRule):
-            return {"ok": False, "skipped": True,
-                    "message": "Device-правила появятся в следующем промте"}
+            from core.routing.device_rule import apply_device_rule
+            return apply_device_rule(rule)
         return {"ok": False, "error": "Неизвестный тип правила"}
 
     def _remove(self, rule: RoutingRule) -> dict:
@@ -174,6 +174,9 @@ class RoutingManager:
         if isinstance(rule, DomainRoutingRule):
             from core.routing.domain_rule import remove_domain_rule
             return remove_domain_rule(rule)
+        if isinstance(rule, DeviceRoutingRule):
+            from core.routing.device_rule import remove_device_rule
+            return remove_device_rule(rule)
         return {"ok": True, "skipped": True}
 
     # ─────────── apply ALL on iface up/down ───────────

--- a/web/js/pages/awg_routing.js
+++ b/web/js/pages/awg_routing.js
@@ -14,6 +14,8 @@ const AwgRoutingPage = (() => {
     let configs      = [];     // список AWG-конфигов
     let environment  = null;   // отчёт детектора (для подсказок)
     let dnsmasqInfo  = null;   // /api/routing/dnsmasq/status
+    let devices      = [];     // /api/devices (DHCP+ARP)
+    let devicesSrc   = null;   // sources status
     let busy         = false;
 
     // Форма создания (CIDR)
@@ -26,6 +28,13 @@ const AwgRoutingPage = (() => {
     let formDomIface = '';
     let formDomList  = '';
     let formDomDesc  = '';
+
+    // Форма создания (Device)
+    let formDevIface  = '';
+    let formDevManual = '';     // ручной ввод IP, если нет в списке
+    let formDevDesc   = '';
+    let devicesAutoRefresh = false;
+    let devicesAutoTimer   = null;
 
     // Фильтр списка
     let filterIface  = '';
@@ -77,7 +86,9 @@ const AwgRoutingPage = (() => {
         loadAll().then(renderTab);
     }
 
-    function destroy() {}
+    function destroy() {
+        stopDevicesAutoRefresh();
+    }
 
     // ══════════════ data ══════════════
 
@@ -98,6 +109,9 @@ const AwgRoutingPage = (() => {
             }
             if (!formDomIface && configs.length > 0) {
                 formDomIface = configs[0].name;
+            }
+            if (!formDevIface && configs.length > 0) {
+                formDevIface = configs[0].name;
             }
         } catch (err) {
             const box = document.getElementById('awg-routing-tab-content');
@@ -131,17 +145,11 @@ const AwgRoutingPage = (() => {
     function renderTab() {
         const box = document.getElementById('awg-routing-tab-content');
         if (!box) return;
+        // Останавливаем авто-обновление устройств при уходе со страницы.
+        if (activeTab !== 'device') stopDevicesAutoRefresh();
         if (activeTab === 'cidr')   return renderCidrTab(box);
         if (activeTab === 'domain') return renderDomainTab(box);
-        if (activeTab === 'device') return renderPlaceholder(box, 'Устройства',
-            'Per-device routing (по IP/MAC устройств LAN) появится в следующей итерации.');
-    }
-
-    function renderPlaceholder(box, title, desc) {
-        box.innerHTML = `
-            <h3 style="margin: 4px 0 12px 0;">${escapeHtml(title)}</h3>
-            <p class="text-muted">${escapeHtml(desc)}</p>
-        `;
+        if (activeTab === 'device') return renderDeviceTab(box);
     }
 
     // ══════════════ tab: CIDR ══════════════
@@ -413,6 +421,324 @@ const AwgRoutingPage = (() => {
         `;
     }
 
+    // ══════════════ tab: Devices ══════════════
+
+    async function loadDevices() {
+        try {
+            const r = await API.get('/api/devices');
+            if (r && r.ok) {
+                devices    = r.devices || [];
+                devicesSrc = r.sources || null;
+            } else {
+                devices    = [];
+                devicesSrc = null;
+            }
+        } catch (e) {
+            devices    = [];
+            devicesSrc = null;
+        }
+    }
+
+    function renderDeviceTab(box) {
+        const devRules = rules.filter(r => r.type === 'device');
+        const visibleRules = filterIface
+            ? devRules.filter(r => r.target_iface === filterIface)
+            : devRules;
+        const ifacesInRules = Array.from(new Set(devRules.map(r => r.target_iface)));
+
+        const cfgOptions = configs.map(c =>
+            `<option value="${escapeAttr(c.name)}" ${c.name === formDevIface ? 'selected' : ''}>
+                ${escapeHtml(c.name)}${c.active ? ' (активен)' : ''}
+             </option>`
+        ).join('');
+
+        const filterOptions = ['<option value="">Все интерфейсы</option>'].concat(
+            ifacesInRules.map(i =>
+                `<option value="${escapeAttr(i)}" ${i === filterIface ? 'selected' : ''}>
+                    ${escapeHtml(i)}
+                 </option>`
+            )
+        ).join('');
+
+        // Уже привязанные source IP → быстрый поиск.
+        const boundByIp = {};
+        devRules.forEach(r => {
+            const ip = (r.source_ip || '').split('/')[0];
+            if (ip) boundByIp[ip] = r;
+        });
+
+        const srcSummary = devicesSrc
+            ? `<div class="text-muted" style="font-size:12px; margin-bottom:8px;">
+                    Источники: leases — <strong>${(devicesSrc.leases_paths || []).length}</strong>,
+                    ARP — <strong>${devicesSrc.arp_available ? 'да' : 'нет'}</strong>
+               </div>`
+            : '';
+
+        // Запускаем первичную загрузку устройств, если ещё не делали.
+        if (devices.length === 0 && devicesSrc === null) {
+            loadDevices().then(() => renderTab());
+        }
+
+        box.innerHTML = `
+            ${srcSummary}
+
+            <div class="card" style="margin-bottom: 12px;">
+                <div style="display:flex; justify-content:space-between; align-items:center;">
+                    <div class="card-title">Привязать устройство к интерфейсу</div>
+                    <div style="display:flex; gap:6px; align-items:center;">
+                        <label class="text-muted" style="font-size:12px;">
+                            <input type="checkbox"
+                                   ${devicesAutoRefresh ? 'checked' : ''}
+                                   onchange="AwgRoutingPage.toggleDevicesAutoRefresh()">
+                            автообновление
+                        </label>
+                        <button class="btn btn-ghost btn-sm" onclick="AwgRoutingPage.refreshDevices()">
+                            Обновить список
+                        </button>
+                    </div>
+                </div>
+
+                ${configs.length === 0 ? `
+                    <p class="text-muted" style="margin-top: 8px;">
+                        Нет ни одного AWG-конфига. Сначала создайте туннель в разделе
+                        <a href="#awg-configs">Конфиги</a>.
+                    </p>
+                ` : `
+                    <p class="text-muted" style="margin-top: 6px; font-size: 13px;">
+                        Весь трафик с выбранного устройства уйдёт через интерфейс
+                        ниже. Используется
+                        <code>ip rule from &lt;ip&gt; lookup &lt;table&gt;</code>,
+                        работает на Keenetic/OpenWrt/Linux.
+                    </p>
+
+                    <div style="display: grid; grid-template-columns: 200px 1fr; gap: 8px 12px; margin-top: 8px; align-items: start;">
+                        <label class="text-muted" style="padding-top: 6px;">Интерфейс</label>
+                        <select id="rt-dev-iface" onchange="AwgRoutingPage.setFormDevIface(this.value)"
+                                class="form-control" style="max-width: 280px;">
+                            ${cfgOptions}
+                        </select>
+
+                        <label class="text-muted" style="padding-top: 6px;">Описание</label>
+                        <input type="text" id="rt-dev-desc"
+                               oninput="AwgRoutingPage.setFormDevDesc(this.value)"
+                               value="${escapeAttr(formDevDesc)}"
+                               placeholder="например: телефон жены через WARP"
+                               class="form-control" style="max-width: 480px;">
+                    </div>
+
+                    <div style="margin-top: 14px;">
+                        <div class="text-muted" style="font-size: 12px; margin-bottom: 6px;">
+                            Устройства из DHCP/ARP (${devices.length}):
+                        </div>
+                        ${devices.length === 0
+                            ? `<p class="text-muted" style="font-size: 13px;">
+                                Список пуст. Убедитесь, что сервис запущен на роутере,
+                                либо введите IP вручную ниже.
+                               </p>`
+                            : `
+                            <table class="table" style="margin-top: 4px;">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 14%;">IP</th>
+                                        <th style="width: 18%;">MAC</th>
+                                        <th>Имя</th>
+                                        <th style="width: 12%;">Источник</th>
+                                        <th style="width: 22%; text-align: right;"></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    ${devices.map(d => {
+                                        const bound = boundByIp[d.ip];
+                                        return `
+                                        <tr>
+                                            <td style="font-family: monospace; font-size: 12px;">${escapeHtml(d.ip)}</td>
+                                            <td style="font-family: monospace; font-size: 12px;">${escapeHtml(d.mac || '—')}</td>
+                                            <td>${escapeHtml(d.hostname || '')}</td>
+                                            <td><span class="text-muted" style="font-size: 11px;">${escapeHtml(d.source || '')}</span></td>
+                                            <td style="text-align: right;">
+                                                ${bound
+                                                    ? `<span class="text-muted" style="font-size: 12px; margin-right: 6px;">
+                                                            → <strong>${escapeHtml(bound.target_iface)}</strong>
+                                                       </span>
+                                                       <button class="btn btn-ghost btn-sm"
+                                                               onclick="AwgRoutingPage.deleteRule('${escapeAttr(bound.id)}')">
+                                                           Отвязать
+                                                       </button>`
+                                                    : `<button class="btn btn-primary btn-sm" ${busy ? 'disabled' : ''}
+                                                               onclick="AwgRoutingPage.bindDeviceFromList('${escapeAttr(d.ip)}', '${escapeAttr(d.mac || '')}', '${escapeAttr(d.hostname || '')}')">
+                                                           Через ${escapeHtml(formDevIface || '?')}
+                                                       </button>`
+                                                }
+                                            </td>
+                                        </tr>`;
+                                    }).join('')}
+                                </tbody>
+                            </table>`
+                        }
+                    </div>
+
+                    <div style="margin-top: 16px;">
+                        <div class="text-muted" style="font-size: 12px; margin-bottom: 6px;">
+                            Или вручную (если устройства нет в списке выше):
+                        </div>
+                        <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
+                            <input type="text" id="rt-dev-manual"
+                                   oninput="AwgRoutingPage.setFormDevManual(this.value)"
+                                   value="${escapeAttr(formDevManual)}"
+                                   placeholder="например: 192.168.1.50"
+                                   class="form-control" style="max-width: 240px;">
+                            <button class="btn btn-primary btn-sm" ${busy ? 'disabled' : ''}
+                                    onclick="AwgRoutingPage.submitDeviceManual()">
+                                Добавить
+                            </button>
+                        </div>
+                    </div>
+                `}
+            </div>
+
+            <div class="card">
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <div class="card-title">Device-правила (${devRules.length})</div>
+                    <select onchange="AwgRoutingPage.setFilterIface(this.value)"
+                            class="form-control" style="max-width: 220px;">
+                        ${filterOptions}
+                    </select>
+                </div>
+
+                ${visibleRules.length === 0
+                    ? `<p class="text-muted" style="margin-top: 12px;">Правил пока нет.</p>`
+                    : `
+                <table class="table" style="margin-top: 8px;">
+                    <thead>
+                        <tr>
+                            <th style="width: 14%;">Интерфейс</th>
+                            <th style="width: 18%;">IP</th>
+                            <th style="width: 18%;">MAC</th>
+                            <th>Hostname / описание</th>
+                            <th style="width: 6%;"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${visibleRules.map(r => `
+                            <tr>
+                                <td><strong>${escapeHtml(r.target_iface)}</strong></td>
+                                <td style="font-family: monospace; font-size: 12px;">${escapeHtml(r.source_ip || '')}</td>
+                                <td style="font-family: monospace; font-size: 12px;">${escapeHtml(r.mac || '—')}</td>
+                                <td>
+                                    ${r.hostname ? `<strong>${escapeHtml(r.hostname)}</strong>` : ''}
+                                    ${r.description ? `<div class="text-muted" style="font-size: 12px;">${escapeHtml(r.description)}</div>` : ''}
+                                </td>
+                                <td style="text-align: right;">
+                                    <button class="btn btn-ghost btn-sm"
+                                            title="Удалить"
+                                            onclick="AwgRoutingPage.deleteRule('${escapeAttr(r.id)}')">
+                                        ✕
+                                    </button>
+                                </td>
+                            </tr>
+                        `).join('')}
+                    </tbody>
+                </table>`
+                }
+            </div>
+        `;
+    }
+
+    async function refreshDevices() {
+        await loadDevices();
+        renderTab();
+    }
+
+    function toggleDevicesAutoRefresh() {
+        devicesAutoRefresh = !devicesAutoRefresh;
+        if (devicesAutoRefresh) {
+            startDevicesAutoRefresh();
+        } else {
+            stopDevicesAutoRefresh();
+        }
+        renderTab();
+    }
+
+    function startDevicesAutoRefresh() {
+        stopDevicesAutoRefresh();
+        devicesAutoTimer = setInterval(async () => {
+            if (activeTab !== 'device') {
+                stopDevicesAutoRefresh();
+                return;
+            }
+            await loadDevices();
+            // Также подтянем правила, на случай если их меняли.
+            try {
+                const r = await API.get('/api/routing/rules');
+                rules = r.rules || [];
+            } catch (e) { /* ignore */ }
+            renderTab();
+        }, 10000);
+    }
+
+    function stopDevicesAutoRefresh() {
+        if (devicesAutoTimer) {
+            clearInterval(devicesAutoTimer);
+            devicesAutoTimer = null;
+        }
+    }
+
+    async function bindDeviceFromList(ip, mac, hostname) {
+        if (busy) return;
+        if (!formDevIface) {
+            Toast.error('Выберите интерфейс');
+            return;
+        }
+        await submitDevice({ source_ip: ip, mac: mac, hostname: hostname });
+    }
+
+    async function submitDeviceManual() {
+        if (busy) return;
+        const ip = (formDevManual || '').trim();
+        if (!ip) {
+            Toast.error('Введите IP устройства');
+            return;
+        }
+        await submitDevice({ source_ip: ip });
+    }
+
+    async function submitDevice({ source_ip, mac = '', hostname = '' }) {
+        if (busy) return;
+        if (!formDevIface) {
+            Toast.error('Выберите интерфейс');
+            return;
+        }
+        busy = true;
+        try {
+            const resp = await API.post('/api/routing/rules', {
+                type:         'device',
+                target_iface: formDevIface,
+                source_ip:    source_ip,
+                mac:          mac,
+                hostname:     hostname,
+                description:  formDevDesc,
+                enabled:      true,
+            });
+            if (resp.ok) {
+                Toast.success('Устройство привязано');
+                if (resp.applied && resp.applied.deferred) {
+                    Toast.info('Интерфейс не поднят — правило применится при старте');
+                } else if (resp.applied && resp.applied.error) {
+                    Toast.error('Ошибка применения: ' + resp.applied.error);
+                }
+                formDevManual = '';
+                formDevDesc   = '';
+                await refresh();
+            } else {
+                Toast.error(resp.error || 'Ошибка добавления');
+            }
+        } catch (err) {
+            Toast.error(err.message);
+        } finally {
+            busy = false;
+        }
+    }
+
     function parseDomains(text) {
         return String(text || '')
             .split(/[\s,;]+/)
@@ -471,6 +797,10 @@ const AwgRoutingPage = (() => {
     function setFormDomIface(v) { formDomIface = v; }
     function setFormDomList(v)  { formDomList  = v; }
     function setFormDomDesc(v)  { formDomDesc  = v; }
+
+    function setFormDevIface(v)  { formDevIface  = v; renderTab(); }
+    function setFormDevManual(v) { formDevManual = v; }
+    function setFormDevDesc(v)   { formDevDesc   = v; }
 
     function parseCidrs(text) {
         return String(text || '')
@@ -570,5 +900,8 @@ const AwgRoutingPage = (() => {
         setFilterIface,
         submitCidr, deleteRule, reapplyAll,
         setFormDomIface, setFormDomList, setFormDomDesc, submitDomain,
+        setFormDevIface, setFormDevManual, setFormDevDesc,
+        bindDeviceFromList, submitDeviceManual,
+        refreshDevices, toggleDevicesAutoRefresh,
     };
 })();


### PR DESCRIPTION
## Summary
This PR implements the device-based routing feature for AWG, allowing users to route traffic from specific LAN devices through selected WireGuard interfaces. It includes device discovery from DHCP leases and ARP tables, a new UI tab for managing device rules, and the backend logic to apply source-IP based routing rules.

## Key Changes

### Frontend (web/js/pages/awg_routing.js)
- Added new "Device" tab to the AWG routing page, replacing the placeholder
- Implemented device discovery UI with:
  - Auto-refresh capability (10-second interval) with toggle checkbox
  - Manual device list from DHCP leases and ARP tables
  - Manual IP entry for devices not in the list
  - Device-to-interface binding with description support
- Added form state management for device rules (`formDevIface`, `formDevManual`, `formDevDesc`)
- Implemented device rule display table with bind/unbind actions
- Added lifecycle management: auto-refresh stops when leaving the device tab

### Backend - Device Discovery (core/devices_discovery.py)
- New module for LAN device enumeration from multiple sources:
  - DHCP leases: `/tmp/dhcp.leases`, `/var/lib/misc/dnsmasq.leases`, etc.
  - ARP table: `/proc/net/arp` as fallback/supplement
- Deduplication and merging logic: leases take priority, ARP fills gaps
- Returns normalized device records with IP, MAC, hostname, source, and expiry info
- Includes source status diagnostics for UI feedback
- Pure Python implementation (no external commands) for speed and reliability

### Backend - Device Rule Application (core/routing/device_rule.py)
- Implements source-IP based routing using `ip rule add from <ip> lookup <table>`
- Automatic table ID generation per interface
- Idempotent rule application (deletes before adding to prevent duplicates)
- Validates interface existence and creates default routes in routing tables
- Supports both IPv4 and IPv6
- Thread-safe with locking for concurrent operations
- Deferred application support for interfaces not yet up

### API Endpoints (api/devices.py)
- `GET /api/devices` — returns merged device list with source metadata
- `GET /api/devices/sources` — diagnostic info about available data sources

### Routing Manager Integration (core/routing/manager.py)
- Updated to call `apply_device_rule()` and `remove_device_rule()` for device-type rules
- Proper error handling and status reporting

### API Registration (api/__init__.py)
- Registered new devices API module

## Implementation Details

- **Device deduplication**: Entries are grouped by IP; DHCP leases provide authoritative hostname and expiry, ARP provides online status and interface info
- **Routing priority**: Device rules use priority 10200, higher than CIDR (10000) and domain rules (10100), ensuring explicit device routing takes precedence
- **Idempotency**: All rule operations are safe to repeat; duplicate rules are cleaned up before adding
- **Platform compatibility**: Works on Keenetic (with OpkgTun), OpenWrt, and standard Linux with iproute2
- **UI responsiveness**: Auto-refresh can be toggled; stops automatically when user navigates away from the device tab

https://claude.ai/code/session_016B2cuXzfCm1yXvRWVLfKfv