### PR TITLE
fix: dnsmasq setup checked binary not unit + OUI fallback for Devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.19.18 — dnsmasq setup детектит юнит + OUI-vendor в Устройствах
+
+### Исправлено
+- **«Настроить dnsmasq автоматически» падал с `Unit dnsmasq.service does
+  not exist`** на машинах, где `dnsmasq` стоит из не-пакетного источника
+  (например, бинарь в `/usr/local/bin`). `plan_auto_setup` смотрел на
+  `which dnsmasq`, видел бинарь и пропускал шаг установки пакета — а
+  без пакета нет и `dnsmasq.service`, и последующий
+  `systemctl enable/start dnsmasq` падал. Теперь проверяем именно
+  существование юнита через `systemctl cat dnsmasq.service`; если его
+  нет — добавляем шаг установки `apt-get install dnsmasq`, и
+  enable/start попадают в план только когда юнит уже есть ИЛИ
+  запланирован к установке (`will_have_unit`).
+- **Колонка «Имя» в Устройствах оставалась пустой на
+  VirtualBox/Linux-клиентах** — там у LAN-IP'ов нет ни PTR-записей, ни
+  mDNS, а `avahi-resolve` без `avahi-utils` вообще не отрабатывал.
+  Добавлен 5-й, последний фолбэк: lookup производителя по первым 3
+  байтам MAC (OUI). Зашиты ~70 самых частых OUI'ов: VirtualBox, VMware,
+  QEMU, Hyper-V, Parallels, Raspberry Pi, MikroTik, TP-Link, ASUS,
+  Apple, Samsung, Xiaomi, Huawei, Dell, HP, Lenovo, и т.д. Если OUI не
+  узнали — оставляем пусто (тащить полную базу IEEE в репозиторий
+  нерационально). Источник помечается `+oui`.
+
 ## v0.19.17 — Domain-таб больше не падает + reverse-DNS для устройств
 
 ### Исправлено

--- a/core/devices_discovery.py
+++ b/core/devices_discovery.py
@@ -410,6 +410,19 @@ def list_devices() -> list:
             if "rdns" not in cur_src:
                 rec["source"] = (cur_src + "+rdns").lstrip("+")
 
+    # 5) OUI-vendor — последний фолбэк, чтобы в UI хоть что-то было.
+    #    На VirtualBox-NAT, например, PTR'ов нет и avahi молчит — но
+    #    «VirtualBox NAT» или «Apple device» уже лучше пустой ячейки.
+    for rec in by_ip.values():
+        if rec.get("hostname"):
+            continue
+        vendor = _oui_vendor(rec.get("mac", ""))
+        if vendor:
+            rec["hostname"] = vendor
+            cur_src = rec.get("source", "")
+            if "oui" not in cur_src:
+                rec["source"] = (cur_src + "+oui").lstrip("+")
+
     out = list(by_ip.values())
     # Стабильная сортировка по IPv4 (числовая).
     def _ip_key(rec):
@@ -425,6 +438,109 @@ def list_devices() -> list:
 # из тайм-ауте может встать в секунды. Ключ — IP, значение — (hostname, ts).
 _RDNS_CACHE = {}
 _RDNS_TTL   = 30.0
