### PR TITLE
Add AWG autostart manager with init script support

### DIFF
--- a/api/awg.py
+++ b/api/awg.py
@@ -34,6 +34,14 @@ REST API для интеграции amneziawg-go.
   GET    /api/awg/warp-in-warp          — статус WARP-in-WARP
   POST   /api/awg/warp-in-warp          — поднять (body: outer, inner)
   DELETE /api/awg/warp-in-warp          — отключить
+
+  GET    /api/awg/autostart             — статус автозапуска
+  POST   /api/awg/autostart/install     — установить init-скрипт
+  POST   /api/awg/autostart/remove      — удалить init-скрипт
+  POST   /api/awg/autostart/regenerate  — пересоздать init-скрипт
+  POST   /api/awg/autostart/<name>      — установить флаг autostart
+                                           (body: {"enabled": true|false})
+  POST   /api/awg/autostart/apply       — применить (поднять enabled) сейчас
 """
 
 import threading
@@ -454,6 +462,71 @@ def register(app):
         if not result.get("ok"):
             response.status = 500
         return result
+
+    # ─────────── Autostart ─────────────────────────────────────
+
+    @app.route("/api/awg/autostart")
+    def awg_autostart_status():
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_autostart_manager import get_awg_autostart_manager
+        am = get_awg_autostart_manager()
+        return {"ok": True, "status": am.get_status()}
+
+    @app.route("/api/awg/autostart/install", method="POST")
+    def awg_autostart_install():
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_autostart_manager import get_awg_autostart_manager
+        result = get_awg_autostart_manager().install_script()
+        if not result.get("ok"):
+            response.status = 500
+        return result
+
+    @app.route("/api/awg/autostart/remove", method="POST")
+    def awg_autostart_remove():
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_autostart_manager import get_awg_autostart_manager
+        result = get_awg_autostart_manager().remove_script()
+        if not result.get("ok"):
+            response.status = 500
+        return result
+
+    @app.route("/api/awg/autostart/regenerate", method="POST")
+    def awg_autostart_regenerate():
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_autostart_manager import get_awg_autostart_manager
+        result = get_awg_autostart_manager().regenerate()
+        if not result.get("ok"):
+            response.status = 500
+        return result
+
+    @app.route("/api/awg/autostart/apply", method="POST")
+    def awg_autostart_apply():
+        """Поднять enabled-интерфейсы прямо сейчас."""
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_autostart_manager import get_awg_autostart_manager
+        result = get_awg_autostart_manager().apply_autostart()
+        if not result.get("ok"):
+            response.status = 500
+        return result
+
+    @app.route("/api/awg/autostart/<name>", method="POST")
+    def awg_autostart_set(name):
+        """Установить флаг autostart для конкретного конфига."""
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_autostart_manager import get_awg_autostart_manager
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        enabled = bool(body.get("enabled"))
+        try:
+            return get_awg_autostart_manager().set_enabled(name, enabled)
+        except ValueError as e:
+            response.status = 400
+            return {"ok": False, "error": str(e)}
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
 
     @app.route("/api/awg/keypair", method="POST")
     def awg_keypair():

--- a/app.py
+++ b/app.py
@@ -183,6 +183,97 @@ def _apply_saved_strategy_on_boot():
     t.start()
 
 
+def _apply_awg_autostart_on_boot():
+    """
+    Поднять AWG-интерфейсы при старте GUI, если:
+      * есть enabled-конфиги в settings.json
+      * и отдельный init-скрипт НЕ установлен (иначе он делает это сам,
+        и нам не надо дублировать).
+
+    Запускается в фоновом потоке.
+    """
+    import threading
+    import time
+
+    def _do_apply():
+        try:
+            time.sleep(1.2)
+
+            from core.config_manager import get_config_manager
+            from core.awg_autostart_manager import get_awg_autostart_manager
+            from core.log_buffer import log
+
+            am = get_awg_autostart_manager()
+            enabled = am.get_enabled_interfaces()
+            if not enabled:
+                return
+
+            # Если init-скрипт установлен — он сам поднимает интерфейсы
+            # при старте системы. Не дублируем.
+            status = am.get_status()
+            if status.get("script_installed"):
+                log.info(
+                    "AWG init-скрипт установлен — автозапуск AWG выполняется им",
+                    source="awg_autostart",
+                )
+                return
+
+            log.info("Автоподъём AWG-интерфейсов при старте GUI: %s"
+                     % ", ".join(enabled), source="awg_autostart")
+            am.apply_autostart()
+        except Exception as e:
+            try:
+                from core.log_buffer import log
+                log.error("Ошибка автозапуска AWG: %s" % e,
+                          source="awg_autostart")
+            except Exception:
+                pass
+
+    t = threading.Thread(target=_do_apply, daemon=True, name="awg-autostart-boot")
+    t.start()
+
+
+def _run_awg_autostart_cli(args, stop: bool = False):
+    """
+    CLI-режим автозапуска AmneziaWG: вызывается init-скриптом.
+    Инициализирует только ядро (без Bottle), выполняет apply/stop и выходит.
+    """
+    from core.config_manager import init_config
+    from core.log_buffer import log
+
+    init_config(args.config)
+
+    try:
+        from core.awg_autostart_manager import get_awg_autostart_manager
+        am = get_awg_autostart_manager()
+        if stop:
+            result = am.stop_autostart()
+        else:
+            result = am.apply_autostart()
+        ok = result.get("ok", False)
+        if ok:
+            log.success(
+                "CLI awg %s: ok" % ("stop" if stop else "apply"),
+                source="awg_autostart",
+            )
+        else:
+            log.error(
+                "CLI awg %s: %s" % (
+                    "stop" if stop else "apply",
+                    result.get("error") or "часть операций завершилась с ошибкой",
+                ),
+                source="awg_autostart",
+            )
+        sys.exit(0 if ok else 1)
+    except Exception as e:
+        try:
+            from core.log_buffer import log
+            log.error("CLI awg autostart: %s" % e, source="awg_autostart")
+        except Exception:
+            pass
+        sys.exit(2)
+
+
 def create_app(config_dir: str = None) -> Bottle:
     """
     Создать и настроить Bottle-приложение.
