### PR TITLE
Fix domain-routing by adding MASQUERADE on AWG interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.19.20 — Domain-routing: MASQUERADE на AWG-iface (без него AllowedIPs дропал пакеты)
+
+### Исправлено
+- **Domain-routing не работал, IP-routing работал.** dnsmasq получал
+  запрос, заполнял nftset/ipset, OUTPUT mangle ставил fwmark, ядро
+  переректило пакет через AWG-таблицу — но **src в IP-заголовке
+  оставался от первой маршрутной выборки (WAN_IP)**. Для fwmark
+  route lookup происходит уже ПОСЛЕ того, как src выбран по
+  default-маршруту, и ядро не пересчитывает src на ререйте. В
+  результате пакет уходил по AWG-тоннелю с src=WAN_IP, а AWG-сервер
+  дропал его по `AllowedIPs` клиента (там 10.x туннельный, а не
+  публичный). IP-routing работал, потому что `ip rule to <cidr>
+  lookup <table>` срабатывает на первом lookup'е — src сразу
+  берётся с AWG-iface.
+  Починка: в nftables/iptables backend'ах при apply domain-правила
+  ставим **MASQUERADE** на исходящий AWG-интерфейс (`oifname X
+  masquerade` в nft postrouting `type nat` / `-o X -j MASQUERADE`
+  в iptables nat). Src перепишется на AWG-IP, сервер пропустит.
+  Снимаем MASQUERADE, когда удалено последнее domain-правило на
+  этом интерфейсе. На CIDR-routing MASQUERADE — no-op (src и так
+  уже корректный).
+
 ## v0.19.19 — Domain-routing наконец-то работает: resolv.conf → 127.0.0.1
 
 ### Исправлено

--- a/core/routing/domain_rule.py
+++ b/core/routing/domain_rule.py
@@ -259,6 +259,22 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
                               (fam, r3.get("error")))
                 continue
 
+            # MASQUERADE на исходящий AWG-iface: без него пакеты,
+            # перенаправленные через fwmark уже после первой маршрутной
+            # выборки, уходят через AWG с src=WAN_IP. AWG-сервер дропает
+            # такие пакеты по AllowedIPs клиента — и весь domain-routing
+            # «работает на бумаге», IP-list работает только потому что
+            # для CIDR-правил route lookup и так попадает в таблицу AWG
+            # сразу и src сразу выбирается с AWG. См. подробный
+            # комментарий в backend.ensure_iface_masquerade().
+            mq = (backend.ensure_iface_masquerade(ifname)
+                  if backend is nftset_backend
+                  else backend.ensure_iface_masquerade(ifname, family=fam))
+            if not mq.get("ok"):
+                errors.append("masquerade %s: %s" %
+                              (fam, mq.get("error")))
+                continue
+
             added.append({"family": fam, "set": r1["name"],
                           "mark": mark, "table": table})
 
@@ -293,13 +309,26 @@ def remove_domain_rule(rule: DomainRoutingRule) -> dict:
                     "dnsmasq": _rebuild_managed_dnsmasq()}
 
         mark = _mark_for(rule.id)
-        table = _table_id_for(rule.target_iface)
+        ifname = rule.target_iface
+        table = _table_id_for(ifname)
 
         for fam in ("v4", "v6"):
             set_name = _set_name_for(rule.id, kind) + ("6" if fam == "v6" else "")
             backend.del_ip_rule_fwmark(mark, table, family=fam)
             backend.teardown_mark_rule(set_name, mark, family=fam)
             backend.destroy_set(set_name)
+
+        # MASQUERADE снимаем только если на этот же интерфейс больше
+        # нет других ВКЛЮЧЁННЫХ domain-правил — оставшиеся domain-rules
+        # на том же AWG-iface продолжают на него полагаться.
+        others = [r for r in _all_domain_rules()
+                  if r.id != rule.id and r.target_iface == ifname]
+        if not others:
+            if backend is nftset_backend:
+                backend.remove_iface_masquerade(ifname)
+            else:
+                for fam in ("v4", "v6"):
+                    backend.remove_iface_masquerade(ifname, family=fam)
 
         dn_res = _rebuild_managed_dnsmasq()
         log.info("routing: domain-правило %s снято" % rule.id,

--- a/core/routing/ipset_backend.py
+++ b/core/routing/ipset_backend.py
@@ -24,6 +24,10 @@ from core.log_buffer import log
 # существующие правила пользователя).
 PREROUTING_CHAIN = "AWG_ROUTING_PRE"
 OUTPUT_CHAIN     = "AWG_ROUTING_OUT"
+# Цепочка в таблице nat для MASQUERADE на исходящий AWG-iface
+# (без неё domain-routing уходит с src=WAN_IP и сервер дропает
+# по AllowedIPs — подробности в ensure_iface_masquerade).
+NAT_CHAIN        = "AWG_ROUTING_NAT"
 
 
 def _run(args, timeout=10):
@@ -158,6 +162,59 @@ def teardown_mark_rule(set_name: str, mark: int, family: str = "v4") -> dict:
                  "-j", "MARK", "--set-mark", str(mark)]
         _run([cmd, "-t", table, "-D", chain] + match)
     return {"ok": True}
