### PR TITLE
fix: nft output chain must be type=route (not filter) for fwmark reroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.19.21 — Domain-routing наконец работает: nft output как type=route, а не filter
+
+### Исправлено
+- **Domain-routing продолжал не работать после v0.19.20.** Диагностика
+  показала: `ip rule fwmark 0x… lookup 141` стоит, default-маршрут в
+  таблице 141 ведёт на AWG, dnsmasq заполняет nftset, OUTPUT mangle
+  ставит метку — а пакет всё равно уходит через WAN. handshake AWG
+  идёт (peer показывает свежий handshake), но **реального трафика
+  нет** — только keepalive.
+  Корень: цепочка `output` в `inet awg_routing` создавалась как
+  `type filter hook output priority mangle`. **`type filter` не
+  триггерит ререйт** после изменения mark — ядро отправляет пакет по
+  УЖЕ выбранному маршруту, mark ставится «вдогонку» и `ip rule
+  fwmark` не успевает. Нужен `type route hook output` — это
+  единственный nft-тип, который сигнализирует kernel'у пере-выбрать
+  маршрут, если mark поменялся в хуке (документация nftables:
+  «type route: re-route the packet if any field affecting routing
+  is modified»). prerouting может остаться `type filter` — там
+  routing decision происходит ПОСЛЕ хука.
+  Починка: создаём output с `type route`. На uplevel обнаруживаем
+  таблицу со старым `type filter` и пересоздаём её. Соседние
+  domain-правила, которые там жили, переразлагаем автоматически.
+  Без этого фикса MASQUERADE из 0.19.20 не помогал — пакет до AWG
+  вообще не доходил.
+
 ## v0.19.20 — Domain-routing: MASQUERADE на AWG-iface (без него AllowedIPs дропал пакеты)
 
 ### Исправлено

--- a/core/routing/domain_rule.py
+++ b/core/routing/domain_rule.py
@@ -214,6 +214,17 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
             return {"ok": False,
                     "error": "Нет доступного бэкенда (ipset/nftables)"}
 
+        # Миграция nft: до v0.19.21 цепочка output создавалась как
+        # type=filter — она НЕ триггерит реререйт после изменения mark,
+        # поэтому пакеты уходили через WAN, не попадая на AWG. Если
+        # обнаружили старый тип — _ensure_table_and_chains внутри
+        # backend'а удалит таблицу и пересоздаст. Но это снимет nft
+        # state и соседних domain-правил, которые лежат в storage.
+        # Поэтому переразложим их вручную после миграции.
+        need_repave_neighbors = (
+            backend is nftset_backend and nftset_backend.needs_migration()
+        )
+
         ifname = rule.target_iface
         if not _iface_exists(ifname):
             # Регистрируем правило в managed-файле, чтобы dnsmasq
@@ -277,6 +288,34 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
 
             added.append({"family": fam, "set": r1["name"],
                           "mark": mark, "table": table})
+
+        # Если выше дёрнули миграцию nft-таблицы — соседние domain-rules,
+        # лежавшие в той же таблице, потеряли свой nft-state. Восстановим:
+        # пере-создадим set + mark-правила + masquerade для каждого. Сам
+        # ip rule fwmark и default-route в table N — на уровне kernel-
+        # routing, не nft, миграция их не трогает.
+        if need_repave_neighbors:
+            for other in _all_domain_rules():
+                if other.id == rule.id:
+                    continue
+                if not _iface_exists(other.target_iface):
+                    continue
+                o_mark  = _mark_for(other.id)
+                o_table = _table_id_for(other.target_iface)
+                o_setbase = _set_name_for(other.id, kind)
+                for fam in ("v4", "v6"):
+                    o_set = o_setbase + ("6" if fam == "v6" else "")
+                    backend.create_set(o_set, family=fam)
+                    backend.setup_mark_rule(o_set, o_mark, family=fam)
+                    ip_fam = "-6" if fam == "v6" else "-4"
+                    _ensure_table_default(other.target_iface, o_table, ip_fam)
+                    backend.add_ip_rule_fwmark(
+                        o_mark, o_table, family=fam,
+                        priority=FWMARK_PRIORITY)
+                backend.ensure_iface_masquerade(other.target_iface)
+            log.info("nft migration: переразложено %d соседних domain-правил"
+                     % max(0, len(_all_domain_rules()) - 1),
+                     source="routing")
 
         dn_res = _rebuild_managed_dnsmasq()
 

--- a/core/routing/nftset_backend.py
+++ b/core/routing/nftset_backend.py
@@ -49,34 +49,64 @@ def set_name_for(rule_id: str) -> str:
 
 # ────────────────────── table / chains ──────────────────────────────
 
