### PR TITLE
fix: pin AWG peer endpoint to physical WAN + add diagnostics button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.19.9 — Pin peer endpoint + кнопка диагностики AWG
+
+### Исправлено
+- **AWG up при AllowedIPs=0/0 продолжал ронять инет даже после
+  v0.19.8** — `core/awg_manager.py`. wg-quick-схема с `awg set fwmark`
+  работает, только если userspace-демон (amneziawg-go) реально
+  выставляет SO_MARK на свои UDP-сокеты. На части сборок этого не
+  происходит, encapsulated-трафик не маркируется и зацикливается в
+  туннеле. Теперь перед поднятием default-route'а мы **прибиваем /32
+  (или /128) host-маршрут до каждого peer.Endpoint** через текущий
+  путь main-таблицы — это гарантирует, что encapsulated-UDP пойдёт
+  через физический WAN независимо от fwmark-механики. При down
+  pinned-маршруты симметрично снимаются (но не трогаем preexisting).
+
+### Добавлено
+- **Кнопка «Диагностика» на AWG-дашборде** — собирает в одну вью
+  состояние, по которому видно, почему трафик не идёт: вывод `awg
+  show`, разбор `interface_state` (с fwmark/handshake/RX-TX), полный
+  `ip -4/-6 rule list`, `ip route show table <T>` и main для обоих
+  семейств, `ip route get <endpoint>` для каждого peer-endpoint'а и
+  хвост `log_buffer`'а по awg/routing-источникам. Открывается в
+  модальном окне с кнопкой «Копировать» — удобно вложить в баг-репорт.
+  Бэкенд: `GET /api/awg/configs/<name>/diagnostics`,
+  `AwgManager.diagnostics()`.
+
 ## v0.19.8 — AWG default route без петли + улучшения dnsmasq-preflight
 
 ### Исправлено

--- a/api/awg.py
+++ b/api/awg.py
@@ -303,6 +303,25 @@ def register(app):
         from core.awg_manager import get_awg_manager
         return {"ok": True, "status": get_awg_manager().status(name)}
 
+    @app.route("/api/awg/configs/<name>/diagnostics")
+    def awg_iface_diagnostics(name):
+        """
+        Снимок состояния туннеля для диагностики проблем с маршрутизацией.
+
+        Возвращает сырые выводы `awg show`, `ip rule list`,
+        `ip route show table <T>`, `ip route get <peer endpoint>` —
+        всё, что нужно, чтобы понять, почему трафик не идёт. Эту
+        кнопку юзер жмёт, когда «инет пропал после awg up».
+        """
+        response.content_type = "application/json; charset=utf-8"
+        from core.awg_manager import get_awg_manager
+        try:
+            return {"ok": True,
+                    "diagnostics": get_awg_manager().diagnostics(name)}
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
     @app.route("/api/awg/interfaces")
     def awg_interfaces_list():
         response.content_type = "application/json; charset=utf-8"

--- a/core/awg_manager.py
+++ b/core/awg_manager.py
@@ -437,6 +437,122 @@ class AwgManager:
             })
         return info
 
