### PR TITLE
fix: AWG AllowedIPs=0/0 routing loop + dnsmasq detection on Debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.19.8 — AWG default route без петли + улучшения dnsmasq-preflight
+
+### Исправлено
+- **AWG up при AllowedIPs=0/0 ронял весь инет даже при пустом списке
+  selective routing** — `core/awg_manager.py:_add_default_via`. До правки
+  схема была неполная: добавлялись `ip route default dev <iface> table
+  <X>` и `ip rule add not fwmark <X> table <X>`, но fwmark на самом
+  awg-сокете не выставлялся. Из-за этого encapsulated-UDP, которые
+  amneziawg-go выплёвывает в сторону peer-endpoint'а, тоже попадали
+  под `not fwmark <X>` и заворачивались обратно в туннель —
+  получалась петля, и никакие сайты не открывались. Теперь воспроизведена
+  полная wg-quick-схема:
+  1. `awg set <iface> fwmark <X>` — encapsulated-трафик помечен;
+  2. `ip route add default dev <iface> table <X>`;
+  3. `ip rule add not fwmark <X> table <X>`;
+  4. `ip rule add table main suppress_prefixlength 0` — чтобы LAN /
+     link-local / маршрут до endpoint'а оставались через `main`.
+  Симметричный teardown добавлен в `_remove_added_routes`.
+- **Детект dnsmasq на Debian/Ubuntu** — `core/routing/dnsmasq_integration.py`.
+  Добавлены pid-файлы по новым systemd-путям (`/run/dnsmasq.pid`,
+  `/run/dnsmasq/dnsmasq.pid`), fallback `pgrep -f` и финальный
+  `systemctl show dnsmasq --property=MainPID` — раньше при отсутствии
+  `/var/run`-симлинка preflight ложно срабатывал.
+- **Текст ошибки domain-routing без dnsmasq** —
+  `core/routing/domain_rule.py`. Сообщение теперь описывает реальный
+  затык на Debian (`systemd-resolved` держит порт 53, поэтому
+  `dnsmasq.service` не стартует) и предлагает два пути: отключить
+  `DNSStubListener` или переключиться на CIDR-правило.
+
 ## v0.19.7 — Исправления GUI updater и WARP/routing
 
 ### Исправлено

--- a/core/awg_manager.py
+++ b/core/awg_manager.py
@@ -577,16 +577,61 @@ class AwgManager:
 
     def _add_default_via(self, ifname: str, family: str) -> bool:
         """
-        Простая реализация default route через интерфейс. Используем
-        отдельную таблицу <table_id> + ip rule, чтобы не ломать main.
+        Default route через интерфейс по wg-quick-схеме.
+
+        Трюк wg-quick для AllowedIPs=0/0:
+          1) `awg set <iface> fwmark <X>` — encapsulated-UDP, которые
+             amneziawg-go выплёвывает в сторону peer-endpoint'а, получают
+             этот mark. Без этого шага шаг (3) ловит ВСЕ пакеты, в т.ч.
+             наши же UDP→endpoint, и заворачивает их обратно в туннель —
+             получается петля и инет «отваливается» сразу после `up`
+             даже при пустом списке selective routing (точно как
+             описал пользователь).
+          2) `ip route add default dev <iface> table <X>` — default
+             только в нашей таблице.
+          3) `ip rule add not fwmark <X> table <X>` — всё, что НЕ
+             промаркировано awg-сокетом, идёт в эту таблицу.
+          4) `ip rule add table main suppress_prefixlength 0` — но
+             сначала смотрим main для всех маршрутов с prefix>0
+             (локалка, link-local, маршруты до WG-endpoint'а, etc.).
+             Без него LAN/гейтвей становятся недостижимы.
+
+        Mark === table_id: совпадение mark и table-id — стандартное
+        соглашение wg-quick. На семейство IPv4/IPv6 fwmark на awg-iface
+        ставится один раз (это атрибут wg-сокета, не route).
         """
         table = self._table_id_for(ifname)
+        mark  = table
+
+        # (1) fwmark на awg-сокете. Делаем один раз для семейства "-4"
+        #     (для "-6" тот же сокет, повторно не нужно).
+        if family == "-4":
+            rc, _o, err = _run([self._awg_bin(), "set", ifname,
+                                "fwmark", str(mark)])
+            if rc != 0:
+                log.warning(
+                    "awg set %s fwmark %d: %s — encapsulated-трафик не"
+                    " будет промаркирован, возможна петля маршрутизации"
+                    % (ifname, mark, (err or "").strip()),
+                    source="awg_manager",
+                )
+
+        # (2) default в нашей таблице
         rc, _o, _e = _run(["ip", family, "route", "add", "default",
                            "dev", ifname, "table", str(table)])
         if rc != 0:
             return False
+
+        # (3) not fwmark X → table X
         _run(["ip", family, "rule", "add", "not", "fwmark",
-              str(table), "table", str(table)])
+              str(mark), "table", str(table)])
+
+        # (4) main первым, но без его default. Идемпотентность по
+        #     наличию проверять не будем — `ip rule add` спокойно
+        #     создаёт дубликаты, а они дают тот же эффект; вычистим
+        #     ровно столько же при `down`.
+        _run(["ip", family, "rule", "add", "table", "main",
+              "suppress_prefixlength", "0"])
         return True
 
     def _table_id_for(self, ifname: str) -> int:
@@ -711,8 +756,12 @@ class AwgManager:
             family = r.get("family", "-4")
             if r.get("default"):
                 table = self._table_id_for(ifname)
