### PR TITLE
Show installed AWG versions + Update button on Setup page

### DIFF
--- a/core/awg_installer.py
+++ b/core/awg_installer.py
@@ -24,8 +24,10 @@
 import hashlib
 import json
 import os
+import re
 import shutil
 import stat
+import subprocess
 import tarfile
 import tempfile
 import threading
@@ -63,6 +65,30 @@ def _sha256_of(path: str) -> str:
         for chunk in iter(lambda: f.read(64 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+_VERSION_RE = re.compile(r"v?(\d+(?:\.\d+){1,3}(?:[A-Za-z][\w.\-]*)?)")
+
+
+def _detect_binary_version(path: str) -> str:
+    """
+    Спросить у бинарника его версию через `--version` / `-v`.
+    Возвращает строку вроде '0.2.17' или '' если не удалось.
+    """
+    if not path or not os.path.isfile(path):
+        return ""
+    for flag in ("--version", "-v"):
+        try:
+            r = subprocess.run(
+                [path, flag], capture_output=True, text=True, timeout=4,
+            )
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            continue
+        out = (r.stdout or "") + (r.stderr or "")
+        m = _VERSION_RE.search(out)
+        if m:
+            return m.group(1)
+    return ""
 
 
 class AwgInstaller:
@@ -350,12 +376,23 @@ class AwgInstaller:
         else:
             current_dir = platform.binary_dir
 
+        # Для внешних установок версии в settings'ах нет — спросим у самих
+        # бинарников через `--version`. Это нужно UI, чтобы сравнить с
+        # доступной версией в manifest'е и предложить обновление.
+        go_version    = s["installed_go"]
+        tools_version = s["installed_tools"]
+        if is_external:
+            if not go_version and bin_go:
+                go_version = _detect_binary_version(bin_go)
+            if not tools_version and bin_awg:
+                tools_version = _detect_binary_version(bin_awg)
+
         return {
             "installed":      installed,
             "external":       is_external,
             "tag":            s["installed_tag"],
-            "go_version":     s["installed_go"],
-            "tools_version":  s["installed_tools"],
+            "go_version":     go_version,
+            "tools_version":  tools_version,
             "binary_dir":     current_dir,
             "platform_default_dir": platform.binary_dir,
             "amneziawg_go":   bin_go,

--- a/web/js/pages/awg_setup.js
+++ b/web/js/pages/awg_setup.js
@@ -374,20 +374,65 @@ const AwgSetupPage = (() => {
             );
         }
 
+        // ── Установленная версия + детект обновления ─────────────
+        const latestGo    = (manifest && manifest.amneziawg_go    && manifest.amneziawg_go.version)    || '';
+        const latestTools = (manifest && manifest.amneziawg_tools && manifest.amneziawg_tools.version) || '';
+        const latestTag   = (manifest && manifest.tag) || '';
+        const goOutdated    = !!(latestGo    && installed.go_version    && installed.go_version    !== latestGo);
+        const toolsOutdated = !!(latestTools && installed.tools_version && installed.tools_version !== latestTools);
+        const tagOutdated   = !!(latestTag   && installed.tag           && installed.tag           !== latestTag);
+        const updateAvailable = installed.installed && (goOutdated || toolsOutdated || tagOutdated);
+
+        // Если для external-установки версии так и не определились (бинарь
+        // не отвечает на --version), считаем что предложить переустановку
+        // имеет смысл всегда — но без шильда "обновление".
+        const versionsUnknown = installed.installed && installed.external &&
+                                !installed.go_version && !installed.tools_version;
+
+        function verCell(installedVer, latestVer, outdated) {
+            const cur = installedVer || '?';
+            if (!latestVer) {
+                return `<span class="awg-mono">${escapeHtml(cur)}</span>`;
+            }
+            if (outdated) {
+                return `<span class="awg-mono">${escapeHtml(cur)}</span> ` +
+                       `<span style="color: var(--warning);">→ ${escapeHtml(latestVer)}</span>`;
+            }
+            return `<span class="awg-mono">${escapeHtml(cur)}</span> ` +
+                   `<span style="color: var(--success); font-size: 11px;">(актуально)</span>`;
+        }
+
         let installedHtml = '';
         if (installed.installed) {
-            installedHtml = rowHtml(
-                installed.external ? 'info' : 'ok',
-                installed.external ? 'Установка вне нашего GUI' : 'Уже установлено',
-                installed.external
-                    ? `Найден amneziawg-go: <span class="awg-mono">${escapeHtml(installed.amneziawg_go || '')}</span><br>` +
-                      `Найден awg: <span class="awg-mono">${escapeHtml(installed.awg || '')}</span><br>` +
-                      `GUI ещё не управляет этой установкой — после переустановки она перейдёт под управление.`
-                    : `Релиз: <span class="awg-mono">${escapeHtml(installed.tag || '?')}</span>, ` +
-                      `amneziawg-go ${escapeHtml(installed.go_version || '?')}, ` +
-                      `amneziawg-tools ${escapeHtml(installed.tools_version || '?')}<br>` +
-                      `Каталог: <span class="awg-mono">${escapeHtml(installed.binary_dir || '')}</span>`
-            );
+            let kind, title, detail;
+            if (updateAvailable) {
+                kind  = 'info';
+                title = 'Доступно обновление';
+            } else if (installed.external) {
+                kind  = 'info';
+                title = versionsUnknown ? 'Установка вне нашего GUI' : 'Установка вне нашего GUI (актуально)';
+            } else {
+                kind  = 'ok';
+                title = 'Установлено и актуально';
+            }
+
+            const verLines =
+                `amneziawg-go: ${verCell(installed.go_version, latestGo, goOutdated)}<br>` +
+                `amneziawg-tools: ${verCell(installed.tools_version, latestTools, toolsOutdated)}`;
+
+            const tagLine = installed.tag
+                ? `<br>Релиз: <span class="awg-mono">${escapeHtml(installed.tag)}</span>` +
+                  (tagOutdated ? ` <span style="color: var(--warning);">→ ${escapeHtml(latestTag)}</span>` : '')
+                : (latestTag ? `<br>Свежий релиз: <span class="awg-mono">${escapeHtml(latestTag)}</span>` : '');
+
+            const pathLine = installed.external
+                ? `<br>amneziawg-go: <span class="awg-mono">${escapeHtml(installed.amneziawg_go || '')}</span>` +
+                  `<br>awg: <span class="awg-mono">${escapeHtml(installed.awg || '')}</span>` +
+                  `<br><span class="text-muted" style="font-size: 11px;">GUI ещё не управляет этой установкой — после установки она перейдёт под управление.</span>`
+                : `<br>Каталог: <span class="awg-mono">${escapeHtml(installed.binary_dir || '')}</span>`;
+
+            detail = verLines + tagLine + pathLine;
+            installedHtml = rowHtml(kind, title, detail);
         }
 
         // Куда поставим + warning'и
@@ -457,10 +502,20 @@ const AwgSetupPage = (() => {
 
         // Кнопки
         const canInstall = ready && manifest && archSupported && !op.in_progress && !installRunning;
-        const installLabel = installed.installed ? 'Переустановить' : 'Установить';
+        let installLabel;
+        if (!installed.installed) {
+            installLabel = 'Установить';
+        } else if (updateAvailable) {
+            installLabel = latestTag
+                ? `Обновить до ${latestTag}`
+                : 'Обновить';
+        } else {
+            installLabel = 'Переустановить';
+        }
+        const installBtnClass = updateAvailable ? 'btn-primary' : 'btn-success';
         const buttonsHtml = `
             <div class="actions-row" style="margin-top: 10px;">
-                <button class="btn btn-success" id="awg-btn-install"
+                <button class="btn ${installBtnClass}" id="awg-btn-install"
                         onclick="AwgSetupPage.doInstall()" ${canInstall ? '' : 'disabled'}>
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>


### PR DESCRIPTION
For external installs (binaries present, but settings.installed_tag empty) the Setup page previously showed only file paths — no version numbers and no clear "Update" button, only "Reinstall".

- Detect versions of external binaries via `<bin> --version` so the installed amneziawg-go and amneziawg-tools versions are visible even when the GUI didn't install them.
- Compare installed go/tools/tag against the manifest's latest. When any differ, show "Доступно обновление" with explicit `installed → latest` arrows per component.
- Button label adapts: "Установить" / "Обновить до <tag>" / "Переустановить" depending on state. The Update variant uses the primary (not success) accent so it stands out.

https://claude.ai/code/session_015Hs3WaHdGeqpAtCfi8JFiK