@@ -276,6 +367,10 @@ def create_app(config_dir: str = None) -> Bottle:
     # (для платформ без отдельного nfqws2-init: Ubuntu/systemd и пр.)
     _apply_saved_strategy_on_boot()
 
+    # Автоподъём AWG-интерфейсов при старте GUI (если init-скрипт не
+    # установлен — иначе он сам справится при загрузке системы).
+    _apply_awg_autostart_on_boot()
+
     return app
 
 
@@ -300,8 +395,22 @@ def main():
         "--debug", action="store_true",
         help="Режим отладки"
     )
+    parser.add_argument(
+        "--apply-awg-autostart", action="store_true",
+        help="CLI-режим: поднять все enabled-AWG-интерфейсы "
+             "(вызывается init-скриптом при загрузке) и выйти"
+    )
+    parser.add_argument(
+        "--stop-awg-autostart", action="store_true",
+        help="CLI-режим: опустить все поднятые AWG-интерфейсы и выйти"
+    )
 
     args = parser.parse_args()
+
+    # CLI-режимы (не запускаем web-сервер)
+    if args.apply_awg_autostart or args.stop_awg_autostart:
+        _run_awg_autostart_cli(args, stop=args.stop_awg_autostart)
+        return
 
     # Создаём приложение
     app = create_app(config_dir=args.config)