+def _output_chain_type_wrong(table_listing: str) -> bool:
+    """
+    True, если в выводе `nft list table inet awg_routing` цепочка output
+    имеет старый тип `filter` вместо нужного `route`.
+
+    type=filter в output НЕ триггерит реререйтинг пакета после изменения
+    mark — ядро тихо отправляет пакет по уже выбранному (WAN) маршруту.
+    Нужен type=route. До v0.19.21 цепочка создавалась как filter, поэтому
+    у уже установленных пользователей таблицу надо мигрировать.
+    """
+    if "type filter hook output" in table_listing:
+        return True
+    return False
+
+
 def _ensure_table_and_chains():
     """
     Гарантировать, что наша таблица и цепочки существуют.
 
-    Цепочки prerouting/output типа filter с hook=mangle:
-    в nft mark меняется именно через type filter hook prerouting/output
-    с приоритетом mangle.
+    Цепочки:
+      * prerouting — type filter hook prerouting priority mangle.
+        Для forwarded-трафика mark выставляется ДО routing decision,
+        так что type filter ok.
+      * output — **type route** hook output priority mangle.
+        Для локально-генерируемых пакетов routing decision уже
+        принят к моменту OUTPUT mangle. Нужно `type route`, чтобы
+        ядро пере-рутило пакет после изменения mark. Без этого
+        пакет уходит через первый выбранный (WAN) маршрут с уже
+        стоящим mark — fwmark-rule не успевает.
+      * postrouting — type nat hook postrouting priority srcnat.
+        Туда вешаем masquerade на исходящий AWG-iface, чтобы src
+        не остался от WAN после переректа (см. ensure_iface_masquerade).
 
-    Дополнительно создаём postrouting type=nat — туда повесим
-    masquerade на исходящий AWG-интерфейс. Без MASQUERADE для
-    fwmark-маршрутизации src IP пакета остаётся от первой маршрутной
-    выборки (через WAN), и AWG-сервер дропает пакеты по AllowedIPs.
-    Подробности — в комментарии к ensure_iface_masquerade().
+    Если таблица уже есть, но output создан со старым type=filter,
+    мы её сносим целиком и пересоздаём с правильными типами. Часть
+    rules при этом теряется — caller (apply_domain_rule) повторно
+    разложит их через reapply-логику.
     """
     rc, out, _e = _run(["nft", "list", "table", "inet", TABLE_NAME])
     if rc == 0:
-        chains_ok = ("chain prerouting" in out and
-                     "chain output" in out and
-                     "chain postrouting" in out)
-        if chains_ok:
-            return True
+        if _output_chain_type_wrong(out):
+            log.info("nft migration: пересоздаю awg_routing с"
+                     " type=route hook output (was type=filter)",
+                     source="routing")
+            _run(["nft", "delete", "table", "inet", TABLE_NAME])
+        else:
+            chains_ok = ("chain prerouting" in out and
+                         "chain output" in out and
+                         "chain postrouting" in out)
+            if chains_ok:
+                return True
 
     cmds = [
         ["nft", "add", "table", "inet", TABLE_NAME],
         ["nft", "add", "chain", "inet", TABLE_NAME, "prerouting",
          "{ type filter hook prerouting priority mangle; policy accept; }"],
         ["nft", "add", "chain", "inet", TABLE_NAME, "output",
-         "{ type filter hook output priority mangle; policy accept; }"],
+         "{ type route hook output priority mangle; policy accept; }"],
         ["nft", "add", "chain", "inet", TABLE_NAME, "postrouting",
          "{ type nat hook postrouting priority srcnat; policy accept; }"],
     ]
@@ -86,6 +116,17 @@ def _ensure_table_and_chains():
             log.warning("nft init: %s: %s" % (" ".join(c), err.strip()),
                         source="routing")
     return True
+
+
+def needs_migration() -> bool:
+    """Публичная проверка: нужна ли миграция nft-таблицы (старый type=filter
+    в output). Caller (domain_rule.apply_domain_rule) использует, чтобы
+    после миграции переразложить ВСЕ enabled-правила, иначе пострадают
+    соседние rules в той же таблице."""
+    rc, out, _e = _run(["nft", "list", "table", "inet", TABLE_NAME])
+    if rc != 0:
+        return False
+    return _output_chain_type_wrong(out)
 
 
 # ────────────────────── set ops ─────────────────────────────────────

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.20"
+GUI_VERSION = "0.19.21"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.19.20"
+VERSION="0.19.21"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"


### PR DESCRIPTION
User's diagnostics on v0.19.20 showed: ip rule fwmark 0x... lookup 141 in place, default in table 141 on AWG, dnsmasq populating nftset, OUTPUT mangle setting the mark — yet handshake-only traffic, no real data through AWG. Real packets kept going through WAN despite the mark.

Root cause: the `output` chain in our `inet awg_routing` table was created as `type filter hook output priority mangle`. `type filter` does NOT trigger the kernel reroute after a mark change in the hook — the packet stays on the route picked at the first lookup (WAN). The only nft chain type that signals "re-evaluate routing if mark/ tos/daddr/sport changed" is `type route` (per nftables docs: "route: re-route the packet if any field affecting routing is modified"). This is the equivalent of iptables `mangle` semantics on OUTPUT.

`prerouting` can stay `type filter` because the routing decision happens AFTER prerouting hooks, so the mark naturally takes effect for forwarded traffic.

Fix: create the output chain with `type route`. On startup, detect existing tables with the legacy `type filter` on output and delete the whole inet awg_routing table so it gets recreated with correct types on the next apply. Neighbor domain rules in the same table lose their nft state during that recreate, so we replay them in apply_domain_rule (set + mark rule + masquerade per family) right after the migration kicks in.

Without this, the v0.19.20 MASQUERADE patch was a no-op because the packet never made it to the AWG interface to begin with — the masquerade rule had nothing to match.