### PR TITLE
Fix OpkgTun detection + refresh Step 4 done text

### DIFF
--- a/core/awg_keenetic_setup.py
+++ b/core/awg_keenetic_setup.py
@@ -63,12 +63,10 @@ def check_opkg_tun() -> dict:
 
     result["needs_opkg_tun"] = major >= 5
 
-    if result["needs_opkg_tun"]:
-        result["installed"] = _cmd_ok(["opkg", "status", "opkg-tun"])
-        result["ready"] = result["installed"] and result["tun_device"]
-    else:
-        result["installed"] = result["tun_device"]
-        result["ready"] = result["tun_device"]
+    # OpkgTun — системный компонент Keenetic, не opkg-пакет. Его наличие
+    # определяем по факту появления /dev/net/tun.
+    result["installed"] = result["tun_device"]
+    result["ready"] = result["tun_device"]
 
     if not result["ready"]:
         result["instructions"] = generate_install_instructions()

--- a/core/awg_platform.py
+++ b/core/awg_platform.py
@@ -142,9 +142,18 @@ class KeeneticPlatform(AwgPlatform):
             return 0
 
     def has_opkg_tun(self):
-        """OpkgTun нужен начиная с KeenOS 5.0."""
+        """
+        OpkgTun нужен начиная с KeenOS 5.0.
+
+        OpkgTun — это СИСТЕМНЫЙ компонент Keenetic (включается в
+        веб-админке: «Управление → Компоненты → Поддержка TUN/TAP
+        для OPKG»), а не opkg-пакет. Реальный индикатор того, что он
+        включён, — появление `/dev/net/tun`. Старая проверка
+        `opkg status opkg-tun` всегда возвращала false, потому что
+        такого opkg-пакета не существует.
+        """
         if self._version_major() >= 5:
-            return _cmd_ok(["opkg", "status", "opkg-tun"])
+            return self.tun_available()
         # На KeenOS < 5 TUN обычно доступен иначе
         return self.tun_available()
 

--- a/web/js/pages/awg_setup.js
+++ b/web/js/pages/awg_setup.js
@@ -104,7 +104,13 @@ const AwgSetupPage = (() => {
                     Шаг 4. Готово
                 </div>
                 <div id="awg-done-body" style="margin-top: 10px; font-size: 13px; color: var(--text-secondary);">
-                    AWG установлен и готов к настройке. Создание интерфейсов и WARP появятся в следующих обновлениях.
+                    AWG установлен и готов к работе. Дальше:
+                    <ul style="margin: 6px 0 0 18px; padding: 0;">
+                        <li><a href="#awg" style="color: var(--primary);">AmneziaWG → туннели</a> — статус интерфейсов, Start/Stop/Restart, peers и трафик.</li>
+                        <li><a href="#awg-configs" style="color: var(--primary);">Конфиги</a> — создание и редактирование .conf, импорт.</li>
+                        <li><a href="#awg-warp" style="color: var(--primary);">WARP</a> — нативная генерация и импорт Cloudflare WARP.</li>
+                        <li><a href="#awg-routing" style="color: var(--primary);">Routing</a> — selective routing по CIDR, доменам и устройствам.</li>
+                    </ul>
                 </div>
             </div>
 
@@ -478,7 +484,7 @@ const AwgSetupPage = (() => {
                 `${active.map(n => `<span class="awg-mono">${escapeHtml(n)}</span>`).join(', ')}<br>` +
                 `После установки новых бинарников эти процессы продолжат работу со старым кодом. ` +
                 `Чтобы переключить их на свежие бинарники, перейдите в ` +
-                `<a href="#awg-dashboard" style="color: var(--primary);">AmneziaWG → туннели</a> ` +
+                `<a href="#awg" style="color: var(--primary);">AmneziaWG → туннели</a> ` +
                 `и нажмите <strong>Restart</strong> на нужном туннеле.`
             );
         }


### PR DESCRIPTION
OpkgTun:
- OpkgTun is a Keenetic firmware system component (enabled from the router admin UI: «Управление → Компоненты → Поддержка TUN/TAP для OPKG»), NOT an opkg package. The previous probe `opkg status opkg-tun` always returned non-zero because no such package exists; the practical indicator that the component is enabled is `/dev/net/tun` becoming available. This regression only surfaced after Keenetic detection started including `ndmc`, which caused systems that previously fell through as "generic Linux" to start running the OpkgTun prerequisite check.
- KeeneticPlatform.has_opkg_tun() and awg_keenetic_setup.check_opkg_tun now both rely on tun_available().

Setup page:
- "Шаг 4. Готово" no longer claims "Создание интерфейсов и WARP появятся в следующих обновлениях" — those features shipped long ago. Replace with links to the relevant sections (туннели / конфиги / WARP / Routing). Also fix the dashboard hash route: it's `#awg`, not `#awg-dashboard`.

https://claude.ai/code/session_015Hs3WaHdGeqpAtCfi8JFiK