+
+
+# OUI-vendor (первые 3 байта MAC) — мини-словарь для популярных
+# производителей. Цель — НЕ дать пользователю смотреть на пустую
+# колонку «Имя» в типичных средах (VirtualBox, VMware, Apple, и т.д.).
+# Если нужного OUI нет — пусть остаётся пусто; полная база IEEE OUI
+# занимает мегабайты, тащить её в репозиторий не стоит.
+_OUI_VENDORS = {
+    # Виртуализация / гипервизоры
+    "08:00:27": "VirtualBox",
+    "52:54:00": "QEMU/KVM",
+    "00:50:56": "VMware",
+    "00:0c:29": "VMware",
+    "00:05:69": "VMware",
+    "00:1c:14": "VMware",
+    "00:15:5d": "Hyper-V",
+    "00:03:ff": "Microsoft VPC",
+    "00:16:3e": "Xen",
+    "f4:5c:89": "Parallels",
+    "00:1c:42": "Parallels",
+    # Сетевое оборудование (роутеры/SOHO)
+    "00:1d:7e": "Cisco",
+    "00:23:04": "Cisco-Linksys",
+    "b8:27:eb": "Raspberry Pi",
+    "dc:a6:32": "Raspberry Pi",
+    "e4:5f:01": "Raspberry Pi",
+    "00:0d:b9": "PC Engines (APU)",
+    "4c:5e:0c": "Keenetic",
+    "f8:09:a4": "TP-Link",
+    "50:c7:bf": "TP-Link",
+    "ec:08:6b": "TP-Link",
+    "a4:2b:b0": "TP-Link",
+    "00:0c:43": "MikroTik / Ralink",
+    "6c:3b:6b": "MikroTik",
+    "08:55:31": "MikroTik",
+    "08:60:6e": "ASUS",
+    "20:cf:30": "ASUS",
+    "00:24:01": "D-Link",
+    "00:1e:58": "D-Link",
+    "00:1f:33": "Netgear",
+    "20:e5:2a": "Netgear",
+    "ec:1a:59": "Belkin",
+    "00:90:4c": "Epigram (Ubiquiti)",
+    "fc:ec:da": "Ubiquiti",
+    "f0:9f:c2": "Ubiquiti",
+    # Десктопы / NIC'и
+    "00:1b:21": "Intel",
+    "ac:de:48": "Apple",
+    "00:50:e4": "Apple",
+    "f0:18:98": "Apple",
+    "f0:79:60": "Apple",
+    "a4:5e:60": "Apple",
+    "00:25:00": "Apple",
+    "98:01:a7": "Apple",
+    "00:1e:c2": "Apple",
+    # Телефоны / гаджеты
+    "00:1a:11": "Google",
+    "f4:f5:e8": "Google / Nest",
+    "44:65:0d": "Amazon",
+    "fc:65:de": "Amazon",
+    "ec:1f:72": "Sony",
+    "00:24:e4": "Withings",
+    "00:90:4c": "Epigram",
+    "00:1d:0f": "TP-Link",
+    "20:df:b9": "Google",
+    "94:65:2d": "Huawei",
+    "f8:e7:1e": "Huawei",
+    "cc:46:d6": "Huawei",
+    "00:1a:7d": "Xiaomi (?)",
+    "8c:53:c3": "Xiaomi",
+    "f4:6b:8c": "Xiaomi",
+    "c4:0b:cb": "Xiaomi",
+    "78:11:dc": "Xiaomi",
+    "f8:8f:ca": "Samsung",
+    "00:23:99": "Samsung",
+    "04:18:0f": "Samsung",
+    "5c:0a:5b": "Samsung",
+    "1c:5c:f2": "Samsung",
+    "00:21:19": "Samsung",
+    "00:0e:8e": "SparkLAN / Realtek",
+    "52:74:f2": "Realtek",
+    "00:50:79": "Realtek",
+    # Производители ПК
+    "00:1e:c9": "Dell",
+    "b8:ca:3a": "Dell",
+    "f8:b1:56": "Dell",
+    "00:25:64": "Dell",
+    "94:de:80": "Lenovo",
+    "00:21:cc": "Lenovo",
+    "f8:8a:5e": "Lenovo",
+    "c4:8e:8f": "HP",
+    "3c:d9:2b": "HP",
+    "00:21:5a": "HP",
+    "9c:8e:99": "HP",
+}
+
+
+def _oui_vendor(mac: str) -> str:
+    """Достать производителя по первым 3 байтам MAC. '' если не знаем."""
+    if not mac or len(mac) < 8:
+        return ""
+    oui = mac[:8].lower()
+    return _OUI_VENDORS.get(oui, "")
 
 
 def _reverse_lookup(ip: str) -> str:

--- a/core/routing/dnsmasq_integration.py
+++ b/core/routing/dnsmasq_integration.py
@@ -358,19 +358,30 @@ class DnsmasqIntegration:
         steps = []
         warnings = []
 
-        binary = _which("dnsmasq")
-        if not binary:
+        # systemctl-based авто-setup имеет смысл только если у нас есть
+        # юнит dnsmasq.service. Один лишь бинарь /usr/local/bin/dnsmasq
+        # ничего не даст — `systemctl enable dnsmasq` упадёт с «Unit
+        # dnsmasq.service does not exist». Поэтому проверяем именно
+        # существование юнита, а не PATH.
+        has_unit   = self._has_dnsmasq_service()
+        has_binary = bool(_which("dnsmasq"))
+        if not has_unit:
             apt = _which("apt-get") or _which("apt")
             if apt:
                 steps.append({
                     "id":   "install_dnsmasq",
-                    "what": "Установить dnsmasq через apt-get",
+                    "what": ("Установить пакет dnsmasq через apt-get"
+                             " (бинарь %s уже есть, но systemd-юнит"
+                             " отсутствует)" % "найден"
+                             if has_binary else
+                             "Установить пакет dnsmasq через apt-get"),
                     "cmd":  "%s install -y dnsmasq" % apt,
                 })
             else:
                 warnings.append(
-                    "dnsmasq не установлен и apt-get не найден — нужно"
-                    " поставить пакет вручную для вашего дистрибутива.")
+                    "Нет ни systemd-юнита dnsmasq.service, ни apt-get/apt"
+                    " — нужно поставить пакет dnsmasq вручную для вашего"
+                    " дистрибутива.")
 
         resolved_running = self._systemctl_is_active("systemd-resolved")
         if resolved_running:
