### PR TITLE
Fix manifest fallback, NDM hostnames, AWG auto-tag freshness

### DIFF
--- a/.github/workflows/build-awg-binaries.yml
+++ b/.github/workflows/build-awg-binaries.yml
@@ -33,8 +33,10 @@ on:
     tags:
       - 'awg-bin-*'
   schedule:
-    # Ежедневно 06:00 UTC — авто-детект новых апстрим-версий
-    - cron: '0 6 * * *'
+    # Каждые 6 часов — авто-детект новых апстрим-версий.
+    # Раньше было раз в сутки; если апстрим тэг проставлен сразу после
+    # запуска, ждать почти 24 часа неудобно.
+    - cron: '0 */6 * * *'
 
 permissions:
   contents: write
@@ -64,13 +66,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Берём самый свежий git-тэг (а не релиз): амнезия часто
+          # проставляет тэг раньше, чем создаёт Release-объект, поэтому
+          # releases/latest может «отставать» от tags на несколько дней.
           resolve_latest() {
             local repo="$1"
             local out
-            if out=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null); then
+            if out=$(gh api "repos/$repo/tags" --jq '.[0].name' 2>/dev/null) \
+               && [ -n "$out" ] && [ "$out" != "null" ]; then
               echo "$out"; return
             fi
-            if out=$(gh api "repos/$repo/tags" --jq '.[0].name' 2>/dev/null); then
+            if out=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null) \
+               && [ -n "$out" ] && [ "$out" != "null" ]; then
               echo "$out"; return
             fi
             echo "main"
@@ -132,13 +139,17 @@ jobs:
             fi
           fi
 
+          # Берём самый свежий git-тэг (а не релиз): амнезия часто
+          # проставляет тэг раньше, чем создаёт Release-объект.
           resolve_latest() {
             local repo="$1"
             local out
-            if out=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null); then
+            if out=$(gh api "repos/$repo/tags" --jq '.[0].name' 2>/dev/null) \
+               && [ -n "$out" ] && [ "$out" != "null" ]; then
               echo "$out"; return
             fi
-            if out=$(gh api "repos/$repo/tags" --jq '.[0].name' 2>/dev/null); then
+            if out=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null) \
+               && [ -n "$out" ] && [ "$out" != "null" ]; then
               echo "$out"; return
             fi
             echo "main"

--- a/core/awg_installer.py
+++ b/core/awg_installer.py
@@ -196,7 +196,16 @@ class AwgInstaller:
 
     def _resolve_release_tag(self, repo: str, tag_prefix: str) -> str:
         """
-        Найти последний релиз с тэгом, начинающимся на tag_prefix.
+        Найти последний релиз, в котором есть manifest.json.
+
+        Логика поиска:
+          1. Если есть релиз с tag_name, начинающимся на tag_prefix,
+             и в его assets есть manifest.json — берём его (новые сверху).
+          2. Иначе берём первый релиз с manifest.json в assets независимо
+             от префикса — это работает для ручных релизов (например
+             `manual-YYYYMMDDHHMMSS`).
+          3. Если ни в одном релизе нет manifest.json — кидаем понятную
+             ошибку с найденными тэгами.
 
         GitHub API releases возвращает их в порядке создания (новые сверху).
         """
@@ -209,20 +218,42 @@ class AwgInstaller:
                 "Не удалось получить список релизов %s: %s" % (url, e)
             )
 
+        def _has_manifest(rel):
+            for a in rel.get("assets") or []:
+                if (a.get("name") or "").lower() == "manifest.json":
+                    return True
+            return False
+
+        # 1) Предпочтительно — последний релиз с нужным префиксом.
         for rel in data:
             tag = rel.get("tag_name") or ""
-            if tag.startswith(tag_prefix) and not rel.get("draft"):
+            if rel.get("draft"):
+                continue
+            if tag.startswith(tag_prefix) and _has_manifest(rel):
                 return tag
 
