### PR TITLE
Prefer opkg over --version for installed AWG package versions

### DIFF
--- a/core/awg_installer.py
+++ b/core/awg_installer.py
@@ -70,10 +70,42 @@ def _sha256_of(path: str) -> str:
 _VERSION_RE = re.compile(r"v?(\d+(?:\.\d+){1,3}(?:[A-Za-z][\w.\-]*)?)")
 
 
+def _opkg_pkg_version(pkg_name: str) -> str:
+    """
+    Версия установленного opkg-пакета (Entware/OpenWrt).
+
+    `opkg status <pkg>` пишет `Version: vX.Y.Z` для установленных
+    пакетов. Это надёжнее, чем `--version` бинарника: апстрим
+    amneziawg-go нередко собирается без ldflags, и `--version`
+    возвращает дату сборки вместо тэга релиза.
+
+    Возвращает '' если opkg не нашёл пакет или opkg недоступен.
+    """
+    if not pkg_name:
+        return ""
+    try:
+        r = subprocess.run(
+            ["opkg", "status", pkg_name],
+            capture_output=True, text=True, timeout=4,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return ""
+    if r.returncode != 0 or not r.stdout:
+        return ""
+    for line in r.stdout.splitlines():
+        m = re.match(r"\s*Version\s*:\s*(\S+)", line)
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
 def _detect_binary_version(path: str) -> str:
     """
     Спросить у бинарника его версию через `--version` / `-v`.
     Возвращает строку вроде '0.2.17' или '' если не удалось.
+
+    Менее надёжно opkg'a: апстрим может зашить дату сборки,
+    а не релизный тэг. Используется как fallback.
     """
     if not path or not os.path.isfile(path):
         return ""
@@ -89,6 +121,20 @@ def _detect_binary_version(path: str) -> str:
         if m:
             return m.group(1)
     return ""
+
+
+def _resolve_external_version(pkg_name: str, bin_path: str) -> tuple:
+    """
+    Вернуть (version, source) — самый достоверный источник версии
+    для внешнего бинарника. source: 'opkg' | 'binary' | ''.
+    """
+    v = _opkg_pkg_version(pkg_name)
+    if v:
+        return v, "opkg"
+    v = _detect_binary_version(bin_path)
+    if v:
+        return v, "binary"
+    return "", ""
 
 
 class AwgInstaller:
@@ -376,16 +422,23 @@ class AwgInstaller:
         else:
             current_dir = platform.binary_dir
 
-        # Для внешних установок версии в settings'ах нет — спросим у самих
-        # бинарников через `--version`. Это нужно UI, чтобы сравнить с
-        # доступной версией в manifest'е и предложить обновление.
-        go_version    = s["installed_go"]
-        tools_version = s["installed_tools"]
+        # Для внешних установок версии в settings'ах нет — спрашиваем
+        # opkg (если Entware/OpenWrt), а в крайнем случае сам бинарь
+        # через --version. opkg надёжнее: апстримный amneziawg-go может
+        # вернуть дату сборки вместо релизного тэга.
+        go_version       = s["installed_go"]
+        tools_version    = s["installed_tools"]
+        go_version_src   = "settings" if go_version else ""
+        tools_version_src = "settings" if tools_version else ""
         if is_external:
-            if not go_version and bin_go:
-                go_version = _detect_binary_version(bin_go)
-            if not tools_version and bin_awg:
-                tools_version = _detect_binary_version(bin_awg)
+            if not go_version:
+                v, src = _resolve_external_version("amneziawg-go", bin_go)
+                if v:
+                    go_version, go_version_src = v, src
+            if not tools_version:
+                v, src = _resolve_external_version("amneziawg-tools", bin_awg)
+                if v:
+                    tools_version, tools_version_src = v, src
 
         return {
             "installed":      installed,
@@ -393,6 +446,8 @@ class AwgInstaller:
             "tag":            s["installed_tag"],
             "go_version":     go_version,
             "tools_version":  tools_version,
+            "go_version_source":    go_version_src,    # opkg|binary|settings|''
+            "tools_version_source": tools_version_src,
             "binary_dir":     current_dir,
             "platform_default_dir": platform.binary_dir,
             "amneziawg_go":   bin_go,

--- a/web/js/pages/awg_setup.js
+++ b/web/js/pages/awg_setup.js
@@ -378,9 +378,13 @@ const AwgSetupPage = (() => {
         const latestGo    = (manifest && manifest.amneziawg_go    && manifest.amneziawg_go.version)    || '';
         const latestTools = (manifest && manifest.amneziawg_tools && manifest.amneziawg_tools.version) || '';
         const latestTag   = (manifest && manifest.tag) || '';
-        const goOutdated    = !!(latestGo    && installed.go_version    && installed.go_version    !== latestGo);
-        const toolsOutdated = !!(latestTools && installed.tools_version && installed.tools_version !== latestTools);
-        const tagOutdated   = !!(latestTag   && installed.tag           && installed.tag           !== latestTag);
+        // opkg возвращает версии вроде `v0.2.16-1`, manifest — `0.2.18`.
+        // Нормализуем перед сравнением, чтобы не считать `v0.2.18` !== `0.2.18`.
+        const normalizeVer = v => String(v || '').trim().replace(/^v/i, '').replace(/-\d+$/, '');
+        const verEqual = (a, b) => !a || !b || normalizeVer(a) === normalizeVer(b);
+        const goOutdated    = !!(latestGo    && installed.go_version    && !verEqual(installed.go_version,    latestGo));
+        const toolsOutdated = !!(latestTools && installed.tools_version && !verEqual(installed.tools_version, latestTools));
+        const tagOutdated   = !!(latestTag   && installed.tag           && installed.tag !== latestTag);
         const updateAvailable = installed.installed && (goOutdated || toolsOutdated || tagOutdated);
 
         // Если для external-установки версии так и не определились (бинарь
@@ -389,16 +393,19 @@ const AwgSetupPage = (() => {
         const versionsUnknown = installed.installed && installed.external &&
                                 !installed.go_version && !installed.tools_version;
 
-        function verCell(installedVer, latestVer, outdated) {
+        function verCell(installedVer, latestVer, outdated, source) {
             const cur = installedVer || '?';
+            const srcHint = source
+                ? ` <span class="text-muted" style="font-size: 11px;">[${escapeHtml(source)}]</span>`
+                : '';
             if (!latestVer) {
-                return `<span class="awg-mono">${escapeHtml(cur)}</span>`;
+                return `<span class="awg-mono">${escapeHtml(cur)}</span>${srcHint}`;
             }
             if (outdated) {
-                return `<span class="awg-mono">${escapeHtml(cur)}</span> ` +
+                return `<span class="awg-mono">${escapeHtml(cur)}</span>${srcHint} ` +
                        `<span style="color: var(--warning);">→ ${escapeHtml(latestVer)}</span>`;
             }
-            return `<span class="awg-mono">${escapeHtml(cur)}</span> ` +
+            return `<span class="awg-mono">${escapeHtml(cur)}</span>${srcHint} ` +
                    `<span style="color: var(--success); font-size: 11px;">(актуально)</span>`;
         }
 
@@ -417,8 +424,8 @@ const AwgSetupPage = (() => {
             }
 
             const verLines =
-                `amneziawg-go: ${verCell(installed.go_version, latestGo, goOutdated)}<br>` +
-                `amneziawg-tools: ${verCell(installed.tools_version, latestTools, toolsOutdated)}`;
+                `amneziawg-go: ${verCell(installed.go_version, latestGo, goOutdated, installed.go_version_source)}<br>` +
+                `amneziawg-tools: ${verCell(installed.tools_version, latestTools, toolsOutdated, installed.tools_version_source)}`;
 
             const tagLine = installed.tag
                 ? `<br>Релиз: <span class="awg-mono">${escapeHtml(installed.tag)}</span>` +


### PR DESCRIPTION
`amneziawg-go --version` returns the upstream build date (e.g. '0.0.20250522') instead of the release tag because the upstream build doesn't bake `-ldflags="-X .Version=..."`. opkg knows the real package version it installed (`v0.2.16-1`).

- Query `opkg status amneziawg-go` / `amneziawg-tools` first; fall back to binary `--version` only when opkg has nothing (non-Entware systems).
- Surface `*_version_source` ('opkg' | 'binary' | 'settings') in the API so the UI can show where the number came from.
- Compare normalized versions in the UI: strip leading `v` and trailing `-N` (opkg style) so `v0.2.16-1` vs manifest `0.2.18` still triggers the "update available" path, but `v0.2.18` matches `0.2.18` and is treated as up-to-date.

https://claude.ai/code/session_015Hs3WaHdGeqpAtCfi8JFiK