### PR TITLE
fix: device routing MASQUERADE + .table CSS + routing-state diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## v0.19.22 — Device-rules: тот же MASQUERADE-фикс + диагностика routing-state + .table CSS
+
+### Исправлено
+- **Device-routing не работал по той же причине, что и domain-routing
+  до v0.19.20.** Пакеты от LAN-устройства идут через гейтвей в AWG,
+  но src остаётся LAN-IP (192.168.x.y). AWG-сервер дропает их по
+  AllowedIPs клиента (туннельный 10.x). Теперь `apply_device_rule`
+  ставит **MASQUERADE** на исходящий AWG-iface через тот же
+  `ensure_iface_masquerade`-helper, что и domain-rule. Снимается,
+  когда на этом iface не остаётся ни одного domain/device правила.
+  domain-rule при удалении теперь тоже учитывает device-rules,
+  иначе снос domain удалял masquerade, нужный для соседних device.
+- **«Поля разъезжаются» в таблицах CIDR/Domain/Device.** Класс
+  `.table` использовался в HTML, но в CSS его не было — браузер
+  применял `table-layout: auto`, при котором `<th style="width:X%">`
+  это всего лишь подсказка ширины, и контент перетирает её. Добавил
+  в `style.css` правила `.table { width: 100%; table-layout: fixed;
+  border-collapse: collapse }` + padding/border для th/td. Теперь
+  колонки сидят на месте при добавлении длинных значений.
+
+### Изменено
+- **Диагностика AWG теперь дампит routing-state.** Без этого
+  невозможно понять, почему domain/device-routing молча не
+  работает — `ip rule` и `ip route` могут быть в полном порядке,
+  но пакеты всё равно идут мимо AWG (старый `type filter` на nft
+  output, незаполненный nftset, /etc/resolv.conf указывает не на
+  127.0.0.1 и т.д.). Diagnostics-кнопка теперь даёт:
+  `nft list table inet awg_routing` целиком (видно chain types и
+  rules), наполнение всех `awgr_*` sets, наши `AWG_ROUTING_*`
+  цепочки в iptables mangle/nat (v4+v6), все `awgr_*` ipset'ы с
+  содержимым, `/etc/resolv.conf` и `/etc/systemd/resolved.conf`,
+  managed dnsmasq-файл и основной dnsmasq.conf. Если 2ip.ru
+  по-прежнему не маршрутизируется — на новом дампе сразу будет
+  видно, где конкретно сломалось.
+
 ## v0.19.21 — Domain-routing наконец работает: nft output как type=route, а не filter
 
 ### Исправлено

--- a/core/awg_manager.py
+++ b/core/awg_manager.py
@@ -481,6 +481,7 @@ class AwgManager:
             "endpoint_routes": [],
             "last_up":   None,
             "log_tail":  [],
+            "routing_state": {},
             "errors": [],
         }
 
@@ -632,6 +633,17 @@ class AwgManager:
                     "family":   fam_flag,
                     "route":    out.strip() if rc == 0 else "(get failed)",
                 })
+
+        # Полный routing-state: nft/iptables/ipset/dnsmasq managed file,
+        # /etc/resolv.conf. Без этого по диагностике невозможно понять,
+        # почему domain/device-rules не маршрутизируют — `ip rule` и
+        # `ip route` могут быть в полном порядке, а пакет всё равно не
+        # уходить через AWG (например, потому что цепочка output создана
+        # с неправильным типом и не триггерит реререйт после mark).
+        try:
+            info["routing_state"] = self._collect_routing_state()
+        except Exception as e:
+            info["errors"].append("routing_state: %s" % e)
 
         # последние записи log_buffer'а из awg-источников
         try:
@@ -866,6 +878,131 @@ class AwgManager:
         for ch in ifname:
             h = (h * 31 + ord(ch)) & 0xFFFFFFFF
         return 100 + (h % 900)