--- a/core/awg_autostart_manager.py
+++ b/core/awg_autostart_manager.py
@@ -1,0 +1,289 @@
+# core/awg_autostart_manager.py
+"""
+Менеджер автозапуска AmneziaWG-интерфейсов и привязанных routing-правил.
+
+Что обеспечивает:
+  * per-config флаг autostart хранится в settings.json
+      config["awg"]["autostart"]["interfaces"][<name>] = bool
+  * глобальная установка init-скрипта (Entware / OpenWrt procd / systemd)
+    через AwgPlatform.install_init_script(). Скрипт вызывает CLI-режим
+    app.py — `python3 app.py --apply-awg-autostart` (и --stop-awg-autostart).
+  * сам CLI-режим: поднимает enabled-интерфейсы, применяет routing-правила
+    (apply_all_for_iface вызывается AwgManager._do_up автоматически),
+    восстанавливает WARP-in-WARP, если был активен.
+
+Порядок при старте системы:
+    1. init-скрипт стартует после сети
+    2. → python3 app.py --apply-awg-autostart
+    3. → для каждого enabled-конфига AwgManager.up(name)
+       (внутри up: routing.apply_all_for_iface — это и есть «сначала intf,
+       потом routing»)
+    4. → если был активен WARP-in-WARP — wiw.setup(outer, inner)
+"""
+
+import os
+import sys
+import threading
+
+from core.log_buffer import log
+
+
+APP_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_PY = os.path.join(APP_DIR, "app.py")
+
+
+# ───────────────────────── singleton ─────────────────────────────────
+
+_instance = None
+_instance_lock = threading.Lock()
+
+
+def get_awg_autostart_manager():
+    global _instance
+    if _instance is None:
+        with _instance_lock:
+            if _instance is None:
+                _instance = AwgAutostartManager()
+    return _instance
+
+
+# ───────────────────────── manager ───────────────────────────────────
+
+class AwgAutostartManager:
+
+    def __init__(self):
+        self._lock = threading.Lock()
+
+    # ─────────── settings.json helpers ───────────
+
+    def _section(self) -> dict:
+        from core.config_manager import get_config_manager
+        cm = get_config_manager()
+        sec = cm.get("awg", "autostart") or {}
+        if not isinstance(sec, dict):
+            sec = {}
+        sec.setdefault("interfaces", {})
+        sec.setdefault("enabled", False)
+        return sec
+
+    def _save_section(self, sec: dict):
+        from core.config_manager import get_config_manager
+        cm = get_config_manager()
+        cm.set("awg", "autostart", sec)
+        cm.save()
+
+    # ─────────── per-config flag ───────────
+
+    def is_enabled(self, name: str) -> bool:
+        return bool(self._section().get("interfaces", {}).get(name))
+
+    def set_enabled(self, name: str, value: bool) -> dict:
+        with self._lock:
+            sec = self._section()
+            ifaces = dict(sec.get("interfaces", {}))
+            if value:
+                ifaces[name] = True
+            else:
+                ifaces.pop(name, None)
+            sec["interfaces"] = ifaces
+            self._save_section(sec)
+
+            # Если включили хоть один интерфейс — и глобальный init.d
+            # ещё не установлен — пробуем поставить.
+            if value and not self._is_script_installed():
+                try:
+                    self._install_script_locked()
+                except Exception as e:
+                    log.warning("Не удалось установить awg autostart-скрипт: %s"
+                                % e, source="awg_autostart")
+
+            # Если выключили все — снимаем init.d (опционально).
+            if not value and not any(ifaces.values()):
+                if self._is_script_installed():
+                    try:
+                        self._remove_script_locked()
+                    except Exception as e:
+                        log.warning("Не удалось снять awg autostart-скрипт: %s"
+                                    % e, source="awg_autostart")
+
+        log.info("AWG autostart для %s → %s" % (name, "ON" if value else "OFF"),
+                 source="awg_autostart")
+        return {"ok": True, "name": name, "enabled": bool(value)}
+
+    def get_enabled_interfaces(self) -> list:
+        ifaces = self._section().get("interfaces", {})
+        return sorted([n for n, v in ifaces.items() if v])
+
+    # ─────────── init-script ───────────
+
+    def _platform(self):
+        from core.awg_detector import get_awg_detector
+        return get_awg_detector().detect_platform()
+
+    def _is_script_installed(self) -> bool:
+        try:
+            p = self._platform().init_script_path()
+            return os.path.isfile(p)
+        except Exception:
+            return False
+
+    def install_script(self) -> dict:
+        with self._lock:
+            try:
+                path = self._install_script_locked()
+                return {"ok": True, "path": path,
+                        "message": "Скрипт автозапуска установлен"}
+            except Exception as e:
+                return {"ok": False, "error": str(e)}
+
+    def remove_script(self) -> dict:
+        with self._lock:
+            try:
+                self._remove_script_locked()
+                return {"ok": True, "message": "Скрипт автозапуска удалён"}
+            except Exception as e:
+                return {"ok": False, "error": str(e)}
+
+    def _install_script_locked(self) -> str:
+        from core.awg_init_script import install_init_script
+        platform = self._platform()
+        path = install_init_script(platform, python_bin=_python_bin(),
+                                   app_py=APP_PY)
+        log.info("AWG autostart-скрипт записан: %s" % path,
+                 source="awg_autostart")
+        return path
+
+    def _remove_script_locked(self):
+        platform = self._platform()
+        platform.remove_init_script()
+        log.info("AWG autostart-скрипт удалён", source="awg_autostart")
+
+    def regenerate(self) -> dict:
+        """Пересоздать скрипт (если установлен)."""
+        with self._lock:
+            if not self._is_script_installed():
+                return {"ok": True, "message": "Скрипт не установлен — пропуск"}
+            try:
+                path = self._install_script_locked()
+                return {"ok": True, "path": path,
+                        "message": "Скрипт автозапуска пересоздан"}
+            except Exception as e:
+                return {"ok": False, "error": str(e)}
+
+    # ─────────── status ───────────
+
+    def get_status(self) -> dict:
+        sec = self._section()
+        platform = self._platform()
+        try:
+            script_path = platform.init_script_path()
+        except Exception:
+            script_path = ""
+        return {
+            "platform":         platform.name,
+            "script_path":      script_path,
+            "script_installed": self._is_script_installed(),
+            "interfaces":       sec.get("interfaces", {}),
+            "enabled_count":    sum(1 for v in sec.get("interfaces", {}).values() if v),
+        }
+
+    # ─────────── CLI: apply / stop ───────────
+
+    def apply_autostart(self) -> dict:
+        """
+        Поднять все enabled-интерфейсы и восстановить WARP-in-WARP.
+        Вызывается init-скриптом (через `app.py --apply-awg-autostart`)
+        и при старте GUI (см. _apply_awg_autostart_on_boot в app.py).
+
+        Routing-правила применяются автоматически внутри AwgManager.up()
+        через apply_all_for_iface — это гарантирует, что сначала интерфейс
+        поднимается, и только потом к нему привязываются правила.
+        """
+        from core.awg_manager import get_awg_manager
+        mgr = get_awg_manager()
+
+        results = []
+        enabled = self.get_enabled_interfaces()
+
+        # Существующие конфиги — некоторые могли быть удалены
+        existing = {c["name"] for c in mgr.list_configs()}
+
+        for name in enabled:
+            if name not in existing:
+                log.warning("AWG autostart: конфиг %s отсутствует, пропуск" % name,
+                            source="awg_autostart")
+                results.append({"name": name, "ok": False,
+                                "message": "Конфиг не найден"})
+                continue
+            if mgr.is_running(name):
+                results.append({"name": name, "ok": True,
+                                "message": "Уже поднят", "already_up": True})
+                continue
+            log.info("AWG autostart: поднимаем %s" % name,
+                     source="awg_autostart")
+            r = mgr.up(name)
+            results.append({"name": name, **r})
+
+        # WARP-in-WARP — восстанавливаем, если был активен
+        wiw_result = self._restore_warp_in_warp()
+        if wiw_result is not None:
+            results.append({"warp_in_warp": wiw_result})
+
+        ok = all(r.get("ok", True) for r in results) if results else True
+        log.success("AWG autostart применён (%d интерфейсов)" % len(enabled),
+                    source="awg_autostart")
+        return {"ok": ok, "results": results, "applied": enabled}
+
+    def stop_autostart(self) -> dict:
+        """Опустить все enabled-интерфейсы (используется init-скриптом stop)."""
+        from core.awg_manager import get_awg_manager
+        mgr = get_awg_manager()
+
+        results = []
+        # Снимаем WARP-in-WARP в первую очередь
+        try:
+            from core.awg_warp_in_warp import status as wiw_status, teardown as wiw_teardown
+            st = wiw_status()
+            if st.get("active"):
+                results.append({"warp_in_warp": wiw_teardown()})
+        except Exception as e:
+            log.warning("teardown WiW: %s" % e, source="awg_autostart")
+
+        # Опускаем enabled-интерфейсы (или все поднятые — для надёжности)
+        targets = set(self.get_enabled_interfaces())
+        for i in mgr.list_interfaces():
+            targets.add(i["name"])
+
+        for name in sorted(targets):
+            try:
+                r = mgr.down(name)
+                results.append({"name": name, **r})
+            except Exception as e:
+                results.append({"name": name, "ok": False, "error": str(e)})
+
+        return {"ok": True, "results": results}
+
+    def _restore_warp_in_warp(self):
+        """Если в settings есть активная пара WiW — восстановить связку."""
+        try:
+            from core.awg_warp_in_warp import status as wiw_status, setup as wiw_setup
+            st = wiw_status()
+            if not st.get("active"):
+                return None
+            outer = st.get("outer") or ""
+            inner = st.get("inner") or ""
+            if not (outer and inner):
+                return None
+            log.info("AWG autostart: восстанавливаем WARP-in-WARP (%s → %s)"
+                     % (outer, inner), source="awg_autostart")
+            return wiw_setup(outer, inner)
+        except Exception as e:
+            log.warning("WiW restore: %s" % e, source="awg_autostart")
+            return {"ok": False, "error": str(e)}
+
+
+# ───────────────────────── module helpers ────────────────────────────
+
+def _python_bin() -> str:
+    """Возвращает путь к интерпретатору, под которым запущен GUI."""
+    return sys.executable or "/usr/bin/python3"

