### PR TITLE
fix: domain-routing set stayed empty — prepopulate + v6 set in direct…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.19.23 — Domain-routing: set был пуст — pre-population + v6-set в директиве + user=root
+
+### Исправлено
+- **nft/ipset set оставался пустым → трафик не маркировался.**
+  Диагностика v0.19.22 показала: chain output `type route` ✓,
+  MASQUERADE ✓, `ip rule fwmark` ✓, resolv.conf → 127.0.0.1 ✓,
+  dnsmasq запущен с managed-директивой ✓ — но
+  `set awgr_domain_… { type ipv4_addr }` **пустой**. Причины три,
+  и пофикшены все:
+  1. **В директиве `nftset=` был только v4-set.** 2ip.ru (как и
+     большинство сайтов) отдаёт AAAA, браузеры ходят по IPv6 первым.
+     v6-set `awgr_…6` нигде не упоминался — dnsmasq в него не писал.
+     Теперь эмитим оба set'а одной директивой:
+     `nftset=/dom/inet#awg_routing#set/inet#awg_routing#set6`.
+  2. **Браузеры с DoH (Firefox/Chrome) идут мимо dnsmasq.** dnsmasq
+     заполняет set ТОЛЬКО когда видит DNS-query, а DoH резолвит
+     через Cloudflare напрямую — query до dnsmasq не доходит, set
+     пуст. Добавил **pre-population**: при apply domain-правила сами
+     резолвим домены (v4+v6) и кладём IP в set через `nft add
+     element` / `ipset add`. Работает «на сейчас» независимо от того,
+     каким резолвером пользуется приложение.
+  3. **dnsmasq на Debian дропает CAP_NET_ADMIN.** Без него запись в
+     nftset тихо проваливается. Дефолтный `/etc/dnsmasq.conf` теперь
+     создаётся с `user=root`/`group=root`; для уже настроенных систем
+     auto-setup ретроактивно дописывает `user=root` и рестартует
+     dnsmasq (SIGHUP не применяет смену user). В UI появляется кнопка
+     «Применить обновления dnsmasq-конфига», когда есть отложенные
+     шаги.
+
 ## v0.19.22 — Device-rules: тот же MASQUERADE-фикс + диагностика routing-state + .table CSS
 
 ### Исправлено

--- a/api/routing.py
+++ b/api/routing.py
@@ -36,10 +36,19 @@ def register(app):
             preferred = ("nftset" if (dn.get("supports_nftset") and
                                       backends["nftset"])
                          else ("ipset" if backends["ipset"] else ""))
+            # Прицепляем plan, чтобы UI мог показать кнопку «применить
+            # обновления конфига», если у нас есть отложенные шаги
+            # (например ретроактивное добавление user=root после
+            # апгрейда версии).
+            try:
+                plan = dn_mod.plan_auto_setup()
+            except Exception:
+                plan = {"applicable": False, "steps": []}
             return {"ok": True, "dnsmasq": dn,
                     "backends": backends,
                     "preferred_backend": preferred,
-                    "auto_setup_applied": dn_mod.is_applied()}
+                    "auto_setup_applied": dn_mod.is_applied(),
+                    "auto_setup_plan": plan}
         except Exception as e:
             response.status = 500
             return {"ok": False, "error": str(e)}

--- a/core/routing/dnsmasq_integration.py
+++ b/core/routing/dnsmasq_integration.py
@@ -308,9 +308,17 @@ class DnsmasqIntegration:
                 fam   = blk.get("nft_family") or "inet"
                 table = blk.get("nft_table") or "awg_routing"
                 name  = blk.get("set_name") or ""
-                # dnsmasq directive: nftset=/dom1/dom2/<family>#<table>#<set>
+                # dnsmasq directive: nftset=/dom1/dom2/<spec>/<spec>...
+                # Каждый <spec> = family#table#set. У нас два set'а: v4 и v6
+                # (имя v6 = v4 + "6"). Если перечислять только v4-set, dnsmasq
+                # NIKAGDA не запишет AAAA-IP в v6-set (и весь IPv6-трафик
+                # пользователя через AWG не пойдёт — браузеры предпочитают v6).
+                # Поэтому всегда эмитим оба set'а в одной директиве.
                 joined = "/".join(doms)