+
+    def _collect_routing_state(self) -> dict:
+        """
+        Снимок состояния firewall'а / dnsmasq, относящегося к нашему
+        selective-routing. Используется только для диагностики — мы тут
+        ничего не меняем.
+
+        Содержит сырые dump'ы:
+          * nft awg_routing (chain types, rules, sets с содержимым)
+          * iptables/ip6tables -t mangle/nat -S наших цепочек
+          * ipset list awgr_* с содержимым (если ipset-бэкенд)
+          * /etc/resolv.conf и /etc/systemd/resolved.conf
+          * managed dnsmasq-файл и состояние демона
+          * /etc/dnsmasq.conf (только наши include-строки)
+        """
+        out = {
+            "nft_table_listing": "",
+            "nft_sets":          [],
+            "iptables_mangle":   "",
+            "iptables_nat":      "",
+            "ip6tables_mangle":  "",
+            "ip6tables_nat":     "",
+            "ipset_sets":        [],
+            "resolv_conf":       "",
+            "resolved_conf":     "",
+            "dnsmasq_status":    {},
+            "dnsmasq_managed":   "",
+            "dnsmasq_main":      "",
+        }
+
+        # nft awg_routing — вся таблица сразу (показывает chain types
+        # и правила). Если type=filter для output — это причина почему
+        # domain-routing не работает.
+        rc, t, _e = _run(["nft", "list", "table", "inet", "awg_routing"],
+                         timeout=5)
+        if rc == 0:
+            out["nft_table_listing"] = t
+            # Списки наполнения: дёргаем list set отдельно, поскольку
+            # nft list table даёт только описание, без элементов.
+            try:
+                import re as _re
+                for m in _re.finditer(r"set\s+(awgr_\S+)\s*\{", t):
+                    sname = m.group(1)
+                    rc2, body, _e2 = _run([
+                        "nft", "list", "set", "inet", "awg_routing", sname
+                    ], timeout=3)
+                    out["nft_sets"].append({
+                        "name": sname,
+                        "body": body if rc2 == 0 else "(list failed)",
+                    })
+            except Exception as e:
+                out["nft_sets"].append({"error": str(e)})
+
+        # iptables: только наши цепочки, чтобы вывод не разрывал диагностику
+        for cmd_name, key_pref in (("iptables", ""), ("ip6tables", "ip6")):
+            for table_name in ("mangle", "nat"):
+                rc, dump, _e = _run([
+                    cmd_name, "-t", table_name, "-S"
+                ], timeout=5)
+                if rc != 0:
+                    continue
+                # Отфильтровываем строки, упоминающие наши цепочки/наборы,
+                # чтобы не тащить всю iptables-конфигурацию системы.
+                wanted = []
+                for line in (dump or "").splitlines():
+                    if ("AWG_ROUTING" in line or
+                            "awgr_" in line):
+                        wanted.append(line)
+                joined = "\n".join(wanted)
+                key = (("ip6tables" if key_pref else "iptables")
+                       + "_" + table_name)
+                out[key] = joined
+
+        # ipset: наполнение awgr_* (если ipset-бэкенд)
+        rc, names, _e = _run(["ipset", "list", "-name"], timeout=3)
+        if rc == 0:
+            for name in (names or "").split():
+                if not name.startswith("awgr_"):
+                    continue
+                rc2, body, _e2 = _run(["ipset", "list", name], timeout=3)
+                out["ipset_sets"].append({
+                    "name": name,
+                    "body": body if rc2 == 0 else "(list failed)",
+                })
+
+        # resolv.conf + resolved.conf
+        for k, p in (("resolv_conf",   "/etc/resolv.conf"),
+                     ("resolved_conf", "/etc/systemd/resolved.conf")):
+            try:
+                if os.path.islink(p):
+                    out[k] = "(symlink → %s)\n" % os.readlink(p)
+                    try:
+                        with open(p, "r") as f:
+                            out[k] += f.read()
+                    except (IOError, OSError):
+                        pass
+                elif os.path.isfile(p):
+                    with open(p, "r") as f:
+                        out[k] = f.read()
+            except (IOError, OSError) as e:
+                out[k] = "(read failed: %s)" % e
+
+        # dnsmasq status + managed файл
+        try:
+            from core.routing.dnsmasq_integration import DnsmasqIntegration
+            dn = DnsmasqIntegration()
+            out["dnsmasq_status"] = dn.status()
+            mf = out["dnsmasq_status"].get("managed_file") or ""
+            if mf and os.path.isfile(mf):
+                try:
+                    with open(mf, "r") as f:
+                        out["dnsmasq_managed"] = f.read()
+                except (IOError, OSError) as e:
+                    out["dnsmasq_managed"] = "(read failed: %s)" % e
+            main = out["dnsmasq_status"].get("main_config") or ""
+            if main and os.path.isfile(main):
+                try:
+                    with open(main, "r") as f:
+                        out["dnsmasq_main"] = f.read()
+                except (IOError, OSError) as e:
+                    out["dnsmasq_main"] = "(read failed: %s)" % e
+        except Exception as e:
+            out["dnsmasq_status"] = {"error": str(e)}
+
+        return out
 
     def _apply_setconf(self, ifname: str, setconf_text: str) -> dict:
         # пишем во временный файл (awg setconf хочет путь)