--- a/core/awg_init_script.py
+++ b/core/awg_init_script.py
@@ -2,81 +2,74 @@
 """
 Генерация init-скриптов для автозапуска AmneziaWG-интерфейсов.
 
-В этом промте мы только формируем содержимое скриптов и сохраняем их
-через AwgPlatform.install_init_script(); полноценная интеграция с
-autostart-менеджером — следующий этап (промт 11).
+Скрипты вызывают app.py в CLI-режиме (`--apply-awg-autostart`),
+который поднимает все интерфейсы с per-config флагом autostart=true,
+применяет к ним routing-правила (это делает AwgManager.up через
+core.routing.applier) и восстанавливает WARP-in-WARP, если он был
+активен.
 
-Каждый скрипт по умолчанию обрабатывает интерфейсы, имена которых
-переданы аргументом или прочитаны из переменной окружения AWG_IFACES.
-Если ничего не задано — поднимаются все .conf из config_dir.
+Каждый платформенный рендерер возвращает текст; реальная установка
+делается через AwgPlatform.install_init_script(). См.
+core.awg_autostart_manager.
 """
 
 from core.awg_platform import (
     AwgPlatform,
-    KeeneticPlatform,
     OpenWrtPlatform,
     GenericLinuxPlatform,
 )
 
 