-                lines.append("nftset=/%s/%s#%s#%s" % (joined, fam, table, name))
+                spec_v4 = "%s#%s#%s" % (fam, table, name)
+                spec_v6 = "%s#%s#%s6" % (fam, table, name)
+                lines.append("nftset=/%s/%s/%s" %
+                             (joined, spec_v4, spec_v6))
             else:  # ipset
                 name = blk.get("set_name") or ""
                 # dnsmasq directive: ipset=/dom1/dom2/<set>
@@ -414,13 +422,44 @@ class DnsmasqIntegration:
             })
 
         # dnsmasq.conf: если файла нет — создадим минимальный.
+        # Если есть и это НАШ файл без user=root — допишем директиву,
+        # чтобы dnsmasq не дропал CAP_NET_ADMIN на Debian (без него
+        # запись в nftset тихо проваливается).
         main_conf = self.find_main_config()
+        config_will_change = False
         if not main_conf:
             steps.append({
                 "id":   "create_dnsmasq_conf",
                 "what": "Создать /etc/dnsmasq.conf с минимальной"
                         " конфигурацией (port=53, upstream=1.1.1.1)",
                 "cmd":  "write /etc/dnsmasq.conf",
+            })
+            config_will_change = True
+        else:
+            try:
+                with open(main_conf, "r") as f:
+                    cur_text = f.read()
+                if ("Создан zapret-gui" in cur_text
+                        and "user=root" not in cur_text):
+                    steps.append({
+                        "id":   "create_dnsmasq_conf",
+                        "what": "Добавить user=root в %s (без него dnsmasq"
+                                " на Debian теряет CAP_NET_ADMIN и не"
+                                " пишет в nftset)" % main_conf,
+                        "cmd":  "append /etc/dnsmasq.conf",
+                    })
+                    config_will_change = True
+            except (IOError, OSError):
+                pass
+
+        # Если поменяли конфиг и dnsmasq уже запущен — нужен полный
+        # restart (SIGHUP не применяет смену user=).
+        if config_will_change and self._systemctl_is_active("dnsmasq"):
+            steps.append({
+                "id":   "restart_dnsmasq",
+                "what": "systemctl restart dnsmasq (применить новый"
+                        " user=root и подцепить CAP_NET_ADMIN)",
+                "cmd":  "systemctl restart dnsmasq",
             })
 
         # Включить и стартануть dnsmasq.
@@ -512,6 +551,8 @@ class DnsmasqIntegration:
                 res = self._step_enable_unit("dnsmasq")
             elif sid == "start_dnsmasq":
                 res = self._step_start_unit("dnsmasq")
+            elif sid == "restart_dnsmasq":
+                res = self._step_restart_unit("dnsmasq")
             if res is not None:
                 results.append(res)
 
@@ -863,6 +904,27 @@ class DnsmasqIntegration:
     def _step_create_default_dnsmasq_conf(self) -> dict:
         path = "/etc/dnsmasq.conf"
         if os.path.isfile(path):
+            # Если это НАШ файл (с маркером «Создан zapret-gui») — можем
+            # дописать недостающие директивы при апгрейде версии (например
+            # user=root, которая нужна для CAP_NET_ADMIN на Debian).
+            # Чужой файл не трогаем.
+            try:
+                with open(path, "r") as f:
+                    cur = f.read()
+                if "Создан zapret-gui" in cur and "user=root" not in cur:
+                    with open(path, "a") as f:
+                        f.write(
+                            "\n# Добавлено zapret-gui ретроактивно:\n"
+                            "# без user=root на Debian dnsmasq дропает\n"
+                            "# CAP_NET_ADMIN и не пишет в nftset.\n"
+                            "user=root\n"
+                            "group=root\n"
+                        )
+                    return {"step": "create_dnsmasq_conf", "ok": True,
+                            "updated": True, "path": path}
+            except (IOError, OSError) as e:
+                return {"step": "create_dnsmasq_conf", "ok": False,
+                        "error": "update %s: %s" % (path, e)}
             return {"step": "create_dnsmasq_conf", "ok": True,
                     "skipped": True,
                     "reason": "файл уже есть, не перезаписываем"}
