### PR TITLE
Support multi-directory config scanning and interface name resolution

### DIFF
--- a/api/awg.py
+++ b/api/awg.py
@@ -81,14 +81,27 @@ def register(app):
         response.content_type = "application/json; charset=utf-8"
         from core.awg_installer import get_awg_installer
         inst = get_awg_installer()
+        settings = inst._settings()
+        repo = settings.get("repo", "")
+        tag_prefix = settings.get("tag_prefix", "")
         try:
             force = request.params.get("force", "").lower() in ("1", "true")
             tag = request.params.get("tag") or None
             manifest = inst.get_manifest(tag=tag, force=force)
-            return {"ok": True, "manifest": manifest}
+            return {
+                "ok":         True,
+                "manifest":   manifest,
+                "repo":       repo,
+                "tag_prefix": tag_prefix,
+            }
         except RuntimeError as e:
             response.status = 502
-            return {"ok": False, "error": str(e)}
+            return {
+                "ok":         False,
+                "error":      str(e),
+                "repo":       repo,
+                "tag_prefix": tag_prefix,
+            }
 
     @app.route("/api/awg/install/status")
     def awg_install_status():

--- a/core/awg_detector.py
+++ b/core/awg_detector.py
@@ -104,28 +104,142 @@ class AwgDetector:
     def detect_keenos_version(self):
         """
         Пытается определить версию KeenOS.
-        Возвращает строку вида '5.4.1' или '' если не Keenetic.
+        Возвращает строку вида '5.0.3' или '' если не Keenetic.
+
+        Источники в порядке приоритета:
+          1) `ndmc -c "show version"` — текстовый YAML-подобный вывод,
+             поле `title:` (например `5.0.3`). На современных прошивках
+             даёт самую корректную "пользовательскую" версию.
+          2) `ndmq -p "show version"` — JSON-формат (старые прошивки),
+             поле `"title"` или `"version"`.
+          3) /proc/version — строка с "Keenetic X.Y.Z".
+          4) /etc/openwrt_release — у Keenetic с OpenWrt-основой.
         """
-        # Ndm-команда (доступна на новых прошивках)
-        ndm = _cmd_out(["ndmq", "-p", "show version"], timeout=3)
-        if ndm:
-            m = re.search(r'"version"\s*:\s*"([\d.]+)"', ndm)
+        # 1) ndmc -c "show version" — текстовый YAML-формат:
+        #      title: 5.0.3
+        #      ndw4:
+        #        version: 5.0.C.3.1
+        for cmd in (["ndmc", "-c", "show version"],
+                    ["ndmc", "show", "version"]):
+            ndm = _cmd_out(cmd, timeout=3)
+            if not ndm:
+                continue
+            ver = self._parse_ndmc_version(ndm)
+            if ver:
+                return ver
+
+        # 2) ndmq -p "show version" — может быть как JSON, так и YAML
+        for cmd in (["ndmq", "-p", "show version"],
+                    ["ndmq", "show", "version"]):
+            ndm = _cmd_out(cmd, timeout=3)
+            if not ndm:
+                continue
+            # JSON: {"title":"5.0.3", ...} или {"version":"5.4.1"}
+            m = re.search(r'"title"\s*:\s*"([\d][\w.\-]*)"', ndm)
             if m:
                 return m.group(1)
+            m = re.search(r'"version"\s*:\s*"([\d][\w.\-]*)"', ndm)
+            if m:
+                return m.group(1)
+            # YAML
+            ver = self._parse_ndmc_version(ndm)
+            if ver:
+                return ver
 
-        # /proc/version — содержит строку вида "Keenetic X.Y.Z"
+        # 3) /proc/version — строка вида "Keenetic X.Y.Z"
         proc_ver = _read_file("/proc/version")
         m = re.search(r"Keenetic[^\d]*([\d]+\.[\d]+\.[\d]+)", proc_ver, re.I)
         if m:
             return m.group(1)
 