-        # Покажем какие тэги вообще есть — это самая частая причина
-        # «нет релизов с префиксом»: репозиторий публикует другие
-        # релизы, без awg-bin-*.
+        # 2) Любой релиз с manifest.json (для ручных загрузок).
+        for rel in data:
+            tag = rel.get("tag_name") or ""
+            if rel.get("draft"):
+                continue
+            if _has_manifest(rel):
+                log.info(
+                    "Используем релиз %s (нет тэга с префиксом '%s', "
+                    "но есть manifest.json)" % (tag, tag_prefix),
+                    source="awg_installer",
+                )
+                return tag
+
+        # 3) Ничего не нашли — расскажем что есть.
         seen = [r.get("tag_name") or "" for r in data][:10]
         raise RuntimeError(
-            "В репозитории %s нет релизов с префиксом '%s'. "
-            "Найдены тэги: %s. Проверьте release_tag_prefix в настройках "
-            "или соберите бинарники через workflow build-awg-binaries.yml." %
-            (repo, tag_prefix, (", ".join(t for t in seen if t) or "(нет релизов)"))
+            "Не найден релиз с manifest.json в репозитории %s. "
+            "Проверены тэги (искали префикс '%s' или релиз с asset'ом "
+            "manifest.json): %s. Соберите бинарники через workflow "
+            "build-awg-binaries.yml или загрузите manifest.json в существующий релиз." %
+            (repo, tag_prefix,
+             (", ".join(t for t in seen if t) or "(нет релизов)"))
         )
 
     def get_manifest(self, tag: str = None, force: bool = False) -> dict:

--- a/core/devices_discovery.py
+++ b/core/devices_discovery.py
@@ -3,29 +3,33 @@
 Обнаружение устройств в локальной сети для per-device routing.
 
 Источники данных (в порядке приоритета):
-  1. DHCP-leases dnsmasq:
+  1. Keenetic NDM: `ndmc -c "show ip hotspot"` / `ndmq -p ...` — даёт
+     самые полные имена хостов (name из веб-админки, hostname от клиента)
+  2. DHCP-leases dnsmasq:
        /tmp/dhcp.leases           — Keenetic / OpenWrt / Entware
        /var/lib/misc/dnsmasq.leases
        /tmp/dnsmasq.leases
        /opt/var/lib/misc/dnsmasq.leases
-  2. ARP-таблица: /proc/net/arp как fallback / дополнение
+  3. ARP-таблица: /proc/net/arp как fallback / дополнение
 
 Возвращает дедуплицированный список устройств:
     {
         "ip":         "192.168.1.42",
         "mac":        "aa:bb:cc:dd:ee:ff",   # lowercase
         "hostname":   "Galaxy-S21",
-        "source":     "leases" | "arp" | "leases+arp",
+        "source":     "leases" | "arp" | "ndm" | комбинации через '+',
         "expires_at": 1731234567 | 0,        # 0 если бессрочный/из ARP
         "iface":      "br0" | ""             # только из ARP, опционально
     }
 
