### PR TITLE
fix(workflow): убрать with_ech из sing-box build tags

### DIFF
--- a/.github/workflows/build-singbox-binaries.yml
+++ b/.github/workflows/build-singbox-binaries.yml
@@ -52,9 +52,10 @@ env:
   #   with_grpc     — VLESS+gRPC transport
   #   with_wireguard — WireGuard outbound (комплементарен AWG)
   #   with_utls     — uTLS / Reality (для VLESS)
-  #   with_ech      — Encrypted ClientHello (часто требуется для
-  #                   обхода SNI-фильтров)
-  SINGBOX_TAGS: 'with_quic with_grpc with_wireguard with_utls with_ech'
+  # ВАЖНО: НЕ включаем with_ech — начиная с sing-box 1.10 ECH
+  # реализован в stdlib, отдельный тэг deprecated и при попытке
+  # сборки даёт ошибку «cannot use string constant as int».
+  SINGBOX_TAGS: 'with_quic with_grpc with_wireguard with_utls'
 
 jobs:
   # ── 0. Авто-детект новых версий апстрима (только cron) ─────


### PR DESCRIPTION
sing-box 1.10+ перенёс ECH в stdlib, и build-tag `with_ech` теперь deprecated. При попытке сборки выдаёт:
    common/tls/ech_tag_stub.go:5:13: cannot use "Due to the migration
    to stdlib, the separate `with_ech` build tag has been deprecated
    and is no longer needed, please update your build configuration."
    (untyped string constant) as int value in variable declaration

Это специальный compile-time guard в апстриме, чтобы пользователи обновили build configuration. Убираем тэг — ECH-функциональность остаётся, просто теперь идёт через std crypto/tls.