-        # /etc/openwrt_release на Keenetic с OpenWrt основой
+        # 4) /etc/openwrt_release на Keenetic с OpenWrt основой
         rel = _read_file("/etc/openwrt_release")
         m = re.search(r'DISTRIB_DESCRIPTION="[^"]*Keenetic[^"]*?([\d]+\.[\d]+\.[\d]+)', rel, re.I)
         if m:
             return m.group(1)
 
         return ""
+
+    def _parse_ndmc_version(self, text: str) -> str:
+        """
+        Парсер YAML-подобного вывода `ndmc -c "show version"`.
+
+        Предпочтения:
+          - title (например '5.0.3') — короткая пользовательская версия
+          - ndw4.version (например '5.0.C.3.1')
+          - release (например '5.00.C.3.0-2')
+        """
+        # title: 5.0.3  (на верхнем уровне отступа, может быть с пробелами)
+        for line in text.splitlines():
+            m = re.match(r"\s*title\s*:\s*([\d][\w.\-]*)\s*$", line)
+            if m:
+                return m.group(1).strip()
+
+        # ndw4: \n  version: 5.0.C.3.1
+        in_ndw4 = False
+        ndw4_indent = -1
+        for line in text.splitlines():
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if re.match(r"ndw4\s*:\s*$", stripped):
+                in_ndw4 = True
+                ndw4_indent = indent
+                continue
+            if in_ndw4:
+                if stripped and indent <= ndw4_indent and not stripped.startswith("version"):
+                    in_ndw4 = False
+                    continue
+                m = re.match(r"version\s*:\s*([\d][\w.\-]*)\s*$", stripped)
+                if m:
+                    return m.group(1).strip()
+
+        # release: 5.00.C.3.0-2
+        for line in text.splitlines():
+            m = re.match(r"\s*release\s*:\s*([\d][\w.\-]*)\s*$", line)
+            if m:
+                return m.group(1).strip()
+
+        return ""
+
+    def detect_keenetic_routing(self) -> dict:
+        """
+        Best-effort снимок текущих настроек маршрутизации Keenetic через
+        ndmc/ndmq. Ничего не модифицирует — только показывает админу,
+        чтобы он понимал возможные конфликты с AWG-маршрутами.
+
+        Возвращает:
+          {
+            "available": bool,        # удалось прочитать хоть что-то
+            "policy":    str,         # сырой вывод 'show ip policy'
+            "routes":    str,         # сырой вывод 'show ip route'
+            "interfaces": str,        # сырой вывод 'show interface'
+          }
+        """
+        result = {"available": False, "policy": "", "routes": "", "interfaces": ""}
+
+        def _try(cmds):
+            for cmd in cmds:
+                out = _cmd_out(cmd, timeout=4)
+                if out:
+                    return out
+            return ""
+
+        result["policy"] = _try([
+            ["ndmc", "-c", "show ip policy"],
+            ["ndmq", "-p", "show ip policy"],
+        ])
+        result["routes"] = _try([
+            ["ndmc", "-c", "show ip route"],
+            ["ndmq", "-p", "show ip route"],
+        ])
+        result["interfaces"] = _try([
+            ["ndmc", "-c", "show interface"],
+            ["ndmq", "-p", "show interface"],
+        ])
+        result["available"] = any(
+            result[k] for k in ("policy", "routes", "interfaces")
+        )
+        return result
 
     def detect_architecture(self):
         """
@@ -189,7 +303,7 @@ class AwgDetector:
         # Проверяем что нужно для работы AWG на данной платформе
         prerequisites = self._check_prerequisites(platform, tun)
 
-        return {
+        report = {
             "ok":            True,
             "platform":      platform.as_dict(),
             "architecture":  arch,
@@ -198,6 +312,13 @@ class AwgDetector:
             "prerequisites": prerequisites,
             "ready":         prerequisites["all_met"],
         }
+
+        # На Keenetic подцепим снимок текущих NDM-маршрутов/политик,
+        # чтобы пользователь видел потенциальные конфликты с AWG.
+        if isinstance(platform, KeeneticPlatform):
+            report["keenetic_routing"] = self.detect_keenetic_routing()
+
+        return report
 
     def _check_prerequisites(self, platform: AwgPlatform, tun: dict):
         items = []
@@ -252,7 +373,9 @@ class AwgDetector:
         pv = _read_file("/proc/version").lower()
         if "keenetic" in pv:
             return True
-        if os.path.exists("/opt/etc/init.d") and _cmd_ok(["ndmq", "--help"]):
+        if os.path.exists("/opt/etc/init.d") and (
+            _cmd_ok(["ndmc", "--help"]) or _cmd_ok(["ndmq", "--help"])
+        ):
             return True
         rel = _read_file("/etc/openwrt_release").lower()
         return "keenetic" in rel
@@ -287,17 +410,24 @@ class AwgDetector:
         # Неизвестная арх — возвращаем uname как есть
         return uname_m
 
+    # Каталоги, в которых принято хранить конфиги AmneziaWG / WireGuard.
+    # Сюда смотрят и detector, и manager — чтобы пользовательский конфиг,
+    # лежащий не в platform.config_dir, всё равно был виден.
+    CONFIG_DIR_CANDIDATES = (
+        "/opt/etc/amneziawg",
+        "/opt/etc/amnezia/amneziawg",
+        "/opt/etc/amnezia/awg",
+        "/opt/etc/AmneziaWG",
+        "/opt/etc/wireguard",
+        "/etc/amneziawg",
+        "/etc/amnezia/amneziawg",
+        "/etc/amnezia/awg",
+        "/etc/wireguard",
+    )
+
     def _find_config_dirs(self):
-        candidates = [
-            "/opt/etc/amneziawg",
-            "/opt/etc/amnezia/awg",
-            "/opt/etc/wireguard",
-            "/etc/amneziawg",
-            "/etc/amnezia/awg",
-            "/etc/wireguard",
-        ]
         found = []
-        for d in candidates:
+        for d in self.CONFIG_DIR_CANDIDATES:
             if os.path.isdir(d):
                 confs = [
                     f for f in os.listdir(d)

--- a/core/awg_installer.py
+++ b/core/awg_installer.py
@@ -205,14 +205,24 @@ class AwgInstaller:
             with _http_get(url) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
         except (HTTPError, URLError, ValueError, OSError) as e:
-            raise RuntimeError("Не удалось получить список релизов: %s" % e)
+            raise RuntimeError(
+                "Не удалось получить список релизов %s: %s" % (url, e)
+            )
 
         for rel in data:
             tag = rel.get("tag_name") or ""
             if tag.startswith(tag_prefix) and not rel.get("draft"):
                 return tag
+
+        # Покажем какие тэги вообще есть — это самая частая причина
+        # «нет релизов с префиксом»: репозиторий публикует другие
+        # релизы, без awg-bin-*.
+        seen = [r.get("tag_name") or "" for r in data][:10]
         raise RuntimeError(
-            "В репозитории %s нет релизов с префиксом '%s'" % (repo, tag_prefix)
+            "В репозитории %s нет релизов с префиксом '%s'. "
+            "Найдены тэги: %s. Проверьте release_tag_prefix в настройках "
+            "или соберите бинарники через workflow build-awg-binaries.yml." %
+            (repo, tag_prefix, (", ".join(t for t in seen if t) or "(нет релизов)"))
         )
 
     def get_manifest(self, tag: str = None, force: bool = False) -> dict:
@@ -244,7 +254,7 @@ class AwgInstaller:
                 manifest = json.loads(resp.read().decode("utf-8"))
         except (HTTPError, URLError, ValueError, OSError) as e:
             raise RuntimeError(
-                "Не удалось скачать manifest.json для тэга %s: %s" % (tag, e)
+                "Не удалось скачать manifest.json (%s): %s" % (url, e)
             )
 
         # Подстраховка: tag в манифесте может отличаться от запрошенного

--- a/core/awg_manager.py
+++ b/core/awg_manager.py
@@ -128,8 +128,34 @@ class AwgManager:
         os.makedirs(d, exist_ok=True)
         return d
 
+    def _scan_dirs(self) -> list:
+        """
+        Все каталоги, в которых ищем конфиги: основной platform.config_dir
+        плюс дополнительные кандидаты (на Keenetic пользователи иногда
+        держат конфиги в /opt/etc/amnezia/amneziawg/ и т.п.).
+        """
+        from core.awg_detector import AwgDetector
+        primary = self._platform().config_dir
+        seen = set()
+        dirs = []
+        for d in [primary] + list(AwgDetector.CONFIG_DIR_CANDIDATES):
+            if d and d not in seen and os.path.isdir(d):
+                seen.add(d)
+                dirs.append(d)
+        return dirs
+
     def _config_path(self, name: str) -> str:
-        return os.path.join(self._config_dir(), "%s.conf" % name)
+        """
+        Найти .conf для имени конфига во всех известных каталогах.
+        Если нигде нет — возвращаем путь в platform.config_dir
+        (туда будем сохранять новый файл при save).
+        """
+        fname = "%s.conf" % name
+        for d in self._scan_dirs():
+            p = os.path.join(d, fname)
+            if os.path.isfile(p):
+                return p
+        return os.path.join(self._config_dir(), fname)
 
     def _pid_path(self, iface: str) -> str:
         return os.path.join(self._run_dir(), "awg-%s.pid" % iface)
@@ -140,32 +166,104 @@ class AwgManager:
     # ─────────── CRUD ───────────
 
     def list_configs(self) -> list:
-        """Список конфигов в config_dir с краткой инфой."""
-        d = self._config_dir()
+        """
+        Список конфигов из всех известных каталогов.
+
+        Каждая запись возвращает не только имя файла, но и `iface` —
+        фактическое имя сетевого интерфейса. Это нужно для случаев,
+        когда конфиг назван по схеме `<label>-<iface>.conf` (например
+        `awg0-opkgtun0.conf` для интерфейса `opkgtun0`) — типично
+        для скриптов, оборачивающих awg-quick.
+        """
+        seen = set()  # по имени файла (без .conf)
+        active_ifaces = self._wg_interfaces()
         result = []
-        if not os.path.isdir(d):
-            return result
-        for f in sorted(os.listdir(d)):
-            if not f.endswith(".conf"):
-                continue
-            name = f[:-5]
-            path = os.path.join(d, f)
+        for d in self._scan_dirs():
             try:
-                stat = os.stat(path)
-                size = stat.st_size
-                mtime = int(stat.st_mtime)
+                files = sorted(os.listdir(d))
             except OSError:
-                size = 0
-                mtime = 0
-            active = self.is_running(name)
-            result.append({
-                "name":   name,
-                "path":   path,
-                "size":   size,
-                "mtime":  mtime,
-                "active": active,
-            })
+                continue
+            for f in files:
+                if not f.endswith(".conf"):
+                    continue
+                name = f[:-5]
+                if name in seen:
+                    continue
+                seen.add(name)
+                path = os.path.join(d, f)
+                if not os.path.isfile(path):
+                    continue
+                try:
+                    stat = os.stat(path)
+                    size = stat.st_size
+                    mtime = int(stat.st_mtime)
+                except OSError:
+                    size = 0
+                    mtime = 0
+                iface = self._resolve_iface_name(name, path, active_ifaces)
+                active = self.is_running(iface) or self.is_running(name)
+                result.append({
+                    "name":   name,
+                    "iface":  iface,
+                    "path":   path,
+                    "size":   size,
+                    "mtime":  mtime,
+                    "active": active,
+                })
         return result
+
+    def _resolve_iface_name(self, config_name: str, config_path: str,
+                            active_ifaces: list) -> str:
+        """
+        Определяет имя сетевого интерфейса, которому принадлежит конфиг.
+
+        Эвристика:
+          1. Если имя конфига совпадает с активным интерфейсом — оно и есть.
+          2. Если конфиг назван `<label>-<iface>.conf` и `<iface>` есть в
+             списке активных — возвращаем `<iface>`.
+          3. Сверка по PublicKey пира: если в конфиге есть [Peer]/PublicKey,
+             совпадающий с PublicKey пира одного из активных интерфейсов,
+             возвращаем имя этого интерфейса.
+          4. Иначе — возвращаем сам name (классический wg-quick case).
+        """
+        active = set(active_ifaces or [])
+        if config_name in active:
+            return config_name
+
+        if "-" in config_name:
+            suffix = config_name.rsplit("-", 1)[-1]
+            if suffix and suffix in active:
+                return suffix
+
+        # Сверка по PublicKey пира — медленнее, но надёжно.
+        try:
+            with open(config_path, "r") as f:
+                cfg = parse_conf(f.read())
+        except (IOError, OSError, ValueError):
+            return config_name
+
+        peer_keys = set()
+        for peer in cfg.get("peers", []) or []:
+            pk = (peer.get("PublicKey") or "").strip()
+            if pk:
+                peer_keys.add(pk)
+
+        if peer_keys:
+            for iface in active:
+                rc, out, _ = _run([self._awg_bin(), "show", iface, "dump"], timeout=5)
+                if rc != 0 or not out.strip():
+                    continue
+                lines = [l for l in out.splitlines() if l.strip()]
+                # Первая строка — [Interface], дальше — пиры (поле[0] = pubkey).
+                for line in lines[1:]:
+                    parts = line.split("\t")
+                    if not parts:
+                        continue
+                    iface_pk = parts[0].strip()
+                    if iface_pk and iface_pk in peer_keys:
+                        return iface
+
+        return config_name
 
     def get_config(self, name: str) -> dict:
         """