--- a/core/routing/device_rule.py
+++ b/core/routing/device_rule.py
@@ -24,6 +24,7 @@ import ipaddress
 import threading
 
 from core.log_buffer import log
+from core.routing import ipset_backend, nftset_backend
 from core.routing.rules import DeviceRoutingRule
 
 
@@ -147,14 +148,35 @@ def apply_device_rule(rule: DeviceRoutingRule) -> dict:
             return {"ok": False,
                     "error": "ip rule add from %s: %s" % (src, err.strip())}
 
-        log.info("routing: device-правило %s применено (src=%s → %s table %d)"
-                 % (rule.id, src, ifname, table),
+        # MASQUERADE на AWG-iface: device-правило ловит обычно forwarded-
+        # трафик от LAN-клиента (src=192.168.x.y), которому ip rule from
+        # выкручивает руль на AWG-таблицу. Пакет уходит через AWG, но src
+        # остаётся 192.168.x.y — AWG-сервер дропает его по AllowedIPs
+        # клиента (там туннельный 10.x). Без MASQUERADE device-routing
+        # «работает на бумаге»: пакеты уходят, ответов нет. Маскарадим
+        # nft-бэкендом если доступен (он покрывает v4+v6 одной inet-
+        # цепочкой), иначе через iptables. Для CIDR-rules аналогичная
+        # проблема не стоит — там src чаще локальный, и пакет берёт
+        # src=AWG_IP на первой маршрутной выборке.
+        masq_status = "skipped"
+        if nftset_backend.available():
+            mq = nftset_backend.ensure_iface_masquerade(ifname)
+            masq_status = "nft ok" if mq.get("ok") else (
+                "nft error: %s" % mq.get("error"))
+        elif ipset_backend.available():
+            mq = ipset_backend.ensure_iface_masquerade(ifname, family=fam)
+            masq_status = "iptables ok" if mq.get("ok") else (
+                "iptables error: %s" % mq.get("error"))
+
+        log.info("routing: device-правило %s применено (src=%s → %s"
+                 " table %d, masquerade=%s)"
+                 % (rule.id, src, ifname, table, masq_status),
                  source="routing")
 
         return {
             "ok":     True,
             "added":  [{"family": fam, "source": src, "table": table,
-                        "iface": ifname}],
+                        "iface": ifname, "masquerade": masq_status}],
         }
 
 
@@ -173,6 +195,35 @@ def remove_device_rule(rule: DeviceRoutingRule) -> dict:
     with _lock:
         rc, _o, _e = _run(["ip", family, "rule", "del", "from", src,
                            "lookup", str(table)])