@@ -878,6 +940,12 @@ class DnsmasqIntegration:
             "server=2606:4700:4700::1111\n"
             "server=2606:4700:4700::1001\n"
             "cache-size=1000\n"
+            "# user=root: без drop-privs у dnsmasq остаётся CAP_NET_ADMIN,\n"
+            "# и nftset=/.../inet#awg_routing#... не отваливается тихо.\n"
+            "# На Debian default-пакет ставит user=dnsmasq, и без явного\n"
+            "# CAP_NET_ADMIN в systemd-юните запись в nftset проваливается.\n"
+            "user=root\n"
+            "group=root\n"
         )
         try:
             with open(path, "w") as f:

--- a/core/routing/domain_rule.py
+++ b/core/routing/domain_rule.py
@@ -140,6 +140,57 @@ def _iface_exists(ifname: str) -> bool:
         return False
 
 
+def _prepopulate_set(set_name: str, domain: str, family: str,
+                     backend) -> dict:
+    """
+    Резолвим домен и кладём IP'шники в set СРАЗУ — без ожидания того,
+    что какой-то софт сделает DNS-запрос через dnsmasq.
+
+    Зачем: dnsmasq заполняет set ТОЛЬКО когда видит query, а браузеры
+    с DoH (Firefox/Chrome) уходят мимо системного резолвера прямиком
+    в Cloudflare DoH. dnsmasq никогда не видит query → set пуст →
+    трафик не маркируется → не маршрутизируется через AWG. У curl и
+    `dig` такой проблемы нет (они идут через libc → /etc/resolv.conf →
+    dnsmasq), но проверяет пользователь обычно браузером.
+
+    Pre-population работает «на сейчас»: на момент apply мы резолвим
+    домен и заносим IP. Если IP позже сменится (CDN, rotation) — про
+    это узнает либо dnsmasq при следующем libc-запросе, либо новый
+    apply правила. Это компромисс: 100% покрытие гарантируется только
+    если приложение реально ходит через dnsmasq.
+    """
+    import socket
+    af = socket.AF_INET6 if family == "v6" else socket.AF_INET
+    try:
+        addrinfos = socket.getaddrinfo(domain, None, af, socket.SOCK_STREAM)
+    except (socket.gaierror, OSError):
+        return {"ok": False, "added": 0, "domain": domain,
+                "family": family, "error": "resolve failed"}
+    ips = sorted({a[4][0] for a in addrinfos if a and a[4]})
+    if not ips:
+        return {"ok": True, "added": 0, "domain": domain,
+                "family": family}
+
+    import subprocess
+    added = 0
+    for ip in ips:
+        if backend is nftset_backend:
+            cmd = ["nft", "add", "element", "inet",
+                   nftset_backend.TABLE_NAME, set_name,
+                   "{ %s }" % ip]
+        else:
+            cmd = ["ipset", "add", set_name, ip, "-exist"]
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True,
+                               timeout=3)
+            if r.returncode == 0 or "exist" in (r.stderr or "").lower():
+                added += 1
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            continue
+    return {"ok": True, "added": added, "domain": domain,
+            "family": family, "ips": ips}
+
+
 def _ensure_table_default(ifname: str, table: int, family: str) -> bool:
     """Гарантировать default-route в таблице (то же, что в manager._ensure_table_default)."""
     import subprocess
@@ -319,10 +370,27 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
 
         dn_res = _rebuild_managed_dnsmasq()
 