-Никаких внешних команд, кроме чтения /proc и текстовых файлов —
-функция должна быть быстрой и устойчивой на любой платформе.
+ndmc/ndmq вызываются только если бинарники найдены — на не-Keenetic
+системах функция работает как раньше (быстрая, без внешних команд).
 """
 
+import json
 import os
 import re
+import subprocess
 
 
 # Кандидатные пути для dnsmasq leases.
@@ -126,6 +130,158 @@ def _read_leases() -> list:
     return out
 
 
+# ───────────────────────── Keenetic NDM ─────────────────────────────
+
+def _cmd_out(args, timeout=4):
+    try:
+        r = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout
+        )
+        return r.stdout if r.returncode == 0 else ""
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+def _parse_ndm_hosts_json(text: str) -> list:
+    """
+    Парсер JSON-вывода `ndmq -p "show ip hotspot"`.
+
+    Ожидается структура { "host": [ {mac, ip, name, hostname, ...}, ... ] }
+    или сразу массив, или одиночный объект под ключом "host".
+    Toleranт к шумным заголовкам ndmq.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    # Иногда ndmq добавляет шапку до JSON
+    start = text.find("{")
+    if start < 0:
+        start = text.find("[")
+    if start < 0:
+        return []
+    try:
+        data = json.loads(text[start:])
+    except (ValueError, TypeError):
+        return []
+
+    if isinstance(data, dict):
+        hosts = data.get("host")
+        if hosts is None:
+            return []
+        if isinstance(hosts, dict):
+            hosts = [hosts]
+    elif isinstance(data, list):
+        hosts = data
+    else:
+        return []
+
+    out = []
+    for h in hosts:
+        if not isinstance(h, dict):
+            continue
+        mac = _normalize_mac(h.get("mac") or "")
+        ip  = (h.get("ip") or "").strip()
+        if not mac and not _is_valid_ip(ip):
+            continue
+        # Предпочитаем "name" (заданное в админке), затем "hostname".
+        name = (h.get("name") or h.get("hostname") or "").strip()
+        out.append({
+            "ip":         ip if _is_valid_ip(ip) else "",
+            "mac":        mac,
+            "hostname":   name,
+            "source":     "ndm",
+            "expires_at": 0,
+            "iface":      "",
+        })
+    return out
+
+
+def _parse_ndm_hosts_yaml(text: str) -> list:
+    """
+    Парсер текстового YAML-подобного вывода `ndmc -c "show ip hotspot"`.
+
+    Записи разделены строками вида `host:` или `host, name = ...`.
+    Внутри блока ищем `mac:`, `ip:`, `name:`, `hostname:` независимо
+    от отступов — поскольку ndmc форматирует столбцом разной ширины.
+    """
+    if not text:
+        return []
+    out = []
+    cur = None
+
+    def _flush():
+        if not cur:
+            return
+        mac = _normalize_mac(cur.get("mac", ""))
+        ip  = (cur.get("ip") or "").strip()
+        if not mac and not _is_valid_ip(ip):
+            return
+        name = (cur.get("name") or cur.get("hostname") or "").strip()
+        out.append({
+            "ip":         ip if _is_valid_ip(ip) else "",
+            "mac":        mac,
+            "hostname":   name,
+            "source":     "ndm",
+            "expires_at": 0,
+            "iface":      "",
+        })
+
+    key_re = re.compile(r"^\s*([A-Za-z][\w\-]*)\s*:\s*(.*?)\s*$")
+    host_marker_re = re.compile(r"^\s*host\s*(?::|,)", re.IGNORECASE)
+
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        if host_marker_re.match(line):
+            _flush()
+            cur = {}
+            # Иногда поля идут на той же строке: "host, name = \"X\", mac = ..."
+            inline = re.findall(r"(\w+)\s*=\s*\"?([^,\"]+)\"?", line)
+            for k, v in inline:
+                cur[k.lower()] = v.strip()
+            continue
+        if cur is None:
+            continue
+        m = key_re.match(line)
+        if not m:
+            continue
+        k = m.group(1).lower()
+        v = m.group(2).strip()
+        # Поля могут встретиться несколько раз — берём первое непустое.
+        if k in ("mac", "ip", "name", "hostname") and v and k not in cur:
+            cur[k] = v
+    _flush()
+    return out
+
+
+def _read_ndm_hosts() -> list:
+    """
+    Лучшие усилия по чтению списка хостов через NDM.
+    Возвращает [] на не-Keenetic системах (когда ndmc/ndmq нет).
+    """
+    # Сначала пробуем JSON (легче и однозначнее парсится).
+    for cmd in (
+        ["ndmq", "-p", "show ip hotspot"],
+        ["ndmq", "-p", "show ip dhcp bindings"],
+    ):
+        out = _cmd_out(cmd)
+        hosts = _parse_ndm_hosts_json(out) if out else []
+        if hosts:
+            return hosts
+
+    # Затем YAML-подобный вывод ndmc.
+    for cmd in (
+        ["ndmc", "-c", "show ip hotspot"],
+        ["ndmc", "-c", "show ip dhcp bindings"],
+    ):
+        out = _cmd_out(cmd)
+        hosts = _parse_ndm_hosts_yaml(out) if out else []
+        if hosts:
+            return hosts
+    return []
+
+
 # ───────────────────────── ARP ──────────────────────────────────────
 
 def _read_arp() -> list:
@@ -173,30 +329,55 @@ def _read_arp() -> list:
 def list_devices() -> list:
     """
     Вернуть список всех видимых устройств LAN, сгруппированных по IP.
-    Записи из leases приоритетнее (hostname, expiry); из ARP добавляем
-    те, которых нет в leases.
+
+    Приоритет hostname: NDM (Keenetic) → DHCP-leases → ARP.
+    NDM-данные мерджатся как по IP, так и по MAC, поскольку в JSON-выводе
+    ndmq IP может быть пустым (хост зарегистрирован, но не в сети сейчас).
     """