+
+        # MASQUERADE убираем только если на этот iface не осталось
+        # никаких других routing-rules (ни domain, ни device).
+        # Проверяем через storage: загружаем правила и смотрим,
+        # ссылается ли кто-то ещё на target_iface.
+        try:
+            from core.routing import storage
+            from core.routing.rules import DomainRoutingRule
+            others = []
+            for r in storage.load_rules():
+                if not r.enabled or r.id == rule.id:
+                    continue
+                if r.target_iface != rule.target_iface:
+                    continue
+                if isinstance(r, (DeviceRoutingRule, DomainRoutingRule)):
+                    others.append(r)
+                    break
+            if not others:
+                if nftset_backend.available():
+                    nftset_backend.remove_iface_masquerade(rule.target_iface)
+                elif ipset_backend.available():
+                    for f in ("v4", "v6"):
+                        ipset_backend.remove_iface_masquerade(
+                            rule.target_iface, family=f)
+        except Exception as e:
+            log.warning("routing: cleanup masquerade %s: %s"
+                        % (rule.target_iface, e),
+                        source="routing")
+
         log.info("routing: device-правило %s снято (src=%s)"
                  % (rule.id, src), source="routing")
         return {"ok": True, "removed": (rc == 0)}

--- a/core/routing/domain_rule.py
+++ b/core/routing/domain_rule.py
@@ -358,10 +358,21 @@ def remove_domain_rule(rule: DomainRoutingRule) -> dict:
             backend.destroy_set(set_name)
 
         # MASQUERADE снимаем только если на этот же интерфейс больше
-        # нет других ВКЛЮЧЁННЫХ domain-правил — оставшиеся domain-rules
-        # на том же AWG-iface продолжают на него полагаться.
-        others = [r for r in _all_domain_rules()
-                  if r.id != rule.id and r.target_iface == ifname]
+        # нет других ВКЛЮЧЁННЫХ правил, которым masquerade нужен —
+        # domain-rules (fwmark-routing) и device-rules (forwarded
+        # трафик с чужим src). CIDR-rules не считаем: их трафик уже
+        # выходит с src=AWG_IP естественным образом.
+        from core.routing import storage as _storage
+        from core.routing.rules import DeviceRoutingRule as _DevRule
+        others = []
+        for r in _storage.load_rules():
+            if not r.enabled or r.id == rule.id:
+                continue
+            if r.target_iface != ifname:
+                continue
+            if isinstance(r, (DomainRoutingRule, _DevRule)):
+                others.append(r)
+                break
         if not others:
             if backend is nftset_backend:
                 backend.remove_iface_masquerade(ifname)

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.21"
+GUI_VERSION = "0.19.22"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.19.21"
+VERSION="0.19.22"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1589,6 +1589,38 @@ input:focus, textarea:focus, select:focus {
     }
 }
 