+    # ─────────── diagnostics ───────────
+
+    def diagnostics(self, name: str) -> dict:
+        """
+        Полный снимок состояния туннеля + системного routing.
+
+        Используется GUI'ем как «диагностическая кнопка», когда после
+        `awg up` пропадает инет — даёт всё, что нужно, чтобы понять,
+        куда уходят пакеты и видит ли амнеziaWG последний handshake.
+        Не дёргает `_lock`, чтобы можно было звать параллельно с
+        up/down (читаем только текущее состояние ядра).
+        """
+        ifname = self._iface_for_name(name) or name
+        table  = self._table_id_for(ifname)
+        info   = {
+            "name":     name,
+            "iface":    ifname,
+            "table_id": table,
+            "active":   False,
+            "platform": {},
+            "awg_show": "",
+            "interface_state": {},
+            "rules":  {"v4": "", "v6": ""},
+            "routes": {
+                "table_v4":  "",
+                "table_v6":  "",
+                "main_v4":   "",
+                "main_v6":   "",
+            },
+            "endpoint_routes": [],
+            "log_tail":  [],
+            "errors": [],
+        }
+
+        # platform info — куда мы вообще установлены
+        try:
+            plat = self._platform()
+            info["platform"] = {
+                "name":       getattr(plat, "name", ""),
+                "binary_dir": getattr(plat, "binary_dir", ""),
+                "config_dir": getattr(plat, "config_dir", ""),
+                "run_dir":    getattr(plat, "run_dir", ""),
+            }
+        except Exception as e:
+            info["errors"].append("platform: %s" % e)
+
+        # awg show <iface> — handshake, RX/TX, fwmark
+        rc, out, err = _run([self._awg_bin(), "show", ifname], timeout=5)
+        if rc == 0:
+            info["awg_show"] = out
+            info["active"]   = True
+        else:
+            info["awg_show"] = "(awg show failed) " + (err or "").strip()
+
+        # структурированный статус (с уже распарсенным fwmark)
+        try:
+            info["interface_state"] = self.status(ifname)
+        except Exception as e:
+            info["errors"].append("status: %s" % e)
+
+        # ip rule list — оба семейства
+        for fam_key, fam_flag in (("v4", "-4"), ("v6", "-6")):
+            rc, out, err = _run(["ip", fam_flag, "rule", "list"], timeout=5)
+            info["rules"][fam_key] = out if rc == 0 else (
+                "(rule list failed) " + (err or "").strip()
+            )
+
+        # таблица туннеля + main (с suppress_prefixlength 0)
+        for fam_key, fam_flag in (("v4", "-4"), ("v6", "-6")):
+            rc, out, _ = _run(["ip", fam_flag, "route", "show", "table",
+                               str(table)], timeout=5)
+            info["routes"]["table_" + fam_key] = out if rc == 0 else ""
+            rc, out, _ = _run(["ip", fam_flag, "route", "show", "table",
+                               "main"], timeout=5)
+            info["routes"]["main_" + fam_key] = out if rc == 0 else ""
+
+        # ip route get <peer endpoint> — самое важное для диагностики
+        # петли: видно, через что РЕАЛЬНО уходит encapsulated-UDP.
+        try:
+            cfg = self.get_config(name)
+            parsed = cfg.get("parsed") or {}
+        except Exception:
+            parsed = {}
+        for peer in parsed.get("peers", []):
+            endpoint = peer.get("Endpoint", "")
+            host, port = _parse_endpoint_host(endpoint)
+            if not host:
+                continue
+            for ip in _resolve_host(host):
+                fam_flag = "-6" if ":" in ip else "-4"
+                rc, out, _ = _run(["ip", fam_flag, "route", "get", ip],
+                                  timeout=3)
+                info["endpoint_routes"].append({
+                    "endpoint": endpoint,
+                    "ip":       ip,
+                    "family":   fam_flag,
+                    "route":    out.strip() if rc == 0 else "(get failed)",
+                })
+
+        # последние записи log_buffer'а из awg-источников
+        try:
+            from core.log_buffer import get_log_buffer
+            buf = get_log_buffer()
+            entries = buf.get_filtered(search=None, n=200) or []
+            keep_sources = {"awg_manager", "awg_installer", "awg_detector",
+                            "warp_importer", "warp_generator", "routing"}
+            info["log_tail"] = [
+                e for e in entries
+                if (e.get("source") if isinstance(e, dict) else None)
+                   in keep_sources
+            ][-80:]
+        except Exception as e:
+            info["errors"].append("log_buffer: %s" % e)
+
+        return info
+
     # ─────────── up / down ───────────
 
     def up(self, name: str) -> dict:
@@ -532,6 +648,24 @@ class AwgManager:
         # 4) маршруты из AllowedIPs (если не Table=off)
         added_routes = []
         table_off = str(iface.get("Table", "")).lower() == "off"