@@ -409,18 +420,26 @@ class DnsmasqIntegration:
             })
 
         # Включить и стартануть dnsmasq.
-        if not self._systemctl_is_enabled("dnsmasq"):
-            steps.append({
-                "id":   "enable_dnsmasq",
-                "what": "systemctl enable dnsmasq",
-                "cmd":  "systemctl enable dnsmasq",
-            })
-        if not self._systemctl_is_active("dnsmasq"):
-            steps.append({
-                "id":   "start_dnsmasq",
-                "what": "systemctl start dnsmasq",
-                "cmd":  "systemctl start dnsmasq",
-            })
+        # ВАЖНО: enable/start добавляем только если юнит уже есть ИЛИ
+        # запланирована его установка через apt — иначе на выполнении
+        # получим «Unit dnsmasq.service does not exist» и весь setup
+        # пойдёт красным.
+        will_have_unit = has_unit or any(
+            s["id"] == "install_dnsmasq" for s in steps
+        )
+        if will_have_unit:
+            if not has_unit or not self._systemctl_is_enabled("dnsmasq"):
+                steps.append({
+                    "id":   "enable_dnsmasq",
+                    "what": "systemctl enable dnsmasq",
+                    "cmd":  "systemctl enable dnsmasq",
+                })
+            if not has_unit or not self._systemctl_is_active("dnsmasq"):
+                steps.append({
+                    "id":   "start_dnsmasq",
+                    "what": "systemctl start dnsmasq",
+                    "cmd":  "systemctl start dnsmasq",
+                })
 
         return {
             "ok":        True,
@@ -647,6 +666,18 @@ class DnsmasqIntegration:
                         source="routing")
 
     # ─────── shaped low-level steps ───────
+
+    def _has_dnsmasq_service(self) -> bool:
+        """
+        Есть ли в системе юнит dnsmasq.service? `systemctl cat` отвечает
+        быстро и НЕ требует, чтобы сервис был запущен — нам важен сам
+        факт наличия .service-файла, чтобы потом мочь его enable/start.
+        """
+        sctl = _which("systemctl")
+        if not sctl:
+            return False
+        rc, _o, _e = _run([sctl, "cat", "--", "dnsmasq.service"], timeout=3)
+        return rc == 0
 
     def _systemctl_is_active(self, unit: str) -> bool:
         sctl = _which("systemctl")

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.17"
+GUI_VERSION = "0.19.18"


### PR DESCRIPTION
1) Setup wizard failed with "Unit dnsmasq.service does not exist".
   plan_auto_setup was using `which dnsmasq` to decide whether to add
   the apt-install step. On the user's machine a dnsmasq binary was
   already in PATH (probably from /usr/local/bin or an old custom
   install) but the Debian package wasn't installed, so there was no
   systemd unit, and the enable/start steps blew up. Switched the
   detection to `systemctl cat dnsmasq.service` (the actual thing we
   need) and now also gate enable/start on `will_have_unit`, i.e.
   only add them when the unit either exists or will be installed.

2) On Debian/VBox the Devices tab still showed an empty "Имя" column
   for everything, because rDNS via avahi-resolve / gethostbyaddr
   returns nothing in those environments (VBox NAT has no PTR
   records, and avahi-utils is rarely preinstalled). Added an OUI
   vendor lookup as the last-resort fallback after rDNS: ~70 of the
   most common OUI prefixes inline — VirtualBox, VMware, QEMU,
   Raspberry Pi, MikroTik, TP-Link, Apple, Samsung, Xiaomi, Huawei,
   Dell, HP, Lenovo, etc. When matched, we fill `hostname` with the
   vendor and tag `source` with `+oui`. Unknown OUIs stay empty — a
   full IEEE OUI dump is megabytes and not worth shipping.

Bumped GUI_VERSION to 0.19.18.

https://claude.ai/code/session_01QBqxZVswPnKN1RNKzfCnMd