+/* ===== Generic .table ===== */
+/* Используется в awg_routing/awg_dashboard. Без table-layout: fixed
+ * колонки расползаются при добавлении новой строки: <th style="width:X%">
+ * с auto-layout — это только подсказка ширины, content её перетирает,
+ * и поля «разъезжаются» относительно заголовков. */
+.table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    text-align: left;
+    padding: 6px 8px;
+    vertical-align: top;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    border-bottom: 1px solid var(--border);
+}
+
+.table th {
+    font-weight: 600;
+    font-size: 12px;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+}
+
+.table tr:last-child td {
+    border-bottom: none;
+}
+
 /* ===== Blobs Page ===== */
 
 .blob-table {

--- a/web/js/pages/awg_dashboard.js
+++ b/web/js/pages/awg_dashboard.js
@@ -529,6 +529,52 @@ const AwgDashboardPage = (() => {
             lines.push('');
         }
 
+        if (d.routing_state) {
+            const rs = d.routing_state;
+            lines.push('════ ROUTING STATE (firewall / dnsmasq) ════');
+            lines.push('Снимок текущего nft/iptables/ipset/dnsmasq —');
+            lines.push('по нему видно, доходит ли пакет до AWG, заполняется');
+            lines.push('ли set после резолва, и какой type у chain output.');
+            lines.push('');
+            push('nft list table inet awg_routing', rs.nft_table_listing);
+            if (rs.nft_sets && rs.nft_sets.length) {
+                lines.push('── nft list set inet awg_routing <name> ──');
+                rs.nft_sets.forEach(s => {
+                    lines.push('• ' + (s.name || '?'));
+                    lines.push(s.body || s.error || '(empty)');
+                });
+                lines.push('');
+            }
+            push('iptables -t mangle -S (только AWG_ROUTING_*)',
+                 rs.iptables_mangle);
+            push('iptables -t nat -S (только AWG_ROUTING_*)',
+                 rs.iptables_nat);
+            push('ip6tables -t mangle -S (только AWG_ROUTING_*)',
+                 rs.ip6tables_mangle);
+            push('ip6tables -t nat -S (только AWG_ROUTING_*)',
+                 rs.ip6tables_nat);
+            if (rs.ipset_sets && rs.ipset_sets.length) {
+                lines.push('── ipset list awgr_* ──');
+                rs.ipset_sets.forEach(s => {
+                    lines.push('• ' + (s.name || '?'));
+                    lines.push(s.body || '(empty)');
+                });
+                lines.push('');
+            }
+            push('/etc/resolv.conf', rs.resolv_conf);
+            push('/etc/systemd/resolved.conf', rs.resolved_conf);
+            if (rs.dnsmasq_status) {
+                lines.push('── dnsmasq status ──');
+                Object.entries(rs.dnsmasq_status).forEach(([k, v]) => {
+                    lines.push('  ' + k + ': ' + v);
+                });
+                lines.push('');
+            }
+            push('dnsmasq managed file (zapret-gui-awg-routing.conf)',
+                 rs.dnsmasq_managed);
+            push('dnsmasq main config', rs.dnsmasq_main);
+        }
+
         if (d.last_up) {
             const lu = d.last_up;
             const savedTs = lu.saved_at


### PR DESCRIPTION
Three things in one commit because all three came from analyzing the same user's broken-domain-routing log.

1) Device routing was broken by the same MASQUERADE-omission bug that
   killed domain routing before v0.19.20. Forwarded traffic from a LAN
   device gets `ip rule from <lan-ip> lookup <table>` matched at first
   route lookup → goes out the AWG interface, but src still = the LAN
   IP (192.168.x.y). The AWG server drops it under the peer's
   AllowedIPs (tunnel 10.x). Now apply_device_rule calls the same
   ensure_iface_masquerade helper as apply_domain_rule. The teardown
   logic in both rule modules was updated to also keep masquerade in
   place if ANY domain or device rule still targets the same iface —
   otherwise removing a domain rule would yank masquerade out from
   under a device rule that still needs it.

2) The "fields scatter" UI complaint: the .table class used in
   awg_routing.js and awg_dashboard.js was never defined in style.css.
   Browsers used table-layout: auto, where `<th style="width:X%">` is
   just a hint and long content (long CIDR list, long domain list,
   pasted descriptions) overrides it. Added a real .table rule:
   `width: 100%; table-layout: fixed; border-collapse: collapse`
   plus th/td padding/border. Columns now stay aligned when rows are
   added at the bottom.

3) The AWG diagnostics dump now includes a "ROUTING STATE" section:
   full `nft list table inet awg_routing` (so we can finally SEE if
   chain output is type=route or type=filter post-migration), all
   `awgr_*` set contents on both nft and ipset backends, our
   AWG_ROUTING_* chains in iptables mangle/nat for v4 and v6,
   /etc/resolv.conf, /etc/systemd/resolved.conf, the dnsmasq managed
   file and main config, and dnsmasq.status(). Without this the
   previous two rounds of diagnostics were dark: ip rule and ip
   route looked fine but we had no visibility into whether the
   packet ever made it to the AWG interface in the first place.