+        # Pre-population: набиваем set'ы IP'шниками доменов прямо сейчас.
+        # Без этого браузер с DoH идёт мимо dnsmasq, set остаётся пустым,
+        # трафик не маркируется. Делаем после _rebuild_managed_dnsmasq —
+        # чтобы dnsmasq уже знал директиву (на случай гонки), а ТЕПЕРЬ
+        # ещё и кладём IP сами через nft/ipset, не дожидаясь, пока кто-то
+        # сделает резолв через libc.
+        prepop_results = []
+        set_base_v4 = _set_name_for(rule.id, kind)
+        set_base_v6 = set_base_v4 + "6"
+        for domain in (rule.domains or []):
+            prepop_results.append(
+                _prepopulate_set(set_base_v4, domain, "v4", backend))
+            prepop_results.append(
+                _prepopulate_set(set_base_v6, domain, "v6", backend))
+        prepop_added = sum(r.get("added", 0) for r in prepop_results)
+
         ok = bool(added) and not errors and dn_res.get("ok", True)
         log.info(
-            "routing: domain-правило %s применено (iface=%s, %d записей, %d ошибок)"
-            % (rule.id, ifname, len(added), len(errors)),
+            "routing: domain-правило %s применено (iface=%s, %d записей,"
+            " %d ошибок, prepop=%d IP)"
+            % (rule.id, ifname, len(added), len(errors), prepop_added),
             source="routing",
         )
         return {
@@ -331,6 +399,8 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
             "errors":  errors,
             "backend": kind,
             "dnsmasq": dn_res,
+            "prepop":  {"total_ips_added": prepop_added,
+                        "per_domain": prepop_results},
         }
 
 

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.22"
+GUI_VERSION = "0.19.23"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.19.22"
+VERSION="0.19.23"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"

--- a/web/js/pages/awg_routing.js
+++ b/web/js/pages/awg_routing.js
@@ -299,10 +299,17 @@ const AwgRoutingPage = (() => {
         // только запустить), либо есть бэкенд (можно поставить dnsmasq).
         const needsSetup = !dnReady &&
             (!!dn.available || !!backends.ipset || !!backends.nftset);
-        const setupButton = needsSetup
+        // Также показываем кнопку, если auto_setup имеет применимые шаги
+        // (например, при апгрейде версии: новая версия требует user=root
+        // в dnsmasq.conf, и нашу запись надо добавить ретроактивно).
+        const setupPlanHasSteps = !!(dnsmasqInfo &&
+            dnsmasqInfo.auto_setup_plan &&
+            dnsmasqInfo.auto_setup_plan.applicable);
+        const setupButton = (needsSetup || setupPlanHasSteps)
             ? `<button class="btn btn-primary btn-sm"
                        onclick="AwgRoutingPage.runDnsmasqSetup()">
-                   Настроить dnsmasq автоматически
+                   ${needsSetup ? 'Настроить dnsmasq автоматически'
+                                 : 'Применить обновления dnsmasq-конфига'}
                </button>`
             : '';
         const revertButton = setupApplied && dnReady


### PR DESCRIPTION
…ive + user=root

The v0.19.22 diagnostics finally showed the smoking gun: every prior fix was in place (output chain type=route, MASQUERADE on the AWG iface, ip rule fwmark, resolv.conf → 127.0.0.1, dnsmasq running with the managed nftset directive) — yet the nft set itself was EMPTY. No IPs, so nothing matched `ip daddr @set`, so nothing got marked. Three independent reasons, all fixed:

1) The nftset= directive only listed the v4 set. 2ip.ru (like most
   sites) serves AAAA records and browsers prefer IPv6, but the v6 set
   awgr_…6 was never referenced, so dnsmasq never populated it. Now we
   emit both sets in one directive:
   nftset=/dom/inet#awg_routing#set/inet#awg_routing#set6
   (dnsmasq tells specs from domains by the '#').

2) Browsers with DoH (Firefox/Chrome default) resolve via Cloudflare
   directly, bypassing /etc/resolv.conf → dnsmasq never sees the query
   → set stays empty. Added eager pre-population: apply_domain_rule now
   resolves each domain (v4+v6) itself and inserts the IPs straight
   into the set via `nft add element` / `ipset add`. Works regardless
   of which resolver the app uses. dnsmasq still backfills new/rotated
   IPs for apps that do go through it.

3) On Debian dnsmasq drops CAP_NET_ADMIN after privdrop, and nftset
   writes then fail silently. The auto-generated /etc/dnsmasq.conf now
   sets user=root/group=root. For already-configured systems,
   plan_auto_setup detects our config lacking user=root, appends it,
   and restarts dnsmasq (SIGHUP doesn't re-apply user=). The Routing
   tab surfaces a "Применить обновления dnsmasq-конфига" button when
   such deferred steps exist (status endpoint now returns auto_setup_plan).