-def render_init_script(platform: AwgPlatform, ifaces=None,
-                       gui_url: str = "http://127.0.0.1:8080") -> str:
-    """
-    Сгенерировать содержимое init-скрипта для платформы.
+DEFAULT_PYTHON = "/usr/bin/python3"
+DEFAULT_APP_PY = "/opt/zapret-gui/app.py"
 
-    Скрипт дёргает API zapret-gui, чтобы поднять/опустить интерфейсы.
-    Это делает скрипт максимально простым и переносимым: вся логика
-    остаётся в Python-коде GUI.
-    """
-    iface_arg = ""
-    if ifaces:
-        iface_arg = ",".join(ifaces)
 
+def render_init_script(platform: AwgPlatform,
+                       python_bin: str = DEFAULT_PYTHON,
+                       app_py: str = DEFAULT_APP_PY) -> str:
+    """Сгенерировать содержимое init-скрипта для платформы."""
     if isinstance(platform, OpenWrtPlatform):
-        return _openwrt_procd(gui_url, iface_arg)
+        return _openwrt_procd(python_bin, app_py)
     if isinstance(platform, GenericLinuxPlatform):
-        return _systemd_unit(gui_url, iface_arg)
+        return _systemd_unit(python_bin, app_py)
     # Keenetic / Entware (default)
-    return _entware_init(gui_url, iface_arg)
+    return _entware_init(python_bin, app_py)
 
 
-def install_init_script(platform: AwgPlatform, ifaces=None,
-                        gui_url: str = "http://127.0.0.1:8080") -> str:
+def install_init_script(platform: AwgPlatform,
+                        python_bin: str = DEFAULT_PYTHON,
+                        app_py: str = DEFAULT_APP_PY) -> str:
     """
     Записать init-скрипт через platform.install_init_script.
     Возвращает путь к установленному скрипту.
     """
-    content = render_init_script(platform, ifaces=ifaces, gui_url=gui_url)
+    content = render_init_script(platform, python_bin=python_bin, app_py=app_py)
     return platform.install_init_script(content)
 
 
 # ───────────────────────── Entware (Keenetic) ────────────────────────
 
-def _entware_init(gui_url: str, iface_arg: str) -> str:
+def _entware_init(python_bin: str, app_py: str) -> str:
     return f"""#!/bin/sh
 # zapret-gui: AmneziaWG autostart (Entware/Keenetic)
-# Поднимает интерфейсы через REST API локально работающего GUI.
+# Поднимает enabled-AWG-интерфейсы и применяет routing-правила.
+# Сгенерировано автоматически. Не редактируйте вручную.
 
-GUI_URL="{gui_url}"
-IFACES="${{AWG_IFACES:-{iface_arg}}}"
+PYTHON="{python_bin}"
+APP_PY="{app_py}"
+LOG="/opt/var/log/awg-gui-autostart.log"
 
 start() {{
-    if [ -n "$IFACES" ]; then
-        for i in $(echo "$IFACES" | tr ',' ' '); do
-            curl -s -X POST "$GUI_URL/api/awg/configs/$i/up" >/dev/null 2>&1
-        done
-    else
-        curl -s -X POST "$GUI_URL/api/awg/autostart/up" >/dev/null 2>&1
+    if [ ! -f "$APP_PY" ]; then
+        echo "awg-gui-autostart: $APP_PY не найден" >&2
+        return 1
     fi
+    "$PYTHON" "$APP_PY" --apply-awg-autostart >>"$LOG" 2>&1
 }}
 
 stop() {{
-    if [ -n "$IFACES" ]; then
-        for i in $(echo "$IFACES" | tr ',' ' '); do
-            curl -s -X POST "$GUI_URL/api/awg/configs/$i/down" >/dev/null 2>&1
-        done
-    else
-        curl -s -X POST "$GUI_URL/api/awg/autostart/down" >/dev/null 2>&1
+    if [ -f "$APP_PY" ]; then
+        "$PYTHON" "$APP_PY" --stop-awg-autostart >>"$LOG" 2>&1
     fi
 }}
 
@@ -91,41 +84,40 @@ esac
 
 # ───────────────────────── OpenWrt (procd) ───────────────────────────
 
-def _openwrt_procd(gui_url: str, iface_arg: str) -> str:
+def _openwrt_procd(python_bin: str, app_py: str) -> str:
     return f"""#!/bin/sh /etc/rc.common
 # zapret-gui: AmneziaWG autostart (OpenWrt procd)
+# Сгенерировано автоматически. Не редактируйте вручную.
 START=95
 STOP=10
+USE_PROCD=1
 