+
+
+# ─────────────────────── masquerade (nat) ──────────────────────────
+
+def ensure_iface_masquerade(ifname: str, family: str = "v4") -> dict:
+    """
+    Идемпотентно повесить MASQUERADE на исходящий ifname в нашей
+    nat-цепочке.
+
+    Зачем: для fwmark-routing (domain-rules) src IP пакета выбирается
+    при ПЕРВОМ route lookup'е (mark=0 → main-таблица → src=WAN_IP).
+    После того как OUTPUT mangle поставит метку и ядро переректит
+    пакет через AWG-таблицу, src в IP-заголовке УЖЕ зафиксирован —
+    ядро его не пересчитывает. В итоге пакет уходит через AWG с
+    src=WAN_IP, и AWG-сервер дропает его по AllowedIPs клиента.
+    Поэтому маскарадим всё, что физически выходит через AWG — src
+    перепишется на интерфейсный IP. На CIDR-routing это no-op:
+    там src уже корректный.
+    """
+    cmd = "iptables" if family == "v4" else "ip6tables"
+    # Цепочка в nat
+    rc, _o, err = _run([cmd, "-t", "nat", "-N", NAT_CHAIN])
+    if rc != 0 and "already exists" not in (err or "").lower():
+        return {"ok": False, "error": err.strip()}
+    # Jump из POSTROUTING → NAT_CHAIN (один раз)
+    rc, out, _e = _run([cmd, "-t", "nat", "-S", "POSTROUTING"])
+    has_jump = False
+    if rc == 0:
+        for line in out.splitlines():
+            if line.strip() == "-A POSTROUTING -j %s" % NAT_CHAIN:
+                has_jump = True
+                break
+    if not has_jump:
+        _run([cmd, "-t", "nat", "-A", "POSTROUTING", "-j", NAT_CHAIN])
+    # Само правило: -o <ifname> -j MASQUERADE (идемпотентно)
+    rc, out, _e = _run([cmd, "-t", "nat", "-S", NAT_CHAIN])
+    if rc == 0:
+        needle = "-A %s -o %s -j MASQUERADE" % (NAT_CHAIN, ifname)
+        if needle in out:
+            return {"ok": True, "added": False, "ifname": ifname}
+    rc, _o, err = _run([cmd, "-t", "nat", "-A", NAT_CHAIN,
+                        "-o", ifname, "-j", "MASQUERADE"])
+    if rc != 0:
+        return {"ok": False, "error": err.strip(), "ifname": ifname}
+    return {"ok": True, "added": True, "ifname": ifname}
+
+
+def remove_iface_masquerade(ifname: str, family: str = "v4") -> dict:
+    """Удалить MASQUERADE-правило по oifname (если есть)."""
+    cmd = "iptables" if family == "v4" else "ip6tables"
+    _run([cmd, "-t", "nat", "-D", NAT_CHAIN,
+          "-o", ifname, "-j", "MASQUERADE"])
+    return {"ok": True, "ifname": ifname}
 
 
 # ─────────────────────── ip rule fwmark ─────────────────────────────

--- a/core/routing/nftset_backend.py
+++ b/core/routing/nftset_backend.py
@@ -56,12 +56,18 @@ def _ensure_table_and_chains():
     Цепочки prerouting/output типа filter с hook=mangle:
     в nft mark меняется именно через type filter hook prerouting/output
     с приоритетом mangle.