+    ndm    = _read_ndm_hosts()
     leases = _read_leases()
     arp    = _read_arp()
 
     by_ip = {}
+    # 1) leases — основа: IP + hostname + expiry.
     for d in leases:
         by_ip[d["ip"]] = dict(d)
 
+    # 2) ARP — добавляет онлайн-статус и недостающие IP.
     for d in arp:
         if d["ip"] in by_ip:
             cur = by_ip[d["ip"]]
-            # Дополним iface, если из leases он был пуст.
             if not cur.get("iface"):
                 cur["iface"] = d.get("iface", "")
-            # Запомним, что устройство в данный момент онлайн (ARP видел).
             cur["source"] = "leases+arp"
-            # MAC из leases считаем авторитетнее, но если был пуст —
-            # подменим из ARP.
             if not cur.get("mac"):
                 cur["mac"] = d["mac"]
         else:
             by_ip[d["ip"]] = dict(d)
+
+    # 3) NDM — обогащаем hostname. Сверка идёт по IP, при пустом IP —
+    #    по MAC (бывает у Keenetic для статических резерваций).
+    by_mac = {rec.get("mac"): rec for rec in by_ip.values() if rec.get("mac")}
+    for d in ndm:
+        target = None
+        if d["ip"] and d["ip"] in by_ip:
+            target = by_ip[d["ip"]]
+        elif d["mac"] and d["mac"] in by_mac:
+            target = by_mac[d["mac"]]
+        if target is not None:
+            # NDM считаем авторитетным источником имени.
+            if d["hostname"]:
+                target["hostname"] = d["hostname"]
+            cur_src = target.get("source", "")
+            if "ndm" not in cur_src:
+                target["source"] = (cur_src + "+ndm").lstrip("+")
+        else:
+            # Новый хост, не виден ни в leases, ни в ARP. Добавим, если
+            # у него есть IP — иначе строка без IP мало полезна для UI.
+            if d["ip"]:
+                by_ip[d["ip"]] = dict(d)
+                if d["mac"]:
+                    by_mac[d["mac"]] = by_ip[d["ip"]]
 
     out = list(by_ip.values())
     # Стабильная сортировка по IPv4 (числовая).
@@ -223,7 +404,9 @@ def sources_status() -> dict:
     """Диагностика доступности источников (для UI)."""
     leases_paths = [p for p in _LEASE_PATHS if os.path.exists(p)]
     arp_ok = os.path.exists("/proc/net/arp")
+    ndm_ok = bool(_read_ndm_hosts())
     return {
         "leases_paths": leases_paths,
         "arp_available": arp_ok,
+        "ndm_available": ndm_ok,
     }


### PR DESCRIPTION
Manifest:
- Resolve any release with a `manifest.json` asset when no `awg-bin-*` tag exists. Picks up manual uploads (e.g. `manual-20260509174438`) that previously caused "Manifest не загружен" even though the manifest was sitting in a release on the same repo.

Devices/hostnames:
- Enrich device list via `ndmq -p "show ip hotspot"` (JSON) and `ndmc -c "show ip hotspot"` (YAML-like) on Keenetic, falling back to dnsmasq leases + ARP as before. NDM is authoritative for `name`/`hostname`, so the Devices tab no longer shows empty names for hosts that the router knows by name. Hosts not in leases/ARP but registered in the hotspot are still surfaced.
- `sources_status` now reports `ndm_available` so the UI can show which sources contributed.

AWG binary auto-tag:
- The upstream often pushes a git tag before creating a Release object, so `releases/latest` lags behind `tags`. Swap the order: resolve via `tags[0]` first, fall back to `releases/latest`. Otherwise `auto-tag` won't pick up a fresh upstream tag.
- Bump cron from daily to every 6 hours so a fresh upstream tag is picked up within hours rather than up to a day. Workflow can also be triggered manually via `workflow_dispatch` from the Actions tab.

https://claude.ai/code/session_015Hs3WaHdGeqpAtCfi8JFiK