-GUI_URL="{gui_url}"
-IFACES="{iface_arg}"
+PYTHON="{python_bin}"
+APP_PY="{app_py}"
+LOG="/var/log/awg-gui-autostart.log"
 
 start_service() {{
-    if [ -n "$IFACES" ]; then
-        for i in $(echo "$IFACES" | tr ',' ' '); do
-            curl -s -X POST "$GUI_URL/api/awg/configs/$i/up" >/dev/null 2>&1
-        done
-    else
-        curl -s -X POST "$GUI_URL/api/awg/autostart/up" >/dev/null 2>&1
-    fi
+    [ -f "$APP_PY" ] || {{
+        logger -t awg-gui-autostart "app.py не найден: $APP_PY"
+        return 1
+    }}
+    procd_open_instance
+    procd_set_param command /bin/sh -c "$PYTHON $APP_PY --apply-awg-autostart >>$LOG 2>&1"
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
 }}
 
 stop_service() {{
-    if [ -n "$IFACES" ]; then
-        for i in $(echo "$IFACES" | tr ',' ' '); do
-            curl -s -X POST "$GUI_URL/api/awg/configs/$i/down" >/dev/null 2>&1
-        done
-    else
-        curl -s -X POST "$GUI_URL/api/awg/autostart/down" >/dev/null 2>&1
-    fi
+    [ -f "$APP_PY" ] || return 0
+    "$PYTHON" "$APP_PY" --stop-awg-autostart >>"$LOG" 2>&1
 }}
 """
 
 
 # ───────────────────────── systemd ───────────────────────────────────
 
-def _systemd_unit(gui_url: str, iface_arg: str) -> str:
-    iface_env = f'Environment="AWG_IFACES={iface_arg}"' if iface_arg else ""
+def _systemd_unit(python_bin: str, app_py: str) -> str:
     return f"""[Unit]
 Description=zapret-gui AmneziaWG autostart
 After=network-online.target zapret-gui.service
@@ -134,10 +126,8 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-{iface_env}
-Environment="GUI_URL={gui_url}"
-ExecStart=/bin/sh -c 'if [ -n "$AWG_IFACES" ]; then for i in $(echo "$AWG_IFACES" | tr "," " "); do curl -s -X POST "$GUI_URL/api/awg/configs/$i/up" >/dev/null; done; else curl -s -X POST "$GUI_URL/api/awg/autostart/up" >/dev/null; fi'
-ExecStop=/bin/sh -c 'if [ -n "$AWG_IFACES" ]; then for i in $(echo "$AWG_IFACES" | tr "," " "); do curl -s -X POST "$GUI_URL/api/awg/configs/$i/down" >/dev/null; done; else curl -s -X POST "$GUI_URL/api/awg/autostart/down" >/dev/null; fi'
+ExecStart={python_bin} {app_py} --apply-awg-autostart
+ExecStop={python_bin} {app_py} --stop-awg-autostart
 
 [Install]
 WantedBy=multi-user.target