+
+    Дополнительно создаём postrouting type=nat — туда повесим
+    masquerade на исходящий AWG-интерфейс. Без MASQUERADE для
+    fwmark-маршрутизации src IP пакета остаётся от первой маршрутной
+    выборки (через WAN), и AWG-сервер дропает пакеты по AllowedIPs.
+    Подробности — в комментарии к ensure_iface_masquerade().
     """
     rc, out, _e = _run(["nft", "list", "table", "inet", TABLE_NAME])
     if rc == 0:
-        # Уже есть — проверим наличие нужных цепочек
         chains_ok = ("chain prerouting" in out and
-                     "chain output" in out)
+                     "chain output" in out and
+                     "chain postrouting" in out)
         if chains_ok:
             return True
 
@@ -71,6 +77,8 @@ def _ensure_table_and_chains():
          "{ type filter hook prerouting priority mangle; policy accept; }"],
         ["nft", "add", "chain", "inet", TABLE_NAME, "output",
          "{ type filter hook output priority mangle; policy accept; }"],
+        ["nft", "add", "chain", "inet", TABLE_NAME, "postrouting",
+         "{ type nat hook postrouting priority srcnat; policy accept; }"],
     ]
     for c in cmds:
         rc, _o, err = _run(c)
@@ -134,6 +142,65 @@ def setup_mark_rule(set_name: str, mark: int, family: str = "v4") -> dict:
         if rc != 0:
             errors.append("nft add rule %s: %s" % (chain, err.strip()))
     return {"ok": not errors, "mark": mark, "errors": errors}
+
+
+def ensure_iface_masquerade(ifname: str) -> dict:
+    """
+    Идемпотентно повесить masquerade на исходящий ifname в нашей
+    postrouting-nat цепочке.
+
+    Зачем: для fwmark-routing (domain-rules) src IP пакета выбирается
+    при ПЕРВОМ route lookup'е (mark=0 → main-таблица → src=WAN_IP).
+    После того как OUTPUT mangle поставит метку и ядро переректит пакет
+    через AWG-таблицу, src в IP-заголовке УЖЕ зафиксирован — ядро его
+    не пересчитывает. В итоге пакет уходит через AWG с src=WAN_IP,
+    и AWG-сервер дропает его по AllowedIPs (там 10.x клиента, не
+    WAN_IP). Поэтому маскарадим всё, что физически выходит через AWG —
+    src перепишется на интерфейсный IP. На CIDR-routing это no-op:
+    там src уже корректный.
+
+    Поскольку цепочка `inet`, одно правило `oifname X masquerade`
+    покрывает и v4, и v6.
+    """
+    _ensure_table_and_chains()
+    rc, out, _e = _run(["nft", "list", "chain", "inet",
+                        TABLE_NAME, "postrouting"])
+    if rc == 0:
+        needle = "oifname \"%s\" masquerade" % ifname
+        # У некоторых версий nft вывод без кавычек — учитываем обе формы
+        if needle in out or ("oifname %s masquerade" % ifname) in out:
+            return {"ok": True, "added": False, "ifname": ifname}
+
+    rc, _o, err = _run(["nft", "add", "rule", "inet", TABLE_NAME,
+                        "postrouting", "oifname", ifname, "masquerade"])
+    if rc != 0:
+        return {"ok": False, "error": err.strip(), "ifname": ifname}
+    return {"ok": True, "added": True, "ifname": ifname}
+
+
+def remove_iface_masquerade(ifname: str) -> dict:
+    """Удалить ВСЕ masquerade-правила по oifname в postrouting (по handle)."""
+    rc, out, _e = _run(["nft", "-a", "list", "chain", "inet",
+                        TABLE_NAME, "postrouting"])
+    if rc != 0:
+        return {"ok": True, "removed": 0}
+    removed = 0
+    needles = (
+        "oifname \"%s\" masquerade" % ifname,
+        "oifname %s masquerade" % ifname,
+    )
+    for line in out.splitlines():
+        if any(n in line for n in needles) and "handle" in line:
+            parts = line.rsplit("handle", 1)
+            if len(parts) == 2:
+                h = parts[1].strip().split()[0]
+                if h.isdigit():
+                    rc2, _o, _e2 = _run(["nft", "delete", "rule", "inet",
+                                          TABLE_NAME, "postrouting",
+                                          "handle", h])
+                    if rc2 == 0:
+                        removed += 1
+    return {"ok": True, "removed": removed, "ifname": ifname}
 
 
 def teardown_mark_rule(set_name: str, mark: int, family: str = "v4") -> dict:

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.19"
+GUI_VERSION = "0.19.20"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.19.19"
+VERSION="0.19.20"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"


### PR DESCRIPTION
## Summary
Domain-routing rules were not working because packets were being sent through the AWG tunnel with the wrong source IP (WAN_IP instead of the tunnel IP). This fix adds MASQUERADE rules to rewrite the source IP for packets exiting through the AWG interface.

## Problem
When domain-routing redirects packets via fwmark to the AWG routing table, the source IP is already determined from the initial route lookup (which uses the default route and WAN_IP). The kernel doesn't recalculate the source IP on the fwmark-based reroute, so packets exit the AWG tunnel with src=WAN_IP. The AWG server then drops these packets because the source IP doesn't match the client's AllowedIPs (which expect the tunnel IP). IP-routing worked because `ip rule to <cidr>` triggers on the first lookup, selecting the correct source immediately.

## Solution
Added MASQUERADE rules to both nftables and iptables backends that rewrite the source IP to the AWG interface's IP for all outgoing traffic through that interface:

- **nftset_backend.py**: 
  - Added `postrouting` chain (type nat, hook postrouting) to the table initialization
  - Implemented `ensure_iface_masquerade()` to idempotently add masquerade rules
  - Implemented `remove_iface_masquerade()` to clean up rules by handle

- **ipset_backend.py**:
  - Added `NAT_CHAIN` constant for the custom nat chain
  - Implemented `ensure_iface_masquerade()` with iptables nat rules
  - Implemented `remove_iface_masquerade()` to delete rules

- **domain_rule.py**:
  - Call `ensure_iface_masquerade()` when applying domain-routing rules
  - Call `remove_iface_masquerade()` only when the last domain-rule for an interface is removed (other rules on the same interface still depend on it)

## Implementation Details
- MASQUERADE is applied per interface, not per rule (multiple domain-rules on the same AWG interface share one masquerade rule)
- For nftables, one rule covers both IPv4 and IPv6 (inet family)
- For iptables, separate rules are created for v4 and v6
- Rules are idempotent—applying the same rule twice is safe
- MASQUERADE is a no-op for CIDR-routing since the source IP is already correct from the first lookup

https://claude.ai/code/session_01GweMctt8E7VmMg6iJmy3sy