@@ -246,6 +344,25 @@ class AwgManager:
         # Fallback — есть в `wg show interfaces`
         return iface in self._wg_interfaces()
 
+    def _iface_for_name(self, name: str) -> str:
+        """
+        Найти имя реально работающего интерфейса для конфига `name`.
+        Используется при down/restart: если конфиг назван
+        `awg0-opkgtun0`, а активный интерфейс — `opkgtun0`, операции
+        должны идти по `opkgtun0`.
+        """
+        active = self._wg_interfaces()
+        if name in active:
+            return name
+        path = self._config_path(name)
+        if os.path.isfile(path):
+            return self._resolve_iface_name(name, path, active)
+        if "-" in name:
+            suffix = name.rsplit("-", 1)[-1]
+            if suffix in active:
+                return suffix
+        return name
+
     def _wg_interfaces(self) -> list:
         rc, out, _ = _run([self._awg_bin(), "show", "interfaces"], timeout=5)
         if rc == 0 and out.strip():
@@ -273,7 +390,14 @@ class AwgManager:
         return result
 
     def status(self, iface: str) -> dict:
-        """Статус интерфейса: peers, last handshake, RX/TX и пр."""
+        """Статус интерфейса: peers, last handshake, RX/TX и пр.
+
+        Принимает либо имя реального интерфейса (`opkgtun0`), либо имя
+        конфига (`awg0-opkgtun0`) — во втором случае резолвим в реальный.
+        """
+        resolved = self._iface_for_name(iface)
+        if resolved and resolved != iface and resolved in self._wg_interfaces():
+            iface = resolved
         info = {
             "name":     iface,
             "active":   False,
@@ -497,7 +621,10 @@ class AwgManager:
     def _do_down(self, name: str) -> dict:
         if not _valid_iface_name(name):
             return {"ok": False, "message": "Недопустимое имя"}
-        ifname = name
+        # Если конфиг назван `awg0-opkgtun0`, а реальный интерфейс —
+        # `opkgtun0` (поднят внешним скриптом), down должен идти по
+        # реальному имени, иначе `ip link delete` ничего не найдёт.
+        ifname = self._iface_for_name(name)
 
         # PreDown / PostDown
         path = self._config_path(name)

--- a/web/js/pages/awg_dashboard.js
+++ b/web/js/pages/awg_dashboard.js
@@ -12,6 +12,7 @@ const AwgDashboardPage = (() => {
     let configs = [];
     let interfaces = [];
     let autostart = { interfaces: {}, script_installed: false, script_path: '' };
+    let keeneticRouting = null;
     let busy = {};
 
     // ══════════════ render ══════════════
@@ -66,6 +67,7 @@ const AwgDashboardPage = (() => {
             </div>
 
             <div id="awg-tunnels"></div>
+            <div id="awg-keenetic-routing"></div>
         `;
 
         refresh();
@@ -92,15 +94,17 @@ const AwgDashboardPage = (() => {
 
     async function refresh() {
         try {
-            const [cfgsResp, ifsResp, autoResp] = await Promise.all([
+            const [cfgsResp, ifsResp, autoResp, envResp] = await Promise.all([
                 API.get('/api/awg/configs'),
                 API.get('/api/awg/interfaces'),
                 API.get('/api/awg/autostart').catch(() => ({ status: {} })),
+                API.get('/api/awg/environment').catch(() => null),
             ]);
             configs = cfgsResp.configs || [];
             interfaces = ifsResp.interfaces || [];
             autostart = (autoResp && autoResp.status) || { interfaces: {} };
             if (!autostart.interfaces) autostart.interfaces = {};
+            keeneticRouting = (envResp && envResp.keenetic_routing) || null;
             renderBody();
         } catch (err) {
             const body = document.getElementById('awg-summary-body');
@@ -160,17 +164,65 @@ const AwgDashboardPage = (() => {
         }
 
         // Объединяем: конфиги + active-only интерфейсы (которые не имеют конфига)
-        const cfgNames = new Set(configs.map(c => c.name));
-        const orphanIfaces = interfaces.filter(i => !cfgNames.has(i.name));
+        // Сопоставление по реальному имени интерфейса (cfg.iface), а не
+        // только по имени файла — конфиги вида `awg0-opkgtun0.conf` для
+        // интерфейса `opkgtun0` должны находить свой активный туннель.
+        const claimedIfaces = new Set();
+        configs.forEach(c => {
+            if (c.iface) claimedIfaces.add(c.iface);
+            claimedIfaces.add(c.name);
+        });
+        const orphanIfaces = interfaces.filter(i => !claimedIfaces.has(i.name));
 
         const cards = [];
         configs.forEach(c => {
-            cards.push(renderTunnelCard(c, ifaceByName[c.name]));
+            // Берём статус по фактическому имени интерфейса, если оно
+            // отличается от имени конфига.
+            const ifaceData = ifaceByName[c.iface] || ifaceByName[c.name];
+            cards.push(renderTunnelCard(c, ifaceData));
         });
         orphanIfaces.forEach(i => {
             cards.push(renderTunnelCard({ name: i.name, active: i.active, orphan: true }, i));
         });
         wrap.innerHTML = cards.join('');
+
+        renderKeeneticRouting();
+    }
+
+    function renderKeeneticRouting() {
+        const wrap = document.getElementById('awg-keenetic-routing');
+        if (!wrap) return;
+        const k = keeneticRouting;
+        if (!k || !k.available) {
+            wrap.innerHTML = '';
+            return;
+        }
+        const block = (title, body) => body
+            ? `<details style="margin-top: 8px;">
+                   <summary style="cursor:pointer; color: var(--text-secondary); font-size: 13px;">${escapeHtml(title)}</summary>
+                   <pre style="margin-top: 6px; padding: 8px; background: var(--bg-input);
+                                border-radius: var(--radius-sm); font-size: 11px;
+                                max-height: 240px; overflow: auto;">${escapeHtml(body)}</pre>
+               </details>`
+            : '';
+        wrap.innerHTML = `
+            <div class="card" style="margin-top: 16px;">
+                <div class="card-title">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16">
+                        <path d="M6 3v12"/><circle cx="6" cy="18" r="3"/>
+                        <circle cx="18" cy="6" r="3"/><path d="M18 9v12"/>
+                    </svg>
+                    Маршрутизация Keenetic (NDM)
+                </div>
+                <div style="margin-top: 4px; font-size: 12px; color: var(--text-muted);">
+                    Снимок текущих настроек штатного GUI Keenetic. AWG может конфликтовать
+                    с этими политиками и маршрутами — проверьте, если что-то работает не так.
+                </div>
+                ${block('Политики (show ip policy)', k.policy)}
+                ${block('Маршруты (show ip route)', k.routes)}
+                ${block('Интерфейсы (show interface)', k.interfaces)}
+            </div>
+        `;
     }
 
     function renderTunnelCard(cfg, iface) {
@@ -217,6 +269,9 @@ const AwgDashboardPage = (() => {
         const orphan = cfg.orphan
             ? `<span class="badge badge-warning" style="margin-left: 8px;">без конфига</span>`
             : '';
+        const ifaceLabel = (cfg.iface && cfg.iface !== cfg.name)
+            ? `<span class="text-muted" style="margin-left: 8px; font-size: 12px;">→ iface <span style="font-family:monospace;">${escapeHtml(cfg.iface)}</span></span>`
+            : '';
 
         const autoOn = !!(autostart.interfaces || {})[cfg.name];
         const autoToggle = cfg.orphan
@@ -232,7 +287,7 @@ const AwgDashboardPage = (() => {
             <div class="card" style="margin-bottom: 12px;">
                 <div style="display: flex; justify-content: space-between; align-items: center;">
                     <div style="display:flex; align-items: center; gap: 8px;">
-                        <strong>${escapeHtml(cfg.name)}</strong> ${orphan}
+                        <strong>${escapeHtml(cfg.name)}</strong> ${orphan} ${ifaceLabel}
                         <span style="display:flex; gap: 6px; align-items: center; margin-left: 8px;">
                             ${statusBadge}
                         </span>

--- a/web/js/pages/awg_setup.js
+++ b/web/js/pages/awg_setup.js
@@ -12,6 +12,8 @@ const AwgSetupPage = (() => {
 
     let env = null;          // отчёт /api/awg/environment
     let manifest = null;     // /api/awg/manifest
+    let manifestError = null; // диагностика ошибки manifest
+    let manifestRepo = '';
     let installState = null; // /api/awg/install/status
 
     let pollTimer = null;
@@ -210,9 +212,13 @@ const AwgSetupPage = (() => {
     async function loadManifest() {
         try {
             const r = await API.get('/api/awg/manifest');
-            manifest = r.ok ? r.manifest : null;
+            manifest = r && r.ok ? r.manifest : null;
+            manifestError = r && !r.ok ? (r.error || 'unknown') : null;
+            manifestRepo = (r && r.repo) || '';
         } catch (err) {
             manifest = null;
+            manifestError = err && err.message ? err.message : String(err);
+            manifestRepo = '';
         }
         renderInstall();
     }
@@ -356,10 +362,15 @@ const AwgSetupPage = (() => {
                 (archs.length ? `<br>Архитектуры: ${archs.map(a => `<span class="awg-mono">${a}</span>`).join(', ')}` : '')
             );
         } else {
+            const repoLine = manifestRepo
+                ? `Репозиторий: <span class="awg-mono">${escapeHtml(manifestRepo)}</span>.<br>`
+                : '';
+            const errLine = manifestError
+                ? `Подробности: <span class="awg-mono">${escapeHtml(manifestError)}</span>`
+                : 'Проверьте интернет на роутере и наличие релизов с префиксом awg-bin-* в репозитории.';
             manifestHtml = rowHtml(
                 'bad', 'Manifest не загружен',
-                'Не удалось получить manifest.json из GitHub Releases. ' +
-                'Проверьте интернет на роутере и репозиторий в настройках.'
+                repoLine + errLine
             );
         }
 
@@ -410,11 +421,13 @@ const AwgSetupPage = (() => {
         const active = (target.active_interfaces || []).filter(Boolean);
         if (active.length) {
             activeHtml = rowHtml(
-                'bad',
+                'info',
                 'Запущенные AWG/WG интерфейсы',
                 `${active.map(n => `<span class="awg-mono">${escapeHtml(n)}</span>`).join(', ')}<br>` +
-                `Запущенный процесс продолжит работу со старым кодом — после установки перезапустите интерфейс ` +
-                `командой <span class="awg-mono">awg-quick down &lt;name&gt; && awg-quick up &lt;name&gt;</span>.`
+                `После установки новых бинарников эти процессы продолжат работу со старым кодом. ` +
+                `Чтобы переключить их на свежие бинарники, перейдите в ` +
+                `<a href="#awg-dashboard" style="color: var(--primary);">AmneziaWG → туннели</a> ` +
+                `и нажмите <strong>Restart</strong> на нужном туннеле.`
             );
         }
 


### PR DESCRIPTION
## Summary
This PR enhances AmneziaWG configuration management to support configs stored in multiple directories and improves interface name resolution for configs using the `<label>-<iface>` naming pattern (common with external scripts like awg-quick).

## Key Changes

### Core Configuration Management (`core/awg_manager.py`)
- **Multi-directory scanning**: Added `_scan_dirs()` method to search for configs across multiple candidate directories (primary `platform.config_dir` plus additional locations like `/opt/etc/amnezia/amneziawg/`)
- **Enhanced config path resolution**: Modified `_config_path()` to search all known directories and return the first matching config file, falling back to primary directory for new saves
- **Interface name resolution**: Implemented `_resolve_iface_name()` with multi-level heuristics:
  - Direct name match with active interfaces
  - Suffix extraction from `<label>-<iface>` pattern
  - PublicKey matching against active interface peers (via `awg show dump`)
- **Config listing improvements**: Updated `list_configs()` to:
  - Scan all directories and deduplicate by config name
  - Return both config name and resolved interface name (`iface` field)
  - Track active status by both config name and resolved interface name
- **Down operation fix**: Modified `_do_down()` to use `_iface_for_name()` for proper interface resolution, ensuring `ip link delete` targets the correct interface
- **Status endpoint enhancement**: Updated `status()` to accept both config names and interface names, auto-resolving as needed

### Platform Detection (`core/awg_detector.py`)
- **Improved Keenetic version detection**: Enhanced `detect_keenos_version()` with prioritized sources:
  - `ndmc -c "show version"` (YAML format, modern firmware)
  - `ndmq -p "show version"` (JSON format, legacy firmware)
  - `/proc/version` and `/etc/openwrt_release` fallbacks
- **YAML parser**: Added `_parse_ndmc_version()` to handle YAML-like output from ndmc commands with proper indentation handling
- **Keenetic routing snapshot**: New `detect_keenetic_routing()` method to capture current NDM policies, routes, and interfaces for conflict detection
- **Config directory candidates**: Extracted `CONFIG_DIR_CANDIDATES` as class constant for reuse across detector and manager
- **Keenetic detection improvement**: Updated `_is_keenetic()` to check for both `ndmc` and `ndmq` commands
- **Report enhancement**: Modified `_build_report()` to include `keenetic_routing` snapshot for Keenetic platforms

### Web UI (`web/js/pages/awg_dashboard.js`)
- **Keenetic routing display**: Added rendering of NDM routing information with collapsible details sections for policies, routes, and interfaces
- **Interface name mapping**: Updated tunnel card rendering to show resolved interface names when different from config name (e.g., "awg0-opkgtun0 → iface opkgtun0")
- **Improved orphan detection**: Fixed orphan interface detection to use resolved interface names (`cfg.iface`) in addition to config names

### Setup Page (`web/js/pages/awg_setup.js`)
- **Better error diagnostics**: Enhanced manifest loading error reporting with repository URL and detailed error messages
- **Improved manifest failure messages**: Shows available tags when no releases match the expected prefix, helping users diagnose configuration issues

### Installer (`core/awg_installer.py`)
- **Enhanced error messages**: Improved `_resolve_release_tag()` error reporting to show:
  - Full URL of failed request
  - Available tags in the repository (first 10)
  - Guidance on checking `release_tag_prefix` settings or using build workflow

## Implementation Details
- Config deduplication uses a `seen` set to prevent duplicate entries when scanning multiple directories
- Interface resolution uses a fallback chain: direct match → suffix extraction → PublicKey matching → original name
- Keenetic routing detection is non-blocking and gracefully handles command failures
- All file operations include proper error handling with OSError/IOError catching

https://claude.ai/code/session_015Hs3WaHdGeqpAtCfi8JFiK