--- a/web/js/pages/awg_dashboard.js
+++ b/web/js/pages/awg_dashboard.js
@@ -11,6 +11,7 @@ const AwgDashboardPage = (() => {
     let pollTimer = null;
     let configs = [];
     let interfaces = [];
+    let autostart = { interfaces: {}, script_installed: false, script_path: '' };
     let busy = {};
 
     // ══════════════ render ══════════════
@@ -91,12 +92,15 @@ const AwgDashboardPage = (() => {
 
     async function refresh() {
         try {
-            const [cfgsResp, ifsResp] = await Promise.all([
+            const [cfgsResp, ifsResp, autoResp] = await Promise.all([
                 API.get('/api/awg/configs'),
                 API.get('/api/awg/interfaces'),
+                API.get('/api/awg/autostart').catch(() => ({ status: {} })),
             ]);
             configs = cfgsResp.configs || [];
             interfaces = ifsResp.interfaces || [];
+            autostart = (autoResp && autoResp.status) || { interfaces: {} };
+            if (!autostart.interfaces) autostart.interfaces = {};
             renderBody();
         } catch (err) {
             const body = document.getElementById('awg-summary-body');
@@ -112,16 +116,30 @@ const AwgDashboardPage = (() => {
         const totalCfg = configs.length;
         const activeCount = configs.filter(c => c.active).length;
         const peerCount = interfaces.reduce((s, i) => s + (i.peers || []).length, 0);
+        const autoCount = Object.values(autostart.interfaces || {}).filter(Boolean).length;
+        const scriptInstalled = !!autostart.script_installed;
         const summary = document.getElementById('awg-summary-body');
         if (summary) {
+            const scriptInfo = scriptInstalled
+                ? `<span class="text-running">установлен</span>${autostart.script_path ? ` <span class="text-muted" style="font-size:11px;">(${escapeHtml(autostart.script_path)})</span>` : ''}`
+                : `<span class="text-muted">не установлен</span>`;
             summary.innerHTML = `
-                <div style="display: flex; gap: 24px; flex-wrap: wrap;">
+                <div style="display: flex; gap: 24px; flex-wrap: wrap; align-items: flex-end;">
                     <div><div class="text-muted" style="font-size:12px;">Конфигов</div>
                          <div style="font-size: 20px; font-weight: 600;">${totalCfg}</div></div>
                     <div><div class="text-muted" style="font-size:12px;">Активных туннелей</div>
                          <div style="font-size: 20px; font-weight: 600;">${activeCount}</div></div>
                     <div><div class="text-muted" style="font-size:12px;">Peers всего</div>
                          <div style="font-size: 20px; font-weight: 600;">${peerCount}</div></div>
+                    <div><div class="text-muted" style="font-size:12px;">Автозапуск</div>
+                         <div style="font-size: 14px;">${autoCount} интерф., скрипт: ${scriptInfo}</div></div>
+                    <div style="margin-left:auto; display:flex; gap:6px;">
+                        ${scriptInstalled
+                            ? `<button class="btn btn-ghost btn-sm" onclick="AwgDashboardPage.regenerateScript()">Пересоздать скрипт</button>
+                               <button class="btn btn-ghost btn-sm" onclick="AwgDashboardPage.removeScript()">Удалить скрипт</button>`
+                            : `<button class="btn btn-ghost btn-sm" ${autoCount===0?'disabled title="Включите autostart хотя бы у одного интерфейса"':''}
+                                       onclick="AwgDashboardPage.installScript()">Установить init-скрипт</button>`}
+                    </div>
                 </div>
             `;
         }
@@ -200,6 +218,16 @@ const AwgDashboardPage = (() => {
             ? `<span class="badge badge-warning" style="margin-left: 8px;">без конфига</span>`
             : '';
 
+        const autoOn = !!(autostart.interfaces || {})[cfg.name];
+        const autoToggle = cfg.orphan
+            ? ''
+            : `<label style="display:flex; align-items:center; gap:6px; font-size:12px; cursor:pointer;"
+                       title="Поднимать этот интерфейс при загрузке системы">
+                   <input type="checkbox" ${autoOn?'checked':''} ${inUse?'disabled':''}
+                          onchange="AwgDashboardPage.toggleAutostart('${escapeAttr(cfg.name)}', this.checked)">
+                   автозапуск
+               </label>`;
+
         return `
             <div class="card" style="margin-bottom: 12px;">
                 <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -209,24 +237,27 @@ const AwgDashboardPage = (() => {
                             ${statusBadge}
                         </span>
                     </div>
-                    <div style="display:flex; gap: 6px;">
-                        ${active
-                            ? `<button class="btn btn-ghost btn-sm" ${inUse?'disabled':''}
-                                       onclick="AwgDashboardPage.restart('${escapeAttr(cfg.name)}')">Restart</button>
-                               <button class="btn btn-ghost btn-sm" ${inUse?'disabled':''}
-                                       onclick="AwgDashboardPage.down('${escapeAttr(cfg.name)}')">Stop</button>`
-                            : (cfg.orphan
+                    <div style="display:flex; gap: 12px; align-items: center;">
+                        ${autoToggle}
+                        <div style="display:flex; gap: 6px;">
+                            ${active
+                                ? `<button class="btn btn-ghost btn-sm" ${inUse?'disabled':''}
+                                           onclick="AwgDashboardPage.restart('${escapeAttr(cfg.name)}')">Restart</button>
+                                   <button class="btn btn-ghost btn-sm" ${inUse?'disabled':''}
+                                           onclick="AwgDashboardPage.down('${escapeAttr(cfg.name)}')">Stop</button>`
+                                : (cfg.orphan
+                                    ? ''
+                                    : `<button class="btn btn-primary btn-sm" ${inUse?'disabled':''}
+                                               onclick="AwgDashboardPage.up('${escapeAttr(cfg.name)}')">Start</button>`)
+                            }
+                            ${cfg.orphan
                                 ? ''
-                                : `<button class="btn btn-primary btn-sm" ${inUse?'disabled':''}
-                                           onclick="AwgDashboardPage.up('${escapeAttr(cfg.name)}')">Start</button>`)
-                        }
-                        ${cfg.orphan
-                            ? ''
-                            : `<button class="btn btn-ghost btn-sm"
-                                       onclick="window.location.hash='awg-configs?edit=${encodeURIComponent(cfg.name)}'">
-                                   Редактировать
-                               </button>`
-                        }
+                                : `<button class="btn btn-ghost btn-sm"
+                                           onclick="window.location.hash='awg-configs?edit=${encodeURIComponent(cfg.name)}'">
+                                       Редактировать
+                                   </button>`
+                            }
+                        </div>
                     </div>
                 </div>
                 ${peersHtml}
@@ -261,6 +292,66 @@ const AwgDashboardPage = (() => {
             Toast.error(err.message);
         } finally {
             busy[name] = false;
+            await refresh();
+        }
+    }
+
+    async function toggleAutostart(name, enabled) {
+        if (busy[name]) return;
+        busy[name] = true;
+        try {
+            const data = await API.post(
+                `/api/awg/autostart/${encodeURIComponent(name)}`,
+                { enabled: !!enabled }
+            );
+            if (data && data.ok) {
+                Toast.success(enabled
+                    ? `${name}: автозапуск включён`
+                    : `${name}: автозапуск выключен`);
+            } else {
+                Toast.error((data && data.error) || 'Не удалось изменить флаг');
+            }
+        } catch (err) {
+            Toast.error(err.message);
+        } finally {
+            busy[name] = false;
+            await refresh();
+        }
+    }
+
+    async function installScript() {
+        try {
+            const data = await API.post('/api/awg/autostart/install');
+            if (data.ok) Toast.success(data.message || 'Скрипт установлен');
+            else Toast.error(data.error || 'Ошибка установки');
+        } catch (err) {
+            Toast.error(err.message);
+        } finally {
+            await refresh();
+        }
+    }
+
+    async function removeScript() {
+        if (!confirm('Удалить init-скрипт автозапуска AWG?')) return;
+        try {
+            const data = await API.post('/api/awg/autostart/remove');
+            if (data.ok) Toast.success(data.message || 'Скрипт удалён');
+            else Toast.error(data.error || 'Ошибка удаления');
+        } catch (err) {
+            Toast.error(err.message);
+        } finally {
+            await refresh();
+        }
+    }
+
+    async function regenerateScript() {
+        try {
+            const data = await API.post('/api/awg/autostart/regenerate');
+            if (data.ok) Toast.success(data.message || 'Скрипт пересоздан');
+            else Toast.error(data.error || 'Ошибка');
+        } catch (err) {
+            Toast.error(err.message);
+        } finally {
             await refresh();
         }
     }
@@ -301,5 +392,8 @@ const AwgDashboardPage = (() => {
         return String(s || '').replace(/'/g, '&#39;').replace(/"/g, '&quot;');
     }
 
-    return { render, destroy, refresh, up, down, restart };
+    return {
+        render, destroy, refresh, up, down, restart,
+        toggleAutostart, installScript, removeScript, regenerateScript,
+    };
 })();


### PR DESCRIPTION
## Summary
Implement a comprehensive autostart system for AmneziaWG interfaces with per-config flags, init script generation, and CLI mode support. This allows interfaces to be automatically brought up on system boot with their associated routing rules.

## Key Changes

### Core Autostart Manager (`core/awg_autostart_manager.py`)
- New `AwgAutostartManager` singleton class managing per-interface autostart flags stored in `settings.json`
- Per-config `autostart` flag in `config["awg"]["autostart"]["interfaces"][<name>]`
- Methods to enable/disable autostart for individual interfaces with automatic init script installation/removal
- `apply_autostart()` method to bring up all enabled interfaces and restore WARP-in-WARP if active
- `stop_autostart()` method to tear down interfaces (used by init script stop)
- Status reporting with script installation state and enabled interface count

### Init Script Generation (`core/awg_init_script.py`)
- Refactored to generate scripts that call `app.py --apply-awg-autostart` instead of making HTTP requests
- Supports three platforms: Entware/Keenetic, OpenWrt (procd), and systemd
- Scripts log to platform-specific locations and handle missing app.py gracefully
- Removed hardcoded interface lists in favor of reading from settings.json

### CLI Mode (`app.py`)
- Added `--apply-awg-autostart` flag to bring up enabled interfaces on system boot
- Added `--stop-awg-autostart` flag to tear down interfaces
- `_run_awg_autostart_cli()` initializes config and runs autostart without starting web server
- `_apply_awg_autostart_on_boot()` automatically brings up enabled interfaces when GUI starts (if init script not installed)

### REST API (`api/awg.py`)
- `GET /api/awg/autostart` — get autostart status
- `POST /api/awg/autostart/install` — install init script
- `POST /api/awg/autostart/remove` — remove init script
- `POST /api/awg/autostart/regenerate` — regenerate init script
- `POST /api/awg/autostart/<name>` — set per-interface autostart flag
- `POST /api/awg/autostart/apply` — manually trigger autostart now

### Dashboard UI (`web/js/pages/awg_dashboard.js`)
- Display autostart status in summary (enabled count and script installation state)
- Per-interface checkbox to toggle autostart (disabled if interface in use)
- Buttons to install/remove/regenerate init script
- Toast notifications for user feedback
- Fetch autostart status alongside configs and interfaces

## Implementation Details

- **Startup Order**: Init script → `app.py --apply-awg-autostart` → `AwgManager.up()` for each enabled interface → routing rules applied automatically → WARP-in-WARP restored
- **Thread Safety**: Manager uses locks for concurrent access to settings
- **Graceful Degradation**: If init script installation fails, GUI can still bring up interfaces on its own
- **Platform Detection**: Automatically detects platform (Entware/OpenWrt/systemd) and generates appropriate script
- **Logging**: All operations logged with source="awg_autostart" for easy filtering

https://claude.ai/code/session_019L81ERJqCRAKYgy8gw3uku