+
+        # 4a) ПЕРЕД default-route'ом прибиваем /32 host-маршруты до peer-
+        #     endpoint'ов через текущий физический WAN. Без этого
+        #     encapsulated-UDP, которые amneziawg-go отправляет в сторону
+        #     endpoint'а, после установки default'а в туннеле могут
+        #     зациклиться сами в себя (зависит от того, передаёт ли
+        #     userspace-демон SO_MARK во все свои сокеты — у некоторых
+        #     сборок amneziawg-go этого фикса нет). Pin endpoint'а
+        #     гарантирует корректный путь до peer'а независимо от
+        #     fwmark-механики.
+        endpoints_pinned = self._pin_peer_endpoints(ifname, cfg)
+        for p in endpoints_pinned:
+            added_routes.append({
+                "family":   p["family"],
+                "endpoint": p["dest"],
+                "preexisting": p.get("preexisting", False),
+            })
+
         if not table_off:
             for peer in cfg.get("peers", []):
                 for ip in _as_list(peer.get("AllowedIPs")):
@@ -574,6 +708,116 @@ class AwgManager:
             "message": "Интерфейс %s поднят" % ifname,
             "routes":  added_routes,
         }
+
+    def _pin_peer_endpoints(self, ifname: str, cfg: dict) -> list:
+        """
+        До установки default-route в туннеле прибиваем /32(/128) host-
+        маршруты до каждого peer.Endpoint через текущий путь main-таблицы.
+
+        Зачем: при AllowedIPs=0/0 default попадает в таблицу T. Если
+        amneziawg-go не выставляет SO_MARK на своих UDP-сокетах (бывает
+        на форках/старых билдах), encapsulated-трафик не получает
+        fwmark и попадает под `not fwmark T table T` — заворачивается
+        обратно в туннель → петля → инет умирает. Pin host-маршрута
+        гарантирует, что пакет до endpoint'а уйдёт через физический
+        WAN независимо от fwmark-механики.
+
+        Возвращает список словарей со сведениями для teardown.
+        """
+        pinned = []
+        for peer in cfg.get("peers", []):
+            endpoint = peer.get("Endpoint", "")
+            if not endpoint:
+                continue
+            host, _port = _parse_endpoint_host(endpoint)
+            if not host:
+                continue
+
+            ips = _resolve_host(host)
+            if not ips:
+                log.warning(
+                    "Не удалось зарезолвить endpoint %s — host-route не"
+                    " прибит, возможна петля маршрутизации" % host,
+                    source="awg_manager",
+                )
+                continue
+
+            for ip in ips:
+                family = "-6" if ":" in ip else "-4"
+                mask   = "/128" if family == "-6" else "/32"
+                dest   = ip + mask
+
+                # Если уже идёт через наш awg-интерфейс — значит, мы
+                # дозаписываем поверх «сломанной» прошлой сессии;
+                # сначала чистим, чтобы добавить корректный маршрут.
+                rc, out, _ = _run(["ip", family, "route", "get", ip],
+                                  timeout=3)
+                if rc != 0 or not out:
+                    continue
+                parts = out.split()
+                # `ip route get` возвращает «<dst> via <gw> dev <if> src
+                # <src> uid …» — берём первый dev/via.
+                via, dev = "", ""
+                if "via" in parts:
+                    i = parts.index("via")
+                    if i + 1 < len(parts):
+                        via = parts[i + 1]
+                if "dev" in parts:
+                    i = parts.index("dev")
+                    if i + 1 < len(parts):
+                        dev = parts[i + 1]
+
+                if dev == ifname:
+                    # Маршрут УЖЕ через наш туннель (остаток прошлой
+                    # неудачной сессии). Удалим — потом добавим корректный.
+                    _run(["ip", family, "route", "del", dest])
+                    rc, out, _ = _run(["ip", family, "route", "get", ip],
+                                      timeout=3)
+                    parts = out.split() if rc == 0 else []
+                    via, dev = "", ""
+                    if "via" in parts:
+                        i = parts.index("via")
+                        if i + 1 < len(parts):
+                            via = parts[i + 1]
+                    if "dev" in parts:
+                        i = parts.index("dev")
+                        if i + 1 < len(parts):
+                            dev = parts[i + 1]
+                    if dev == ifname or not dev:
+                        # Без default'а в main мы не сможем
+                        # восстановить путь к endpoint'у — пропускаем.
+                        log.warning(
+                            "Endpoint %s достижим только через %s — не"
+                            " могу прибить host-route" % (ip, ifname),
+                            source="awg_manager",
+                        )
+                        continue
+
+                cmd = ["ip", family, "route", "add", dest]
+                if via:
+                    cmd += ["via", via]
+                if dev:
+                    cmd += ["dev", dev]
+                rc, _o, err = _run(cmd)
+                if rc == 0:
+                    pinned.append({"family": family, "dest": dest})
+                    log.info(
+                        "AWG endpoint %s прибит через %s%s" %
+                        (dest, dev, (" via " + via) if via else ""),
+                        source="awg_manager",
+                    )
+                elif "File exists" in (err or ""):
+                    # Уже был такой маршрут (например, мы перезапускаемся).
+                    # Помечаем preexisting, чтобы не удалять чужое.
+                    pinned.append({"family": family, "dest": dest,
+                                   "preexisting": True})
+                else:
+                    log.warning(
+                        "Не удалось прибить endpoint %s: %s" %
+                        (dest, (err or "").strip()),
+                        source="awg_manager",
+                    )
+        return pinned
 
     def _add_default_via(self, ifname: str, family: str) -> bool:
         """
@@ -765,6 +1009,12 @@ class AwgManager:
                 _run(["ip", family, "route", "flush", "table", str(table)])
             elif r.get("cidr"):
                 _run(["ip", family, "route", "del", r["cidr"], "dev", ifname])
+            elif r.get("endpoint"):
+                # Pinned peer endpoint в main-таблице. Если мы его
+                # добавили (preexisting=False) — снимаем. Чужое
+                # (преexisting=True) не трогаем.
+                if not r.get("preexisting"):
+                    _run(["ip", family, "route", "del", r["endpoint"]])
 
         try:
             os.remove(path)
@@ -792,6 +1042,56 @@ class AwgManager:
 
 
 # ───────────────────────── helpers ───────────────────────────────────
+
+def _parse_endpoint_host(endpoint: str):
+    """
+    `host:port` / `[ipv6]:port` → (host, port).
+
+    Дубль `_split_endpoint` из awg_warp_in_warp, но локальный —
+    чтобы избежать циклического импорта.
+    """
+    if not endpoint:
+        return "", ""
+    s = str(endpoint).strip()
+    if s.startswith("["):
+        rb = s.find("]")
+        if rb > 0 and len(s) > rb + 1 and s[rb + 1] == ":":
+            return s[1:rb], s[rb + 2:]
+        return "", ""
+    if ":" in s:
+        host, _, port = s.rpartition(":")
+        return host, port
+    return s, ""
+
+
+def _resolve_host(host: str) -> list:
+    """Резолвить host в список уникальных IP (v4+v6). IP оставляем как есть."""
+    import socket as _s
+    if not host:
+        return []
+    # Если это уже IP — отдаём без резолва
+    try:
+        _s.inet_pton(_s.AF_INET, host)
+        return [host]
+    except (OSError, ValueError):
+        pass
+    try:
+        _s.inet_pton(_s.AF_INET6, host)
+        return [host]
+    except (OSError, ValueError):
+        pass
+    try:
+        infos = _s.getaddrinfo(host, None, type=_s.SOCK_DGRAM)
+    except (OSError, _s.gaierror):
+        return []
+    seen, out = set(), []
+    for info in infos:
+        ip = info[4][0]
+        if ip and ip not in seen:
+            seen.add(ip)
+            out.append(ip)
+    return out
+
 
 def _as_list(v):
     if v is None or v == "":

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.8"
+GUI_VERSION = "0.19.9"

--- a/web/js/pages/awg_dashboard.js
+++ b/web/js/pages/awg_dashboard.js
@@ -305,6 +305,11 @@ const AwgDashboardPage = (() => {
                                     : `<button class="btn btn-primary btn-sm" ${inUse?'disabled':''}
                                                onclick="AwgDashboardPage.up('${escapeAttr(cfg.name)}')">Start</button>`)
                             }
+                            <button class="btn btn-ghost btn-sm"
+                                    title="Снимок awg show + ip rule/route + последние логи — для диагностики проблем с маршрутизацией"
+                                    onclick="AwgDashboardPage.diagnostics('${escapeAttr(cfg.name)}')">
+                                Диагностика
+                            </button>
                             ${cfg.orphan
                                 ? ''
                                 : `<button class="btn btn-ghost btn-sm"
@@ -349,6 +354,165 @@ const AwgDashboardPage = (() => {
             busy[name] = false;
             await refresh();
         }
+    }
+
+    async function diagnostics(name) {
+        if (busy[name]) return;
+        busy[name] = true;
+        try {
+            const data = await API.get(
+                `/api/awg/configs/${encodeURIComponent(name)}/diagnostics`
+            );
+            if (!data || !data.ok) {
+                Toast.error((data && data.error) || 'Ошибка диагностики');
+                return;
+            }
+            showDiagnosticsModal(name, data.diagnostics || {});
+        } catch (err) {
+            Toast.error(err.message);
+        } finally {
+            busy[name] = false;
+        }
+    }
+
+    function showDiagnosticsModal(name, d) {
+        const text = formatDiagnostics(d);
+
+        // Минимальный модал — оверлей + контент, без зависимостей.
+        const overlay = document.createElement('div');
+        overlay.style.cssText =
+            'position:fixed;inset:0;background:rgba(0,0,0,0.55);' +
+            'display:flex;align-items:center;justify-content:center;' +
+            'z-index:10000;padding:24px;';
+        overlay.addEventListener('click', e => {
+            if (e.target === overlay) document.body.removeChild(overlay);
+        });
+
+        const box = document.createElement('div');
+        box.style.cssText =
+            'background:var(--bg-card,#1f1f1f);color:var(--text,#eaeaea);' +
+            'max-width:1000px;width:100%;max-height:85vh;' +
+            'display:flex;flex-direction:column;border-radius:8px;' +
+            'box-shadow:0 8px 28px rgba(0,0,0,0.5);overflow:hidden;';
+
+        const header = document.createElement('div');
+        header.style.cssText =
+            'padding:12px 16px;border-bottom:1px solid var(--border,#333);' +
+            'display:flex;justify-content:space-between;align-items:center;gap:12px;';
+        header.innerHTML =
+            '<strong style="font-size:14px;">Диагностика AWG: ' +
+            escapeHtml(name) + '</strong>' +
+            '<div style="display:flex;gap:8px;">' +
+                '<button class="btn btn-ghost btn-sm" id="awgDiagCopy">Копировать</button>' +
+                '<button class="btn btn-ghost btn-sm" id="awgDiagClose">Закрыть</button>' +
+            '</div>';
+
+        const body = document.createElement('pre');
+        body.style.cssText =
+            'margin:0;padding:14px 16px;overflow:auto;flex:1;' +
+            'background:var(--bg-input,#111);font-family:ui-monospace,' +
+            'SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.5;' +
+            'white-space:pre-wrap;word-break:break-word;';
+        body.textContent = text;
+
+        box.appendChild(header);
+        box.appendChild(body);
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+
+        document.getElementById('awgDiagClose').onclick =
+            () => document.body.removeChild(overlay);
+        document.getElementById('awgDiagCopy').onclick = async () => {
+            try {
+                await navigator.clipboard.writeText(text);
+                Toast.success('Скопировано');
+            } catch {
+                // Фолбэк через execCommand
+                const ta = document.createElement('textarea');
+                ta.value = text;
+                document.body.appendChild(ta);
+                ta.select();
+                try { document.execCommand('copy'); Toast.success('Скопировано'); }
+                catch { Toast.error('Не удалось скопировать'); }
+                document.body.removeChild(ta);
+            }
+        };
+    }
+
+    function formatDiagnostics(d) {
+        const lines = [];
+        const push = (label, val) => {
+            lines.push('── ' + label + ' ──');
+            lines.push(val == null || val === '' ? '(пусто)' : String(val).trimEnd());
+            lines.push('');
+        };
+
+        lines.push('zapret-gui AWG diagnostics');
+        lines.push('config:   ' + (d.name || ''));
+        lines.push('iface:    ' + (d.iface || ''));
+        lines.push('table_id: ' + (d.table_id || ''));
+        lines.push('active:   ' + (d.active ? 'yes' : 'no'));
+        if (d.platform) {
+            lines.push('platform: ' + (d.platform.name || '?') +
+                       '  run_dir=' + (d.platform.run_dir || '?'));
+        }
+        if (d.errors && d.errors.length) {
+            lines.push('errors:   ' + d.errors.join('; '));
+        }
+        lines.push('');
+
+        push('awg show', d.awg_show);
+
+        if (d.interface_state) {
+            const ifs = d.interface_state.interface || {};
+            const peers = d.interface_state.peers || [];
+            lines.push('── interface (parsed) ──');
+            lines.push('fwmark:     ' + (ifs.fwmark || '(off)'));
+            lines.push('listen_port:' + (ifs.listen_port || ''));
+            lines.push('public_key: ' + (ifs.public_key || ''));
+            peers.forEach((p, i) => {
+                lines.push('peer[' + i + ']:');
+                lines.push('  endpoint:           ' + (p.endpoint || ''));
+                lines.push('  allowed_ips:        ' + (p.allowed_ips || ''));
+                lines.push('  latest_handshake:   ' + (p.latest_handshake || ''));
+                lines.push('  rx/tx bytes:        ' +
+                           (p.rx_bytes || 0) + ' / ' + (p.tx_bytes || 0));
+            });
+            lines.push('');
+        }
+
+        push('ip -4 rule list', d.rules && d.rules.v4);
+        push('ip -6 rule list', d.rules && d.rules.v6);
+        push('ip -4 route show table ' + (d.table_id || '?'),
+             d.routes && d.routes.table_v4);
+        push('ip -6 route show table ' + (d.table_id || '?'),
+             d.routes && d.routes.table_v6);
+        push('ip -4 route show table main', d.routes && d.routes.main_v4);
+        push('ip -6 route show table main', d.routes && d.routes.main_v6);
+
+        if (d.endpoint_routes && d.endpoint_routes.length) {
+            lines.push('── ip route get <peer endpoint> ──');
+            d.endpoint_routes.forEach(er => {
+                lines.push('endpoint ' + er.endpoint + ' → ' + er.ip +
+                           ' (' + er.family + ')');
+                lines.push('  ' + (er.route || ''));
+            });
+            lines.push('');
+        }
+
+        if (d.log_tail && d.log_tail.length) {
+            lines.push('── log tail (awg/routing, последние ' +
+                       d.log_tail.length + ') ──');
+            d.log_tail.forEach(e => {
+                const ts = e.timestamp
+                    ? new Date(e.timestamp * 1000).toISOString()
+                    : '?';
+                lines.push('[' + ts + '] ' + (e.level || '') +
+                           ' [' + (e.source || '') + '] ' +
+                           (e.message || ''));
+            });
+        }
+        return lines.join('\n');
     }
 
     async function toggleAutostart(name, enabled) {
@@ -448,7 +612,7 @@ const AwgDashboardPage = (() => {
     }
 
     return {
-        render, destroy, refresh, up, down, restart,
+        render, destroy, refresh, up, down, restart, diagnostics,
         toggleAutostart, installScript, removeScript, regenerateScript,
     };
 })();


### PR DESCRIPTION
1) AllowedIPs=0/0 was still killing internet on Debian even after
   v0.19.8's wg-quick fwmark setup. The wg-quick trick assumes the
   userspace daemon honors fwmark via SO_MARK on its UDP sockets;
   some amneziawg-go builds don't, so the encapsulated traffic is
   unmarked, falls under `not fwmark X table X`, and routes back
   into the tunnel — instant loop. Fix: before adding the default
   route, pin a /32 (or /128) host route to each peer.Endpoint
   through the current main-table path. Encapsulated UDP then
   reaches the peer via the physical WAN regardless of whether
   fwmark propagates. Pinned routes are torn down on `down`
   (preexisting routes are left alone).

2) Added an "Диагностика" button on the AWG dashboard. It gathers
   `awg show`, parsed interface state (fwmark, handshake, RX/TX),
   `ip rule list` for v4/v6, `ip route show table <T>` and main,
   `ip route get <peer endpoint>` per peer, and a tail of awg/routing
   log entries — all in a copyable modal. Easy to paste into a bug
   report when the tunnel misbehaves. Backend:
   GET /api/awg/configs/<name>/diagnostics → AwgManager.diagnostics().

Bumped GUI_VERSION to 0.19.9.

https://claude.ai/code/session_01QBqxZVswPnKN1RNKzfCnMd