+                # Симметричный teardown wg-quick-схемы из
+                # _add_default_via (mark == table_id).
                 _run(["ip", family, "rule", "del", "not", "fwmark",
                       str(table), "table", str(table)])
+                _run(["ip", family, "rule", "del", "table", "main",
+                      "suppress_prefixlength", "0"])
                 _run(["ip", family, "route", "flush", "table", str(table)])
             elif r.get("cidr"):
                 _run(["ip", family, "route", "del", r["cidr"], "dev", ifname])

--- a/core/routing/dnsmasq_integration.py
+++ b/core/routing/dnsmasq_integration.py
@@ -109,22 +109,45 @@ class DnsmasqIntegration:
         return os.path.join(self.find_confdir(main_conf), MANAGED_FILENAME)
 
     def get_pid(self):
-        """PID dnsmasq или 0."""
+        """PID dnsmasq или 0.
+
+        На современном Debian/Ubuntu /var/run — symlink на /run, но на
+        некоторых сборках (контейнеры, snap, NixOS) symlink'а нет, либо
+        путь к pid-файлу выбран дистрибутивом иначе. Чтобы preflight
+        в domain_rule не отваливался ложным «pid не найден», смотрим
+        обе ветки и в конце даём широкий pgrep-фолбэк.
+        """
         for pidfile in ("/opt/var/run/dnsmasq.pid",
                         "/var/run/dnsmasq.pid",
-                        "/var/run/dnsmasq/dnsmasq.pid"):
+                        "/var/run/dnsmasq/dnsmasq.pid",
+                        "/run/dnsmasq.pid",
+                        "/run/dnsmasq/dnsmasq.pid"):
             txt = _read_file(pidfile).strip()
             if txt and txt.isdigit():
                 pid = int(txt)
                 if os.path.isdir("/proc/%d" % pid):
                     return pid
-        # Фолбэк через pgrep
-        rc, out, _e = _run(["pgrep", "-x", "dnsmasq"])
-        if rc == 0 and out.strip():
-            try:
-                return int(out.strip().splitlines()[0])
-            except ValueError:
-                return 0
+        # Фолбэк через pgrep. Сначала -x (exact comm), затем -f
+        # (полный command-line) — для случаев, когда dnsmasq запущен
+        # через wrapper и `comm` отличается от "dnsmasq".
+        for args in (["pgrep", "-x", "dnsmasq"],
+                     ["pgrep", "-f", "(^|/)dnsmasq( |$)"]):
+            rc, out, _e = _run(args)
+            if rc == 0 and out.strip():
+                try:
+                    return int(out.strip().splitlines()[0])
+                except ValueError:
+                    continue
+        # Финальный фолбэк через systemctl — на чисто systemd-системах,
+        # где pid-файла может не быть совсем (Type=notify без PIDFile=).
+        rc, out, _e = _run(["systemctl", "show", "dnsmasq",
+                            "--property=MainPID", "--value"], timeout=3)
+        if rc == 0:
+            txt = (out or "").strip()
+            if txt.isdigit() and txt != "0":
+                pid = int(txt)
+                if os.path.isdir("/proc/%d" % pid):
+                    return pid
         return 0
 
     def get_version(self):

--- a/core/routing/domain_rule.py
+++ b/core/routing/domain_rule.py
@@ -199,9 +199,17 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
             return {
                 "ok": False,
                 "error": (
-                    "dnsmasq установлен, но не запущен (pid не найден)."
-                    " Запустите его (systemctl start dnsmasq /"
-                    " /etc/init.d/dnsmasq start) и повторите."
+                    "dnsmasq установлен, но не запущен. Доменное routing"
+                    " работает только через dnsmasq (он на лету"
+                    " заполняет ipset/nftset при резолве). На Debian/"
+                    "Ubuntu со штатным systemd-resolved порт 53 уже"
+                    " занят, и dnsmasq.service не стартует — нужно"
+                    " либо отключить DNSStubListener в systemd-resolved"
+                    " (`/etc/systemd/resolved.conf`: DNSStubListener=no"
+                    " + `systemctl restart systemd-resolved`), либо"
+                    " запустить dnsmasq на нестандартном порту через"
+                    " `/etc/dnsmasq.conf`. Если возиться не хочется —"
+                    " используйте правило по CIDR вместо домена."
                 ),
             }
 

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.7"
+GUI_VERSION = "0.19.8"


### PR DESCRIPTION
1) Bringing up an AWG interface with AllowedIPs=0/0 was killing all
   internet on Debian even with an empty selective-routing list.
   _add_default_via was only adding the default route and the
   `not fwmark X table X` rule, but never marked the AWG socket
   itself — so amneziawg-go's encapsulated UDP toward the peer
   endpoint also matched `not fwmark X` and got re-routed into the
   tunnel, producing a routing loop. Replaced with the full wg-quick
   pattern: `awg set <iface> fwmark <X>` + the `main
   suppress_prefixlength 0` rule (so LAN, link-local and the route
   to the endpoint keep flowing through main). Symmetric teardown
   added to _remove_added_routes.

2) On Debian/Ubuntu the dnsmasq preflight in apply_domain_rule was
   reporting "не запущен" even when the daemon was running, because
   the detector only looked at /var/run/* pidfiles and `pgrep -x`.
   Added /run/* pidfile candidates, a `pgrep -f` fallback and a
   final `systemctl show dnsmasq --property=MainPID`. Sharpened the
   error text to point users at the real Debian gotcha — the
   systemd-resolved port-53 conflict — and suggest CIDR routing as
   the easy escape hatch.

Bumped GUI_VERSION to 0.19.8.

https://claude.ai/code/session_01QBqxZVswPnKN1RNKzfCnMd