### PR TITLE
Firewall persistence & blob registry: parity with nfqws2-keenetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## v0.20.0 — Паритет с nfqws2-keenetic: персистентность правил, blob'ы, firewall
+
+Перенос ключевых решений из проекта nfqws/nfqws2-keenetic — устраняет случаи,
+когда обход DPI «молча» не работал по сравнению с нативным пакетом.
+
+### Исправлено
+- **Именованные blob'ы не регистрировались → пустые fake-пакеты.** Компактные
+  каталоги (basic/advanced) ссылались на `blob=tls_google` и т.п. через
+  метаполе `blobs =`, но декларацию `--blob=NAME:@bin/file.bin` не несли —
+  nfqws2 слал пустой fake, и обход не срабатывал. Добавлен реестр блобов
+  (`core/blob_registry.py`, 59 алиасов), декларации подмешиваются автоматически.
+- **Рассинхронизация fwmark/queue в автозапуске.** Сгенерированный S99zapret
+  использовал `fwmark=0x10000` и `queue=200`, а живой путь — `0x40000000`/`300`,
+  и не передавал `--fwmark/--user/--lua-init`. Итог: петля/дубликаты пакетов и
+  неработающий `--lua-desync`. Команда запуска теперь единая (compose_command).
+- **Правила firewall ставились только на исходящее направление.** Добавлены
+  PREROUTING (ответный трафик), RETURN для MARK_EXCLUDE, NAT MASQUERADE для UDP
+  и обработка TCP-флагов (fin/rst/syn,ack) — паритет с nfqws2-keenetic, и для
+  iptables, и для nftables.
+- **conntrack не тюнился** → ядро дропало out-of-window сегменты десинка. Теперь
+  при применении правил выставляются `nf_conntrack_tcp_be_liberal=1` и
+  `nf_conntrack_checksum=0`.
+
+### Добавлено
+- **Персистентность firewall-правил** (`core/firewall_persistence.py`): хуки
+  переустановки правил после flush'а системного firewall —
+  `/opt/etc/ndm/netfilter.d/100-zapret-gui.sh` (Keenetic NDMS) и
+  `/etc/hotplug.d/firewall/90-zapret-gui` (OpenWrt). Это главная причина, по
+  которой обход «отваливался» на роутерах. Статус хуков виден в диагностике.
+- **Режимы списков** (`filter.mode`): `none` / `hostlist` / `autohostlist`
+  (`--hostlist-auto` — nfqws2 сам добавляет недоступные домены) / `ipset`, плюс
+  подключение exclude-списка `netrogat.txt`.
+- **Расширенные дефолтные порты**: TCP `80,443,2053,2083,2087,2096,5222,8443`,
+  UDP `443,3478:3481,5349,19294:19344,49152:65535` (QUIC, STUN/TURN, Discord
+  voice). Существующим установкам расширяются только нетронутые значения.
+- **`--bind-fix4/6`** при нескольких WAN-интерфейсах.
+- **Автозапуск на чистом OpenWrt (procd)** — раньше был «unsupported».
+
 ## v0.19.29 — Routing: форвард LAN→туннель резался FORWARD-policy DROP + понятная ошибка dnsmasq
 
 ### Исправлено

--- a/core/autostart_manager.py
+++ b/core/autostart_manager.py
@@ -46,6 +46,247 @@ LOCAL_INIT_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "init.
 LOCAL_SCRIPT_PATH = os.path.join(LOCAL_INIT_DIR, SCRIPT_NAME)
 
 
+# Шаблон init-скрипта S99zapret. Плейсхолдеры вида @NAME@ подставляются в
+# _generate_script(). Firewall-логика портирована из nfqws2-keenetic
+# (etc/init.d/common): отдельные цепочки nfqws_post/nfqws_pre/nfqws_nat,
+# метки MARK_PROCESSED/MARK_EXCLUDE, правила на оба направления, NAT
+# MASQUERADE для UDP, обработка TCP-флагов и тюнинг conntrack через sysctl.
+#
+# Подкоманды firewall_iptables/firewall_ip6tables/firewall_stop позволяют
+# ndm-хуку (Keenetic) и hotplug-хуку (OpenWrt) переустанавливать правила
+# после flush'а системного firewall — без этого правила слетают и nfqws2
+# работает «вхолостую».
+_S99ZAPRET_TEMPLATE = r"""#!/bin/sh
+#
+# Zapret Web-GUI — автозапуск nfqws2
+# Сгенерировано автоматически. Не редактируйте вручную — изменения затрутся
+# при следующей генерации из GUI.
+#
+# Стратегия: @STRATEGY_NAME@ (@STRATEGY_ID@)
+#
+
+SCRIPT_NAME="S99zapret"
+NFQWS_BIN="@NFQWS_BIN@"
+NFQWS_ARGS="@NFQWS_ARGS@"
+PID_FILE="/var/run/zapret-nfqws.pid"
+
+QUEUE_NUM="@QUEUE_NUM@"
+PORTS_TCP="@PORTS_TCP@"
+PORTS_UDP="@PORTS_UDP@"
+MAX_PKT_OUT="@TCP_PKT@"
+MAX_PKT_OUT_UDP="@UDP_PKT@"
+MAX_PKT_IN=15
+MARK_PROCESSED="@MARK_PROCESSED@"
+MARK_EXCLUDE="@MARK_EXCLUDE@"
+IPV6_ENABLED="@IPV6_ENABLED@"
+WAN_IFACES="@WAN_IFACES@"
+
+IPT_GROUP_POST="nfqws_post"
+IPT_GROUP_PRE="nfqws_pre"
+IPT_GROUP_NAT="nfqws_nat"
+
+JNFQ="-j NFQUEUE --queue-num $QUEUE_NUM --queue-bypass"
+CONN_CHECK="-m mark ! --mark $MARK_PROCESSED"
+CB_ORIG="-m connbytes --connbytes-dir=original --connbytes-mode=packets"
+CB_REPLY="-m connbytes --connbytes-dir=reply --connbytes-mode=packets"
+
+is_running() {
+    [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE" 2>/dev/null)" 2>/dev/null
+}
+
+kernel_modules() {
+    modprobe -a -q nfnetlink_queue xt_multiport xt_connbytes xt_NFQUEUE xt_CONNMARK xt_connmark nf_conntrack 2>/dev/null
+}
+
+system_config() {
+    sysctl -w net.netfilter.nf_conntrack_checksum=0 >/dev/null 2>&1
+    sysctl -w net.netfilter.nf_conntrack_tcp_be_liberal=1 >/dev/null 2>&1
+}
+
+# Перечень интерфейсов для итерации. Пусто → один проход без -o/-i (все).
+_iface_list() {
+    if [ -n "$WAN_IFACES" ]; then
+        echo "$WAN_IFACES"
+    else
+        echo "__ALL__"
+    fi
+}
+
+_firewall_start() {
+    CMD="$1"  # iptables | ip6tables
+
+    $CMD -w -t mangle -N $IPT_GROUP_POST 2>/dev/null
+    $CMD -w -t mangle -F $IPT_GROUP_POST
+    $CMD -w -t mangle -C POSTROUTING -j $IPT_GROUP_POST 2>/dev/null || \
+        $CMD -w -t mangle -A POSTROUTING -j $IPT_GROUP_POST
+
+    $CMD -w -t mangle -N $IPT_GROUP_PRE 2>/dev/null
+    $CMD -w -t mangle -F $IPT_GROUP_PRE
+    $CMD -w -t mangle -C PREROUTING -j $IPT_GROUP_PRE 2>/dev/null || \
+        $CMD -w -t mangle -A PREROUTING -j $IPT_GROUP_PRE
+
+    if [ "$CMD" = "iptables" ]; then
+        $CMD -w -t nat -N $IPT_GROUP_NAT 2>/dev/null
+        $CMD -w -t nat -F $IPT_GROUP_NAT
+        $CMD -w -t nat -C POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null || \
+            $CMD -w -t nat -A POSTROUTING -j $IPT_GROUP_NAT
+    fi
+
+    for IFACE in $(_iface_list); do
+        if [ "$IFACE" = "__ALL__" ]; then
+            OIF=""; IIF=""
+        else
+            OIF="-o $IFACE"; IIF="-i $IFACE"
+        fi
+
+        # --- POSTROUTING (исходящий трафик) ---
+        $CMD -w -t mangle -A $IPT_GROUP_POST $OIF -m connmark --mark $MARK_EXCLUDE -j RETURN
+        if [ -n "$PORTS_UDP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p udp -m multiport --dports $PORTS_UDP $CB_ORIG --connbytes 1:$MAX_PKT_OUT_UDP $JNFQ
+        fi
+        if [ -n "$PORTS_TCP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP $CB_ORIG --connbytes 1:$MAX_PKT_OUT $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags fin fin $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags rst rst $JNFQ
+        fi
+
+        # nfqws2 переписывает адреса в пакетах → нужен повторный MASQUERADE.
+        if [ "$CMD" = "iptables" ]; then
+            $CMD -w -t nat -A $IPT_GROUP_NAT $OIF -m mark --mark $MARK_PROCESSED -p udp -j MASQUERADE
+        fi
+
+        # --- PREROUTING (входящий трафик / ответы) ---
+        $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m connmark --mark $MARK_EXCLUDE -j RETURN
+        $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m mark --mark $MARK_PROCESSED -j RETURN
+        if [ -n "$PORTS_UDP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p udp -m multiport --sports $PORTS_UDP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
+        fi
+        if [ -n "$PORTS_TCP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags syn,ack syn,ack $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags fin fin $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags rst rst $JNFQ
+        fi
+    done
+}
+
+_firewall_stop() {
+    CMD="$1"
+
+    while $CMD -w -t mangle -C POSTROUTING -j $IPT_GROUP_POST 2>/dev/null; do
+        $CMD -w -t mangle -D POSTROUTING -j $IPT_GROUP_POST 2>/dev/null || break
+    done
+    while $CMD -w -t mangle -C PREROUTING -j $IPT_GROUP_PRE 2>/dev/null; do
+        $CMD -w -t mangle -D PREROUTING -j $IPT_GROUP_PRE 2>/dev/null || break
+    done
+    if [ "$CMD" = "iptables" ]; then
+        while $CMD -w -t nat -C POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null; do
+            $CMD -w -t nat -D POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null || break
+        done
+    fi
+
+    $CMD -w -t mangle -F $IPT_GROUP_POST 2>/dev/null
+    $CMD -w -t mangle -X $IPT_GROUP_POST 2>/dev/null
+    $CMD -w -t mangle -F $IPT_GROUP_PRE 2>/dev/null
+    $CMD -w -t mangle -X $IPT_GROUP_PRE 2>/dev/null
+    if [ "$CMD" = "iptables" ]; then
+        $CMD -w -t nat -F $IPT_GROUP_NAT 2>/dev/null
+        $CMD -w -t nat -X $IPT_GROUP_NAT 2>/dev/null
+    fi
+}
+
+firewall_iptables() {
+    command -v iptables >/dev/null 2>&1 && _firewall_start iptables
+}
+
+firewall_ip6tables() {
+    [ "$IPV6_ENABLED" = "1" ] || return 0
+    command -v ip6tables >/dev/null 2>&1 && _firewall_start ip6tables
+}
+
+firewall_stop() {
+    command -v iptables >/dev/null 2>&1 && _firewall_stop iptables
+    if [ "$IPV6_ENABLED" = "1" ] && command -v ip6tables >/dev/null 2>&1; then
+        _firewall_stop ip6tables
+    fi
+}
+
+apply_firewall() {
+    firewall_iptables
+    firewall_ip6tables
+}
+
+start() {
+    if is_running; then
+        echo "$SCRIPT_NAME: nfqws2 уже запущен (PID $(cat "$PID_FILE"))"
+        return 0
+    fi
+    if [ ! -x "$NFQWS_BIN" ]; then
+        echo "$SCRIPT_NAME: ОШИБКА — $NFQWS_BIN не найден или не исполняемый"
+        return 1
+    fi
+
+    echo "$SCRIPT_NAME: Запуск nfqws2..."
+    kernel_modules
+
+    $NFQWS_BIN $NFQWS_ARGS --daemon --pidfile="$PID_FILE" \
+        2>>/tmp/zapret-nfqws-stderr.log
+
+    sleep 1
+    if is_running; then
+        apply_firewall
+        system_config
+        echo "$SCRIPT_NAME: nfqws2 запущен (PID $(cat "$PID_FILE"))"
+    else
+        echo "$SCRIPT_NAME: ОШИБКА — nfqws2 не удалось запустить"
+        return 1
+    fi
+}
+
+stop() {
+    firewall_stop
+    if [ -f "$PID_FILE" ]; then
+        PID="$(cat "$PID_FILE")"
+        if kill -0 "$PID" 2>/dev/null; then
+            echo "$SCRIPT_NAME: Остановка nfqws2 (PID $PID)..."
+            kill "$PID" 2>/dev/null
+            for i in 1 2 3 4 5; do
+                kill -0 "$PID" 2>/dev/null || break
+                sleep 1
+            done
+            kill -0 "$PID" 2>/dev/null && kill -9 "$PID" 2>/dev/null
+        fi
+        rm -f "$PID_FILE"
+    fi
+    echo "$SCRIPT_NAME: Остановлен"
+}
+
+case "$1" in
+    start) start ;;
+    stop) stop ;;
+    restart) stop; sleep 1; start ;;
+    status)
+        if is_running; then
+            echo "$SCRIPT_NAME: запущен (PID $(cat "$PID_FILE"))"
+        else
+            echo "$SCRIPT_NAME: остановлен"
+        fi
+        ;;
+    firewall_iptables) is_running && firewall_iptables ;;
+    firewall_ip6tables) is_running && firewall_ip6tables ;;
+    firewall_stop) firewall_stop ;;
+    reapply) is_running && apply_firewall ;;
+    kernel_modules) kernel_modules ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status|reapply|firewall_iptables|firewall_ip6tables|firewall_stop}"
+        exit 1
+        ;;
+esac
+
+exit 0
+"""
+
+
 def _is_entware() -> bool:
     """Запущены ли мы на Entware (есть /opt/etc/init.d)."""
     return os.path.isdir(INIT_DIR)
@@ -358,266 +599,92 @@ class AutostartManager:
 
     def _generate_script(self) -> str:
         """
-        Сгенерировать shell-скрипт для init.d.
+        Сгенерировать shell-скрипт для init.d (Entware).
 
-        Скрипт использует текущую стратегию и настройки из конфига.
+        Команда запуска nfqws2 и параметры firewall берутся из тех же полей
+        конфига, что и живой путь (NFQWSManager/FirewallManager) — раньше
+        автозапуск использовал РАССИНХРОНИЗИРОВАННЫЕ значения (хардкод
+        fwmark=0x10000, queue из firewall.queue_num=200, без --fwmark/--user
+        и без --lua-init), из-за чего обход в режиме автозапуска ломался:
+        nfqws2 метил пакеты одной меткой, а ACCEPT-правило проверяло другую →
+        петля/дубли; lua-движок не грузился → --lua-desync не работал.
+
+        firewall приведён к схеме nfqws2-keenetic: отдельные цепочки
+        nfqws_post/nfqws_pre/nfqws_nat, метки MARK_PROCESSED/MARK_EXCLUDE,
+        правила на оба направления (POSTROUTING + PREROUTING), NAT MASQUERADE
+        для UDP и обработка TCP-флагов.
         """
         from core.config_manager import get_config_manager
         from core.strategy_builder import get_strategy_manager
+        from core.nfqws_manager import get_nfqws_manager
 
         cfg = get_config_manager()
         sb = get_strategy_manager()
+        nm = get_nfqws_manager()
 
         strategy_id = cfg.get("strategy", "current_id")
         strategy_name = cfg.get("strategy", "current_name") or "unknown"
-        nfqws_bin = cfg.get("zapret", "nfqws_binary",
-                            default="/opt/zapret2/nfq2/nfqws2")
-        queue_num = cfg.get("firewall", "queue_num", default=200)
-        fw_type = cfg.get("firewall", "type", default="auto")
 
-        # Получаем аргументы из стратегии
-        nfqws_args = []
+        # Полная команда nfqws2 (binary + base + lua-init + strategy) —
+        # ровно та же, что собирает живой путь NFQWSManager.start().
+        full_cmd = []
         if strategy_id:
             try:
                 strategy = sb.get_strategy(strategy_id)
                 if strategy:
-                    nfqws_args = sb.build_nfqws_args(strategy)
+                    strategy_args = sb.build_nfqws_args(strategy)
+                    full_cmd = nm.compose_command(strategy_args, cfg=cfg)
             except Exception as e:
-                log.warning("Не удалось собрать аргументы стратегии: %s" % e,
+                log.warning("Не удалось собрать команду стратегии: %s" % e,
                             source="autostart")
+        if not full_cmd:
+            full_cmd = [cfg.get("zapret", "nfqws_binary",
+                                default="/opt/zapret2/nfq2/nfqws2")]
 
-        # Формируем строку аргументов
-        args_str = " ".join(nfqws_args) if nfqws_args else ""
+        nfqws_bin = full_cmd[0]
+        nfqws_args = " ".join(full_cmd[1:])
 
-        # Порты из конфига/стратегии
-        ports_tcp = "80,443"
-        ports_udp = "443,50000:50100"
-        tcp_pkt = 8
-        udp_pkt = 8
+        # Параметры firewall — из секции nfqws (совпадают с FirewallManager).
+        queue_num = int(cfg.get("nfqws", "queue_num", default=300))
+        ports_tcp = cfg.get("nfqws", "ports_tcp", default="80,443")
+        ports_udp = cfg.get("nfqws", "ports_udp", default="443")
+        tcp_pkt = int(cfg.get("nfqws", "tcp_pkt_out", default=20))
+        udp_pkt = int(cfg.get("nfqws", "udp_pkt_out", default=5))
+        mark_processed = cfg.get("nfqws", "desync_mark",
+                                 default="0x40000000")
+        mark_exclude = cfg.get("nfqws", "desync_mark_postnat",
+                               default="0x20000000")
+        disable_ipv6 = cfg.get("nfqws", "disable_ipv6", default=True)
+        ipv6_enabled = "0" if disable_ipv6 else "1"
 
-        if strategy_id:
-            try:
-                strategy = sb.get_strategy(strategy_id)
-                if strategy:
-                    fw = strategy.get("firewall", {})
-                    if fw.get("ports_tcp"):
-                        ports_tcp = fw["ports_tcp"]
-                    if fw.get("ports_udp"):
-                        ports_udp = fw["ports_udp"]
-                    if fw.get("tcp_packets"):
-                        tcp_pkt = fw["tcp_packets"]
-                    if fw.get("udp_packets"):
-                        udp_pkt = fw["udp_packets"]
-            except Exception:
-                pass
+        # WAN-интерфейсы (из конфига или авто-детект). Пусто → правила без
+        # привязки к интерфейсу (на всех).
+        wan4 = nm._detect_wan_interfaces(cfg, "wan")
+        wan_ifaces = " ".join(wan4)
 
-        fwmark = "0x10000"
-        fwmask = "0x10000"
+        # Маски для --mark: nfqws2-keenetic использует "MARK/MARK".
+        mark_proc_full = "%s/%s" % (mark_processed, mark_processed)
+        mark_excl_full = "%s/%s" % (mark_exclude, mark_exclude)
 
-        script = """#!/bin/sh
-#
-# Zapret Web-GUI — автозапуск nfqws2
-# Сгенерировано автоматически. Не редактируйте вручную.
-#
-# Стратегия: {strategy_name} ({strategy_id})
-# Дата генерации: $(date 2>/dev/null || echo "unknown")
-#
+        repl = {
+            "@STRATEGY_NAME@": strategy_name,
+            "@STRATEGY_ID@": strategy_id or "none",
+            "@NFQWS_BIN@": nfqws_bin,
+            "@NFQWS_ARGS@": nfqws_args,
+            "@QUEUE_NUM@": str(queue_num),
+            "@PORTS_TCP@": ports_tcp or "",
+            "@PORTS_UDP@": ports_udp or "",
+            "@TCP_PKT@": str(tcp_pkt),
+            "@UDP_PKT@": str(udp_pkt),
+            "@MARK_PROCESSED@": mark_proc_full,
+            "@MARK_EXCLUDE@": mark_excl_full,
+            "@IPV6_ENABLED@": ipv6_enabled,
+            "@WAN_IFACES@": wan_ifaces,
+        }
 
-SCRIPT_NAME="S99zapret"
-NFQWS_BIN="{nfqws_bin}"
-NFQWS_ARGS="{args_str}"
-QUEUE_NUM="{queue_num}"
-PID_FILE="/var/run/zapret-nfqws.pid"
-
-# Параметры firewall
-PORTS_TCP="{ports_tcp}"
-PORTS_UDP="{ports_udp}"
-TCP_PKT="{tcp_pkt}"
-UDP_PKT="{udp_pkt}"
-FWMARK="{fwmark}"
-FWMASK="{fwmask}"
-IPT_COMMENT="zapret-gui"
-
-start() {{
-    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
-        echo "$SCRIPT_NAME: nfqws2 уже запущен (PID $(cat "$PID_FILE"))"
-        return 0
-    fi
-
-    if [ ! -x "$NFQWS_BIN" ]; then
-        echo "$SCRIPT_NAME: ОШИБКА — $NFQWS_BIN не найден или не исполняемый"
-        return 1
-    fi
-
-    echo "$SCRIPT_NAME: Запуск nfqws2..."
-
-    # Применяем правила firewall
-    apply_firewall
-
-    # Запускаем nfqws2
-    $NFQWS_BIN --qnum=$QUEUE_NUM $NFQWS_ARGS --daemon --pidfile="$PID_FILE" \\
-        2>>/tmp/zapret-nfqws-stderr.log
-
-    sleep 1
-
-    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
-        echo "$SCRIPT_NAME: nfqws2 запущен (PID $(cat "$PID_FILE"))"
-    else
-        echo "$SCRIPT_NAME: ОШИБКА — nfqws2 не удалось запустить"
-        remove_firewall
-        return 1
-    fi
-}}
-
-stop() {{
-    if [ -f "$PID_FILE" ]; then
-        PID="$(cat "$PID_FILE")"
-        if kill -0 "$PID" 2>/dev/null; then
-            echo "$SCRIPT_NAME: Остановка nfqws2 (PID $PID)..."
-            kill "$PID" 2>/dev/null
-            # Ждём завершения
-            for i in 1 2 3 4 5; do
-                kill -0 "$PID" 2>/dev/null || break
-                sleep 1
-            done
-            # SIGKILL если не завершился
-            if kill -0 "$PID" 2>/dev/null; then
-                kill -9 "$PID" 2>/dev/null
-                sleep 1
-            fi
-        fi
-        rm -f "$PID_FILE"
-    fi
-
-    # Снимаем правила firewall
-    remove_firewall
-
-    echo "$SCRIPT_NAME: Остановлен"
-}}
-
-apply_firewall() {{
-    # Определяем доступный инструмент
-    if command -v iptables >/dev/null 2>&1; then
-        apply_iptables
-    elif command -v nft >/dev/null 2>&1; then
-        apply_nftables
-    else
-        echo "$SCRIPT_NAME: ПРЕДУПРЕЖДЕНИЕ — ни iptables, ни nft не найдены"
-    fi
-}}
-
-remove_firewall() {{
-    if command -v iptables >/dev/null 2>&1; then
-        remove_iptables
-    fi
-    if command -v nft >/dev/null 2>&1; then
-        remove_nftables
-    fi
-}}
-
-apply_iptables() {{
-    # ACCEPT для помеченных пакетов
-    iptables -t mangle -I POSTROUTING -m mark --mark "$FWMARK/$FWMASK" \\
-        -m comment --comment "$IPT_COMMENT" -j ACCEPT 2>/dev/null
-
-    # TCP -> NFQUEUE
-    if [ -n "$PORTS_TCP" ]; then
-        iptables -t mangle -I POSTROUTING -p tcp \\
-            -m multiport --dports "$PORTS_TCP" \\
-            -m connbytes --connbytes-dir=original --connbytes-mode=packets \\
-            --connbytes "1:$TCP_PKT" \\
-            -m comment --comment "$IPT_COMMENT" \\
-            -j NFQUEUE --queue-num "$QUEUE_NUM" --queue-bypass 2>/dev/null
-    fi
-
-    # UDP -> NFQUEUE
-    if [ -n "$PORTS_UDP" ]; then
-        iptables -t mangle -I POSTROUTING -p udp \\
-            -m multiport --dports "$PORTS_UDP" \\
-            -m connbytes --connbytes-dir=original --connbytes-mode=packets \\
-            --connbytes "1:$UDP_PKT" \\
-            -m comment --comment "$IPT_COMMENT" \\
-            -j NFQUEUE --queue-num "$QUEUE_NUM" --queue-bypass 2>/dev/null
-    fi
-}}
-
-remove_iptables() {{
-    # Удаляем все правила с нашим комментарием (несколько проходов)
-    for pass in 1 2 3 4 5 6 7 8 9 10; do
-        FOUND=0
-        iptables -t mangle -L POSTROUTING --line-numbers -n 2>/dev/null | \\
-            grep "$IPT_COMMENT" | awk '{{print $1}}' | sort -rn | while read NUM; do
-            iptables -t mangle -D POSTROUTING "$NUM" 2>/dev/null
-            FOUND=1
-        done
-        [ "$FOUND" = "0" ] && break
-    done
-}}
-
-apply_nftables() {{
-    nft add table inet zapret-gui 2>/dev/null
-    nft add chain inet zapret-gui postrouting "{{ type filter hook postrouting priority 150; policy accept; }}" 2>/dev/null
-
-    # ACCEPT помеченных
-    nft add rule inet zapret-gui postrouting mark and "$FWMASK" == "$FWMARK" accept 2>/dev/null
-
-    # TCP -> NFQUEUE
-    if [ -n "$PORTS_TCP" ]; then
-        nft add rule inet zapret-gui postrouting tcp dport "{{ $PORTS_TCP }}" \\
-            ct original packets le "$TCP_PKT" queue num "$QUEUE_NUM" bypass 2>/dev/null
-    fi
-
-    # UDP -> NFQUEUE
-    if [ -n "$PORTS_UDP" ]; then
-        nft add rule inet zapret-gui postrouting udp dport "{{ $PORTS_UDP }}" \\
-            ct original packets le "$UDP_PKT" queue num "$QUEUE_NUM" bypass 2>/dev/null
-    fi
-}}
-
-remove_nftables() {{
-    nft delete table inet zapret-gui 2>/dev/null
-}}
-
-case "$1" in
-    start)
-        start
-        ;;
-    stop)
-        stop
-        ;;
-    restart)
-        stop
-        sleep 1
-        start
-        ;;
-    status)
-        if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
-            echo "$SCRIPT_NAME: запущен (PID $(cat "$PID_FILE"))"
-        else
-            echo "$SCRIPT_NAME: остановлен"
-        fi
-        ;;
-    *)
-        echo "Usage: $0 {{start|stop|restart|status}}"
-        exit 1
-        ;;
-esac
-
-exit 0
-""".format(
-            strategy_name=strategy_name,
-            strategy_id=strategy_id or "none",
-            nfqws_bin=nfqws_bin,
-            args_str=args_str,
-            queue_num=queue_num,
-            ports_tcp=ports_tcp,
-            ports_udp=ports_udp,
-            tcp_pkt=tcp_pkt,
-            udp_pkt=udp_pkt,
-            fwmark=fwmark,
-            fwmask=fwmask,
-        )
-
+        script = _S99ZAPRET_TEMPLATE
+        for key, value in repl.items():
+            script = script.replace(key, value)
         return script
 
 

--- a/core/autostart_manager.py
+++ b/core/autostart_manager.py
@@ -169,6 +169,19 @@ def _is_systemd() -> bool:
         "/etc/systemd/system"
     )
 
+
+def _is_openwrt_procd() -> bool:
+    """Чистый OpenWrt с procd (без Entware /opt/etc/init.d).
+
+    На таких системах nfqws2 запускает сам GUI при старте (app.py boot-apply),
+    а GUI поднимается через procd-сервис /etc/init.d/zapret-gui. Персистентность
+    firewall обеспечивает hotplug-хук.
+    """
+    return (
+        os.path.exists("/sbin/procd")
+        or os.path.exists("/etc/openwrt_release")
+    ) and os.path.isfile("/etc/init.d/zapret-gui")
+
 # Singleton
 _instance = None
 _instance_lock = threading.Lock()
@@ -210,6 +223,11 @@ class AutostartManager:
             # сам GUI при старте.
             method = "systemd"
             effective_enabled = enabled and os.path.isfile(SYSTEMD_UNIT_PATH)
+        elif _is_openwrt_procd():
+            # Чистый OpenWrt: стратегию применяет GUI при старте, GUI поднимает
+            # procd. Персистентность firewall — через hotplug-хук.
+            method = "openwrt"
+            effective_enabled = enabled
         else:
             method = "unsupported"
             effective_enabled = False
@@ -332,6 +350,42 @@ class AutostartManager:
                 "ok": True,
                 "message": "Автозапуск включён. Сохранённая стратегия "
                            "будет применена при загрузке системы.",
+            }
+
+        # Чистый OpenWrt с procd (без Entware): nfqws2 запускает GUI при
+        # старте, persistence — hotplug-хук. Включаем procd-сервис GUI и
+        # ставим хуки.
+        if not _is_entware() and _is_openwrt_procd():
+            try:
+                subprocess.run(
+                    ["/etc/init.d/zapret-gui", "enable"],
+                    check=False, timeout=10,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            except Exception:
+                pass
+
+            try:
+                from core.firewall_persistence import install_hooks
+                install_hooks()
+            except Exception as e:
+                log.warning("Не удалось установить хуки персистентности: %s" % e,
+                            source="autostart")
+
+            cfg.set("autostart", "enabled", True)
+            cfg.set("autostart", "method", "openwrt")
+            cfg.save()
+
+            strategy_name = cfg.get("strategy", "current_name") or strategy_id
+            log.success(
+                "Автозапуск включён (OpenWrt/procd, стратегия: %s "
+                "применится при загрузке)" % strategy_name,
+                source="autostart",
+            )
+            return {
+                "ok": True,
+                "message": "Автозапуск включён. Сохранённая стратегия будет "
+                           "применена при загрузке (OpenWrt).",
             }
 
         # Дальше — путь Entware с init.d-скриптом

--- a/core/autostart_manager.py
+++ b/core/autostart_manager.py
@@ -81,140 +81,11 @@ MARK_EXCLUDE="@MARK_EXCLUDE@"
 IPV6_ENABLED="@IPV6_ENABLED@"
 WAN_IFACES="@WAN_IFACES@"
 
-IPT_GROUP_POST="nfqws_post"
-IPT_GROUP_PRE="nfqws_pre"
-IPT_GROUP_NAT="nfqws_nat"
-
-JNFQ="-j NFQUEUE --queue-num $QUEUE_NUM --queue-bypass"
-CONN_CHECK="-m mark ! --mark $MARK_PROCESSED"
-CB_ORIG="-m connbytes --connbytes-dir=original --connbytes-mode=packets"
-CB_REPLY="-m connbytes --connbytes-dir=reply --connbytes-mode=packets"
-
 is_running() {
     [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE" 2>/dev/null)" 2>/dev/null
 }
 
-kernel_modules() {
-    modprobe -a -q nfnetlink_queue xt_multiport xt_connbytes xt_NFQUEUE xt_CONNMARK xt_connmark nf_conntrack 2>/dev/null
-}
-
-system_config() {
-    sysctl -w net.netfilter.nf_conntrack_checksum=0 >/dev/null 2>&1
-    sysctl -w net.netfilter.nf_conntrack_tcp_be_liberal=1 >/dev/null 2>&1
-}
-
-# Перечень интерфейсов для итерации. Пусто → один проход без -o/-i (все).
-_iface_list() {
-    if [ -n "$WAN_IFACES" ]; then
-        echo "$WAN_IFACES"
-    else
-        echo "__ALL__"
-    fi
-}
-
-_firewall_start() {
-    CMD="$1"  # iptables | ip6tables
-
-    $CMD -w -t mangle -N $IPT_GROUP_POST 2>/dev/null
-    $CMD -w -t mangle -F $IPT_GROUP_POST
-    $CMD -w -t mangle -C POSTROUTING -j $IPT_GROUP_POST 2>/dev/null || \
-        $CMD -w -t mangle -A POSTROUTING -j $IPT_GROUP_POST
-
-    $CMD -w -t mangle -N $IPT_GROUP_PRE 2>/dev/null
-    $CMD -w -t mangle -F $IPT_GROUP_PRE
-    $CMD -w -t mangle -C PREROUTING -j $IPT_GROUP_PRE 2>/dev/null || \
-        $CMD -w -t mangle -A PREROUTING -j $IPT_GROUP_PRE
-
-    if [ "$CMD" = "iptables" ]; then
-        $CMD -w -t nat -N $IPT_GROUP_NAT 2>/dev/null
-        $CMD -w -t nat -F $IPT_GROUP_NAT
-        $CMD -w -t nat -C POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null || \
-            $CMD -w -t nat -A POSTROUTING -j $IPT_GROUP_NAT
-    fi
-
-    for IFACE in $(_iface_list); do
-        if [ "$IFACE" = "__ALL__" ]; then
-            OIF=""; IIF=""
-        else
-            OIF="-o $IFACE"; IIF="-i $IFACE"
-        fi
-
-        # --- POSTROUTING (исходящий трафик) ---
-        $CMD -w -t mangle -A $IPT_GROUP_POST $OIF -m connmark --mark $MARK_EXCLUDE -j RETURN
-        if [ -n "$PORTS_UDP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p udp -m multiport --dports $PORTS_UDP $CB_ORIG --connbytes 1:$MAX_PKT_OUT_UDP $JNFQ
-        fi
-        if [ -n "$PORTS_TCP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP $CB_ORIG --connbytes 1:$MAX_PKT_OUT $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags fin fin $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags rst rst $JNFQ
-        fi
-
-        # nfqws2 переписывает адреса в пакетах → нужен повторный MASQUERADE.
-        if [ "$CMD" = "iptables" ]; then
-            $CMD -w -t nat -A $IPT_GROUP_NAT $OIF -m mark --mark $MARK_PROCESSED -p udp -j MASQUERADE
-        fi
-
-        # --- PREROUTING (входящий трафик / ответы) ---
-        $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m connmark --mark $MARK_EXCLUDE -j RETURN
-        $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m mark --mark $MARK_PROCESSED -j RETURN
-        if [ -n "$PORTS_UDP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p udp -m multiport --sports $PORTS_UDP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
-        fi
-        if [ -n "$PORTS_TCP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags syn,ack syn,ack $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags fin fin $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags rst rst $JNFQ
-        fi
-    done
-}
-
-_firewall_stop() {
-    CMD="$1"
-
-    while $CMD -w -t mangle -C POSTROUTING -j $IPT_GROUP_POST 2>/dev/null; do
-        $CMD -w -t mangle -D POSTROUTING -j $IPT_GROUP_POST 2>/dev/null || break
-    done
-    while $CMD -w -t mangle -C PREROUTING -j $IPT_GROUP_PRE 2>/dev/null; do
-        $CMD -w -t mangle -D PREROUTING -j $IPT_GROUP_PRE 2>/dev/null || break
-    done
-    if [ "$CMD" = "iptables" ]; then
-        while $CMD -w -t nat -C POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null; do
-            $CMD -w -t nat -D POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null || break
-        done
-    fi
-
-    $CMD -w -t mangle -F $IPT_GROUP_POST 2>/dev/null
-    $CMD -w -t mangle -X $IPT_GROUP_POST 2>/dev/null
-    $CMD -w -t mangle -F $IPT_GROUP_PRE 2>/dev/null
-    $CMD -w -t mangle -X $IPT_GROUP_PRE 2>/dev/null
-    if [ "$CMD" = "iptables" ]; then
-        $CMD -w -t nat -F $IPT_GROUP_NAT 2>/dev/null
-        $CMD -w -t nat -X $IPT_GROUP_NAT 2>/dev/null
-    fi
-}
-
-firewall_iptables() {
-    command -v iptables >/dev/null 2>&1 && _firewall_start iptables
-}
-
-firewall_ip6tables() {
-    [ "$IPV6_ENABLED" = "1" ] || return 0
-    command -v ip6tables >/dev/null 2>&1 && _firewall_start ip6tables
-}
-
-firewall_stop() {
-    command -v iptables >/dev/null 2>&1 && _firewall_stop iptables
-    if [ "$IPV6_ENABLED" = "1" ] && command -v ip6tables >/dev/null 2>&1; then
-        _firewall_stop ip6tables
-    fi
-}
-
-apply_firewall() {
-    firewall_iptables
-    firewall_ip6tables
-}
+@FIREWALL_FUNCS@
 
 start() {
     if is_running; then
@@ -491,6 +362,15 @@ class AutostartManager:
         if not ok:
             return {"ok": False, "message": "Ошибка установки скрипта в %s" % INIT_DIR}
 
+        # Устанавливаем хуки персистентности (Keenetic ndm / OpenWrt hotplug),
+        # чтобы правила переустанавливались после flush'а системного firewall.
+        try:
+            from core.firewall_persistence import install_hooks
+            install_hooks()
+        except Exception as e:
+            log.warning("Не удалось установить хуки персистентности: %s" % e,
+                        source="autostart")
+
         # Обновляем конфиг
         cfg.set("autostart", "enabled", True)
         cfg.save()
@@ -511,6 +391,14 @@ class AutostartManager:
 
         # Удаляем init.d-скрипт если он есть (Entware-режим)
         removed = self._remove_script()
+
+        # Снимаем хуки персистентности firewall.
+        try:
+            from core.firewall_persistence import remove_hooks
+            remove_hooks()
+        except Exception as e:
+            log.warning("Не удалось снять хуки персистентности: %s" % e,
+                        source="autostart")
 
         # Обновляем конфиг в любом случае. На systemd этого достаточно:
         # GUI при старте проверит флаг и не будет применять стратегию.
@@ -666,6 +554,9 @@ class AutostartManager:
         mark_proc_full = "%s/%s" % (mark_processed, mark_processed)
         mark_excl_full = "%s/%s" % (mark_exclude, mark_exclude)
 
+        # Единый источник shell-функций firewall (общий с reapply-хуками).
+        from core.firewall_persistence import FIREWALL_SH_FUNCTIONS
+
         repl = {
             "@STRATEGY_NAME@": strategy_name,
             "@STRATEGY_ID@": strategy_id or "none",
@@ -680,6 +571,7 @@ class AutostartManager:
             "@MARK_EXCLUDE@": mark_excl_full,
             "@IPV6_ENABLED@": ipv6_enabled,
             "@WAN_IFACES@": wan_ifaces,
+            "@FIREWALL_FUNCS@": FIREWALL_SH_FUNCTIONS,
         }
 
         script = _S99ZAPRET_TEMPLATE

--- a/core/blob_registry.py
+++ b/core/blob_registry.py
@@ -1,0 +1,269 @@
+# core/blob_registry.py
+"""
+Реестр именованных blob'ов для nfqws2.
+
+Контекст проблемы
+─────────────────
+В nfqws2 fake-пакеты задаются ссылкой на ИМЕНОВАННЫЙ blob:
+
+    --lua-desync=fake:blob=tls_google:...
+
+Само имя ``tls_google`` ничего не значит, пока оно не зарегистрировано
+глобально через декларацию:
+
+    --blob=tls_google:@/opt/zapret2/files/fake/tls_clienthello_www_google_com.bin
+
+Полные пресеты (catalogs/builtin/winws2_presets.txt) встраивают такие
+``--blob=...`` декларации прямо в первый профиль и работают. А компактные
+каталоги (basic/advanced) указывают только метаполе ``blobs = tls_google``
+и голую ссылку ``blob=tls_google`` — без декларации. Метаполе при сборке
+аргументов раньше отбрасывалось, поэтому nfqws2 отправлял ПУСТОЙ fake и
+обход не срабатывал.
+
+Этот модуль — единый источник маппинга «символическое имя → файл blob'а».
+Он:
+  • извлекает каноничные ``--blob=NAME:@bin/FILE.bin`` декларации из каталогов
+    (catalogs/builtin/winws2_presets.txt — там полный список из upstream);
+  • дополняет их встроенной таблицей (fallback, если каталог недоступен);
+  • по списку аргументов стратегии генерирует недостающие ``--blob=``
+    декларации, которые нужно подмешать ОДИН раз в начало (до первого
+    ``--new``), т.к. blob-декларации в nfqws2 глобальны.
+
+Встроенные имена nfqws2 (fake_default_http/tls/quic) и инлайновые hex-blob'ы
+(``blob=0x00...``) регистрации НЕ требуют и пропускаются.
+"""
+
+import os
+import re
+import threading
+
+from core.log_buffer import log
+
+
+# Имя → значение декларации (часть после "NAME:" в --blob=NAME:VALUE).
+# Значение может быть "@bin/file.bin" (файл) или "0x..." (инлайн-hex).
+# Заполняется лениво из каталогов + _FALLBACK_ALIASES.
+_registry: dict = {}
+_loaded = False
+_lock = threading.Lock()
+
+
+# Имена, встроенные в сам nfqws2 — регистрировать не нужно.
+BUILTIN_BLOB_NAMES = frozenset({
+    "fake_default_http",
+    "fake_default_tls",
+    "fake_default_quic",
+})
+
+# Каноничный fallback-маппинг (синхронизирован с заголовком
+# catalogs/builtin/winws2_presets.txt). Используется, если каталог
+# почему-то недоступен при импорте/запуске.
+_FALLBACK_ALIASES = {
+    "tls_google":   "@bin/tls_clienthello_www_google_com.bin",
+    "tls1":         "@bin/tls_clienthello_1.bin",
+    "tls2":         "@bin/tls_clienthello_2.bin",
+    "tls2n":        "@bin/tls_clienthello_2n.bin",
+    "tls3":         "@bin/tls_clienthello_3.bin",
+    "tls4":         "@bin/tls_clienthello_4.bin",
+    "tls5":         "@bin/tls_clienthello_5.bin",
+    "tls6":         "@bin/tls_clienthello_6.bin",
+    "tls7":         "@bin/tls_clienthello_7.bin",
+    "tls8":         "@bin/tls_clienthello_8.bin",
+    "tls9":         "@bin/tls_clienthello_9.bin",
+    "tls10":        "@bin/tls_clienthello_10.bin",
+    "tls11":        "@bin/tls_clienthello_11.bin",
+    "tls12":        "@bin/tls_clienthello_12.bin",
+    "tls13":        "@bin/tls_clienthello_13.bin",
+    "tls14":        "@bin/tls_clienthello_14.bin",
+    "tls17":        "@bin/tls_clienthello_17.bin",
+    "tls18":        "@bin/tls_clienthello_18.bin",
+    "tls_sber":     "@bin/tls_clienthello_sberbank_ru.bin",
+    "tls_vk":       "@bin/tls_clienthello_vk_com.bin",
+    "tls_vk_kyber": "@bin/tls_clienthello_vk_com_kyber.bin",
+    "tls_deepseek": "@bin/tls_clienthello_chat_deepseek_com.bin",
+    "tls_max":      "@bin/tls_clienthello_max_ru.bin",
+    "tls_iana":     "@bin/tls_clienthello_iana_org.bin",
+    "tls_4pda":     "@bin/tls_clienthello_4pda_to.bin",
+    "tls_gosuslugi": "@bin/tls_clienthello_gosuslugi_ru.bin",
+    "syndata3":     "@bin/tls_clienthello_3.bin",
+    "syn_packet":   "@bin/syn_packet.bin",
+    "dtls_w3":      "@bin/dtls_clienthello_w3_org.bin",
+    "quic_google":  "@bin/quic_initial_www_google_com.bin",
+    "quic_vk":      "@bin/quic_initial_vk_com.bin",
+    "quic1":        "@bin/quic_1.bin",
+    "quic2":        "@bin/quic_2.bin",
+    "quic3":        "@bin/quic_3.bin",
+    "quic4":        "@bin/quic_4.bin",
+    "quic5":        "@bin/quic_5.bin",
+    "quic6":        "@bin/quic_6.bin",
+    "quic7":        "@bin/quic_7.bin",
+    "stun_pat":     "@bin/stun.bin",
+    "quic_test":    "@bin/quic_test_00.bin",
+    "fake_tls":     "@bin/fake_tls_1.bin",
+    "fake_tls_1":   "@bin/fake_tls_1.bin",
+    "fake_tls_2":   "@bin/fake_tls_2.bin",
+    "fake_tls_3":   "@bin/fake_tls_3.bin",
+    "fake_tls_4":   "@bin/fake_tls_4.bin",
+    "fake_tls_5":   "@bin/fake_tls_5.bin",
+    "fake_tls_6":   "@bin/fake_tls_6.bin",
+    "fake_tls_7":   "@bin/fake_tls_7.bin",
+    "fake_tls_8":   "@bin/fake_tls_8.bin",
+    "fake_quic":    "@bin/fake_quic.bin",
+    "fake_quic_1":  "@bin/fake_quic_1.bin",
+    "fake_quic_2":  "@bin/fake_quic_2.bin",
+    "fake_quic_3":  "@bin/fake_quic_3.bin",
+    "fake_default_udp": "0x00000000000000000000000000000000",
+    "http_req":     "@bin/http_iana_org.bin",
+    "hex_0e0e0f0e": "0x0E0E0F0E",
+    "hex_0f0e0e0f": "0x0F0E0E0F",
+    "hex_0f0f0f0f": "0x0F0F0F0F",
+    "hex_00":       "0x00",
+}
+
+
+# --blob=NAME:VALUE из каталогов (для пополнения реестра из upstream).
+_BLOB_DECL_RE = re.compile(r"^--blob=([^:]+):(.+)$")
+
+# blob=NAME внутри --lua-desync=...:blob=NAME:... (имя — до ':' или конца).
+_BLOB_REF_RE = re.compile(r"blob=([A-Za-z0-9_]+)")
+
+
+def _catalogs_dir() -> str:
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "catalogs",
+    )
+
+
+def _load_from_catalogs(registry: dict) -> int:
+    """Пополнить registry декларациями ``--blob=NAME:VALUE`` из каталогов.
+
+    Каталоги — источник истины (winws2_presets.txt содержит полный
+    upstream-список). Возвращает число добавленных/обновлённых имён.
+    """
+    root = _catalogs_dir()
+    count = 0
+    if not os.path.isdir(root):
+        return 0
+    for dirpath, _dirs, files in os.walk(root):
+        for fn in files:
+            if not fn.endswith(".txt"):
+                continue
+            try:
+                with open(os.path.join(dirpath, fn), "r",
+                          encoding="utf-8", errors="replace") as f:
+                    for raw in f:
+                        line = raw.strip()
+                        if not line.startswith("--blob="):
+                            continue
+                        m = _BLOB_DECL_RE.match(line)
+                        if not m:
+                            continue
+                        name, value = m.group(1).strip(), m.group(2).strip()
+                        if name and value:
+                            registry[name] = value
+                            count += 1
+            except (IOError, OSError):
+                continue
+    return count
+
+
+def _ensure_loaded():
+    global _loaded
+    if _loaded:
+        return
+    with _lock:
+        if _loaded:
+            return
+        reg = dict(_FALLBACK_ALIASES)
+        try:
+            n = _load_from_catalogs(reg)
+            if n:
+                log.debug("blob-реестр: %d деклараций из каталогов, %d всего"
+                          % (n, len(reg)), source="blobs")
+        except Exception as e:  # noqa: BLE001 — реестр не должен ронять запуск
+            log.warning("blob-реестр: ошибка чтения каталогов: %s" % e,
+                        source="blobs")
+        _registry.clear()
+        _registry.update(reg)
+        _loaded = True
+
+
+def reload_registry():
+    """Сбросить кэш реестра (например, после обновления каталогов)."""
+    global _loaded
+    with _lock:
+        _loaded = False
+        _registry.clear()
+
+
+def get_blob_value(name: str):
+    """Значение декларации для имени blob'а или None, если не известно."""
+    _ensure_loaded()
+    return _registry.get(name)
+
+
+def referenced_blob_names(args) -> list:
+    """Имена blob'ов, на которые ссылаются аргументы стратегии.
+
+    Ищет ``blob=NAME`` в любом аргументе (как правило, внутри
+    ``--lua-desync=fake:blob=NAME:...``). Возвращает уникальные имена
+    в порядке первого появления.
+    """
+    seen = []
+    seen_set = set()
+    for a in args:
+        for m in _BLOB_REF_RE.finditer(a):
+            name = m.group(1)
+            if name not in seen_set:
+                seen_set.add(name)
+                seen.append(name)
+    return seen
+
+
+def already_declared(args) -> set:
+    """Имена blob'ов, уже объявленные через ``--blob=NAME:...`` в аргументах."""
+    declared = set()
+    for a in args:
+        if a.startswith("--blob="):
+            m = _BLOB_DECL_RE.match(a)
+            if m:
+                declared.add(m.group(1).strip())
+    return declared
+
+
+def build_blob_declarations(args) -> list:
+    """Сгенерировать недостающие ``--blob=NAME:VALUE`` для аргументов стратегии.
+
+    Логика:
+      • собираем имена из ссылок ``blob=NAME``;
+      • выкидываем встроенные (fake_default_*) и инлайн-hex (``0x...``);
+      • выкидываем уже объявленные в самих аргументах;
+      • для остальных, если имя есть в реестре, формируем декларацию.
+
+    Возвращает список строк ``--blob=NAME:VALUE`` (значения с ``@bin/`` будут
+    отрезолвлены в абсолютный путь позже, в CatalogManager.resolve_paths_in_args).
+    Декларации глобальны — их следует подмешать ОДИН раз в начало команды,
+    до первого ``--new``.
+    """
+    _ensure_loaded()
+    declared = already_declared(args)
+    out = []
+    for name in referenced_blob_names(args):
+        if name in BUILTIN_BLOB_NAMES:
+            continue
+        if name.startswith("0x"):  # инлайновый hex, не имя
+            continue
+        if name in declared:
+            continue
+        value = _registry.get(name)
+        if value is None:
+            # Неизвестное имя — не молчим, но и не падаем: nfqws2 сам
+            # сообщит об отсутствующем blob'е. Чаще всего это опечатка
+            # в пользовательской стратегии.
+            log.warning("blob '%s' не найден в реестре — fake может быть пуст"
+                        % name, source="blobs")
+            continue
+        out.append("--blob=%s:%s" % (name, value))
+        declared.add(name)
+    return out

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -58,8 +58,12 @@ DEFAULT_CONFIG = {
     # --- Настройки nfqws ---
     "nfqws": {
         "queue_num": 300,
-        "ports_tcp": "80,443",
-        "ports_udp": "443",
+        # Расширенный набор портов (паритет с nfqws2-keenetic): помимо HTTP/
+        # HTTPS — Cloudflare alt-порты (2053/2083/2087/2096/8443), Telegram
+        # MTProto (5222), а по UDP — QUIC (443), STUN/TURN, WireGuard-диапазоны
+        # и Discord voice (49152:65535).
+        "ports_tcp": "80,443,2053,2083,2087,2096,5222,8443",
+        "ports_udp": "443,3478:3481,5349,19294:19344,49152:65535",
         "tcp_pkt_out": 20,
         "tcp_pkt_in": 10,
         "udp_pkt_out": 5,
@@ -207,6 +211,16 @@ class ConfigManager:
             changed = True
         if "ipset_path" not in z:
             z["ipset_path"] = "/opt/zapret2/ipset"
+            changed = True
+
+        # Расширение портов: только если значение НЕ трогали (равно прежнему
+        # узкому дефолту). Кастомные значения пользователя не перетираем.
+        n = self._config.get("nfqws", {})
+        if n.get("ports_tcp") == "80,443":
+            n["ports_tcp"] = "80,443,2053,2083,2087,2096,5222,8443"
+            changed = True
+        if n.get("ports_udp") == "443":
+            n["ports_udp"] = "443,3478:3481,5349,19294:19344,49152:65535"
             changed = True
         return changed
 

--- a/core/diagnostics.py
+++ b/core/diagnostics.py
@@ -662,6 +662,7 @@ def get_firewall_status():
         "nfqueue_available": False,
         "nfqueue_count": 0,
         "raw_output": "",
+        "persistence": {},
     }
 
     # Определяем тип firewall
@@ -678,6 +679,14 @@ def get_firewall_status():
 
     # Проверяем NFQUEUE
     result["nfqueue_available"] = _check_nfqueue_available()
+
+    # Статус хуков персистентности (ndm/hotplug) — важно для диагностики
+    # «обход то работает, то отваливается» на роутерах.
+    try:
+        from core.firewall_persistence import get_status as fp_status
+        result["persistence"] = fp_status()
+    except Exception:
+        pass
 
     _cache_set(cache_key, result)
     return result

--- a/core/firewall.py
+++ b/core/firewall.py
@@ -118,6 +118,13 @@ class FirewallManager:
         self._applied = False
         self._fw_type = None          # "iptables" | "nftables" | None
         self._rules_info = []         # Для UI
+        # Доп. параметры для PREROUTING / NAT / TCP-флагов (заполняется в
+        # apply_rules). Дефолты — на случай прямого вызова _apply_* в тестах.
+        self._extra = {
+            "tcp_pkt_in": 10,
+            "udp_pkt_in": 3,
+            "mark_exclude": "0x20000000",
+        }
 
     # ─────────────────────────── public API ───────────────────────────
 
@@ -159,7 +166,18 @@ class FirewallManager:
                                      default="0x40000000")
             tcp_pkt = int(cfg.get("nfqws", "tcp_pkt_out", default=20))
             udp_pkt = int(cfg.get("nfqws", "udp_pkt_out", default=5))
+            tcp_pkt_in = int(cfg.get("nfqws", "tcp_pkt_in", default=10))
+            udp_pkt_in = int(cfg.get("nfqws", "udp_pkt_in", default=3))
+            mark_exclude = cfg.get("nfqws", "desync_mark_postnat",
+                                   default="0x20000000")
             disable_ipv6 = cfg.get("nfqws", "disable_ipv6", default=True)
+            # Параметры ответного направления и исключения — для PREROUTING /
+            # NAT MASQUERADE / TCP-флагов (паритет с nfqws2-keenetic).
+            self._extra = {
+                "tcp_pkt_in": tcp_pkt_in,
+                "udp_pkt_in": udp_pkt_in,
+                "mark_exclude": mark_exclude,
+            }
 
             # WAN-интерфейсы из конфига или auto-detect
             wan4 = self._get_wan_interfaces(cfg, "wan")
@@ -336,9 +354,17 @@ class FirewallManager:
         """
         Применить правила для одного семейства (iptables / ip6tables).
 
-        Аналог zapret2 _fw_nfqws_post4 / _fw_nfqws_post6:
-          - Если wan_ifaces не пуст: для каждого -o $iface отдельное правило
-          - Если пуст: правило без -o (все интерфейсы)
+        Портировано из nfqws2-keenetic (_firewall_start). На каждый WAN
+        (или без привязки, если список пуст) вешаются правила на ОБА
+        направления:
+          • POSTROUTING (исходящий): RETURN для исключённых меток,
+            NFQUEUE для первых N пакетов соединения + по TCP-флагам fin/rst;
+          • NAT POSTROUTING (только IPv4): MASQUERADE для пакетов, которые
+            переписал nfqws2 (иначе пакеты с новым адресом отбрасываются);
+          • PREROUTING (входящий/ответы): RETURN для исключённых и уже
+            обработанных, NFQUEUE по reply-connbytes + TCP-флагам syn,ack/fin/rst.
+
+        Все правила помечаются комментарием IPT_COMMENT — по нему же чистятся.
         """
         ok = True
         family_tag = "IPv4" if ipt_cmd == "iptables" else "IPv6"
@@ -349,67 +375,123 @@ class FirewallManager:
                         source="firewall")
             return True  # Не ошибка — просто нет поддержки
 
-        # Для каждого WAN или без -o
+        mark_proc = "%s/%s" % (fwmark, fwmark)
+        mark_excl_raw = self._extra.get("mark_exclude", "0x20000000")
+        mark_excl = "%s/%s" % (mark_excl_raw, mark_excl_raw)
+        tcp_pkt_in = self._extra.get("tcp_pkt_in", 10)
+        udp_pkt_in = self._extra.get("udp_pkt_in", 3)
+        do_nat = (ipt_cmd == "iptables")  # MASQUERADE только для IPv4
+
+        def _comment():
+            return ["-m", "comment", "--comment", IPT_COMMENT]
+
+        def _nfq():
+            return ["-j", "NFQUEUE", "--queue-num", str(qnum), "--queue-bypass"]
+
+        # Для каждого WAN или без привязки к интерфейсу
         oif_list = wan_ifaces if wan_ifaces else [None]
 
         for oif in oif_list:
             oif_args = ["-o", oif] if oif else []
-            oif_tag = " -o %s" % oif if oif else " (все)"
+            iif_args = ["-i", oif] if oif else []
+            tag = (" %s" % oif) if oif else " (все)"
 
-            # 1) ACCEPT для помеченных (не зацикливать)
-            cmd = [
-                ipt_cmd, "-t", "mangle", "-I", "POSTROUTING",
-            ] + oif_args + [
-                "-m", "mark", "--mark", "%s/%s" % (fwmark, fwmark),
-                "-m", "comment", "--comment", IPT_COMMENT,
-                "-j", "ACCEPT"
-            ]
-            if self._run_cmd(cmd):
-                rules.append("%s ACCEPT mark%s" % (family_tag, oif_tag))
+            # ───────── POSTROUTING (исходящий) ─────────
+            # 1) ACCEPT для уже обработанных (не зацикливаем)
+            if self._run_cmd(
+                [ipt_cmd, "-t", "mangle", "-I", "POSTROUTING"] + oif_args
+                + ["-m", "mark", "--mark", mark_proc] + _comment()
+                + ["-j", "ACCEPT"]
+            ):
+                rules.append("%s ACCEPT processed%s" % (family_tag, tag))
             else:
                 ok = False
 
-            # 2) TCP → NFQUEUE
+            # 2) RETURN для исключённых соединений
+            self._run_cmd(
+                [ipt_cmd, "-t", "mangle", "-A", "POSTROUTING"] + oif_args
+                + ["-m", "connmark", "--mark", mark_excl] + _comment()
+                + ["-j", "RETURN"]
+            )
+
+            # 3) TCP → NFQUEUE (первые N пакетов + fin/rst)
             if ports_tcp:
-                cmd = [
-                    ipt_cmd, "-t", "mangle", "-A", "POSTROUTING",
-                ] + oif_args + [
-                    "-p", "tcp",
-                    "-m", "multiport", "--dports", ports_tcp,
-                    "-m", "connbytes", "--connbytes-dir=original",
-                    "--connbytes-mode=packets",
-                    "--connbytes", "1:%d" % tcp_pkt,
-                    "-m", "comment", "--comment", IPT_COMMENT,
-                    "-j", "NFQUEUE",
-                    "--queue-num", str(qnum),
-                    "--queue-bypass"
-                ]
-                if self._run_cmd(cmd):
+                base = ([ipt_cmd, "-t", "mangle", "-A", "POSTROUTING"]
+                        + oif_args + ["-p", "tcp", "-m", "multiport",
+                                      "--dports", ports_tcp])
+                if self._run_cmd(
+                    base + ["-m", "connbytes", "--connbytes-dir=original",
+                            "--connbytes-mode=packets", "--connbytes",
+                            "1:%d" % tcp_pkt] + _comment() + _nfq()
+                ):
                     rules.append("%s TCP %s → NFQUEUE %d%s" % (
-                        family_tag, ports_tcp, qnum, oif_tag))
+                        family_tag, ports_tcp, qnum, tag))
+                else:
+                    ok = False
+                self._run_cmd(base + ["--tcp-flags", "fin", "fin"]
+                              + _comment() + _nfq())
+                self._run_cmd(base + ["--tcp-flags", "rst", "rst"]
+                              + _comment() + _nfq())
+
+            # 4) UDP → NFQUEUE
+            if ports_udp:
+                if self._run_cmd(
+                    [ipt_cmd, "-t", "mangle", "-A", "POSTROUTING"] + oif_args
+                    + ["-p", "udp", "-m", "multiport", "--dports", ports_udp,
+                       "-m", "connbytes", "--connbytes-dir=original",
+                       "--connbytes-mode=packets", "--connbytes",
+                       "1:%d" % udp_pkt] + _comment() + _nfq()
+                ):
+                    rules.append("%s UDP %s → NFQUEUE %d%s" % (
+                        family_tag, ports_udp, qnum, tag))
                 else:
                     ok = False
 
-            # 3) UDP → NFQUEUE
+            # ───────── NAT POSTROUTING (только IPv4) ─────────
+            # nfqws2 переписывает адреса → повторный MASQUERADE для UDP.
+            if do_nat:
+                if self._run_cmd(
+                    [ipt_cmd, "-t", "nat", "-A", "POSTROUTING"] + oif_args
+                    + ["-m", "mark", "--mark", mark_proc, "-p", "udp"]
+                    + _comment() + ["-j", "MASQUERADE"]
+                ):
+                    rules.append("%s NAT MASQUERADE udp%s" % (family_tag, tag))
+
+            # ───────── PREROUTING (входящий / ответы) ─────────
+            # RETURN для исключённых и уже обработанных
+            self._run_cmd(
+                [ipt_cmd, "-t", "mangle", "-A", "PREROUTING"] + iif_args
+                + ["-m", "connmark", "--mark", mark_excl] + _comment()
+                + ["-j", "RETURN"]
+            )
+            self._run_cmd(
+                [ipt_cmd, "-t", "mangle", "-A", "PREROUTING"] + iif_args
+                + ["-m", "mark", "--mark", mark_proc] + _comment()
+                + ["-j", "RETURN"]
+            )
+            if ports_tcp:
+                base = ([ipt_cmd, "-t", "mangle", "-A", "PREROUTING"]
+                        + iif_args + ["-p", "tcp", "-m", "multiport",
+                                      "--sports", ports_tcp])
+                self._run_cmd(
+                    base + ["-m", "connbytes", "--connbytes-dir=reply",
+                            "--connbytes-mode=packets", "--connbytes",
+                            "1:%d" % tcp_pkt_in] + _comment() + _nfq()
+                )
+                self._run_cmd(base + ["--tcp-flags", "syn,ack", "syn,ack"]
+                              + _comment() + _nfq())
+                self._run_cmd(base + ["--tcp-flags", "fin", "fin"]
+                              + _comment() + _nfq())
+                self._run_cmd(base + ["--tcp-flags", "rst", "rst"]
+                              + _comment() + _nfq())
             if ports_udp:
-                cmd = [
-                    ipt_cmd, "-t", "mangle", "-A", "POSTROUTING",
-                ] + oif_args + [
-                    "-p", "udp",
-                    "-m", "multiport", "--dports", ports_udp,
-                    "-m", "connbytes", "--connbytes-dir=original",
-                    "--connbytes-mode=packets",
-                    "--connbytes", "1:%d" % udp_pkt,
-                    "-m", "comment", "--comment", IPT_COMMENT,
-                    "-j", "NFQUEUE",
-                    "--queue-num", str(qnum),
-                    "--queue-bypass"
-                ]
-                if self._run_cmd(cmd):
-                    rules.append("%s UDP %s → NFQUEUE %d%s" % (
-                        family_tag, ports_udp, qnum, oif_tag))
-                else:
-                    ok = False
+                self._run_cmd(
+                    [ipt_cmd, "-t", "mangle", "-A", "PREROUTING"] + iif_args
+                    + ["-p", "udp", "-m", "multiport", "--sports", ports_udp,
+                       "-m", "connbytes", "--connbytes-dir=reply",
+                       "--connbytes-mode=packets", "--connbytes",
+                       "1:%d" % udp_pkt_in] + _comment() + _nfq()
+                )
 
         return ok
 
@@ -423,13 +505,26 @@ class FirewallManager:
         self._rules_info = []
         return ok
 
+    # Цепочки, в которые мы добавляем правила (таблица, цепочка).
+    _IPT_CHAINS = (
+        ("mangle", "POSTROUTING"),
+        ("mangle", "PREROUTING"),
+        ("nat", "POSTROUTING"),
+    )
+
     def _remove_ipt_family(self, ipt_cmd) -> bool:
-        """Удалить правила одного семейства (несколько проходов)."""
+        """Удалить правила одного семейства из всех наших цепочек."""
+        for table, chain in self._IPT_CHAINS:
+            self._remove_ipt_chain(ipt_cmd, table, chain)
+        return True
+
+    def _remove_ipt_chain(self, ipt_cmd, table, chain) -> None:
+        """Удалить все правила с комментарием IPT_COMMENT из одной цепочки."""
         for _ in range(20):
             found = False
             try:
                 result = subprocess.run(
-                    [ipt_cmd, "-t", "mangle", "-L", "POSTROUTING",
+                    [ipt_cmd, "-t", table, "-L", chain,
                      "--line-numbers", "-n"],
                     capture_output=True, text=True, timeout=5
                 )
@@ -441,8 +536,8 @@ class FirewallManager:
                         parts = line.split()
                         if parts and parts[0].isdigit():
                             self._run_cmd([
-                                ipt_cmd, "-t", "mangle",
-                                "-D", "POSTROUTING", parts[0]
+                                ipt_cmd, "-t", table,
+                                "-D", chain, parts[0]
                             ])
                             found = True
             except Exception:
@@ -450,8 +545,6 @@ class FirewallManager:
 
             if not found:
                 break
-
-        return True
 
     def _get_iptables_rules(self) -> list:
         """Получить текущие NFQUEUE-правила iptables + ip6tables."""
@@ -479,59 +572,87 @@ class FirewallManager:
                         fwmark, tcp_pkt, udp_pkt,
                         wan4_ifaces, wan6_ifaces) -> bool:
         """
-        Применить правила nftables с привязкой к WAN-интерфейсам.
+        Применить правила nftables (паритет с iptables-путём).
 
-        В nftables правила inet-семейства работают для обоих протоколов.
-        Фильтр интерфейса: `oifname { "eth0", "eth1" }`.
+        В inet-таблице создаём три цепочки:
+          • postrouting (исходящий): RETURN для исключённых, NFQUEUE первых N
+            пакетов + по TCP-флагам fin/rst;
+          • prerouting (входящий/ответы): RETURN исключённых и обработанных,
+            NFQUEUE по reply-пакетам + TCP-флагам syn,ack/fin/rst;
+          • nat postrouting: MASQUERADE для пакетов, переписанных nfqws2.
+        Фильтр интерфейса: `oifname { "eth0", "eth1" }` / `iifname ...`.
         """
-        cmds = []
+        mark_excl_raw = self._extra.get("mark_exclude", "0x20000000")
+        tcp_pkt_in = self._extra.get("tcp_pkt_in", 10)
+        udp_pkt_in = self._extra.get("udp_pkt_in", 3)
 
-        # Создаём таблицу и цепочку
-        cmds.append("add table inet %s" % NFT_TABLE)
-        cmds.append(
-            "add chain inet %s postrouting "
-            "{ type filter hook postrouting priority 150 ; }" % NFT_TABLE
-        )
-
-        # Собираем уникальные WAN-интерфейсы для oifname
+        # Собираем уникальные WAN-интерфейсы
         all_wan = set(wan4_ifaces or [])
         if wan6_ifaces:
             all_wan.update(wan6_ifaces)
-        oif_filter = ""
-        if all_wan:
+
+        def _iface(kw):
+            if not all_wan:
+                return ""
             if len(all_wan) == 1:
-                # Один интерфейс — без фигурных скобок
-                oif_filter = "oifname %s " % list(all_wan)[0]
-            else:
-                # Несколько — множество nft
-                oif_filter = "oifname { %s } " % ", ".join(sorted(all_wan))
+                return "%s %s " % (kw, list(all_wan)[0])
+            return "%s { %s } " % (kw, ", ".join(sorted(all_wan)))
 
-        # ACCEPT для помеченных пакетов
-        cmds.append(
-            "add rule inet %s postrouting %s"
-            "meta mark and %s == %s accept" % (
-                NFT_TABLE, oif_filter, fwmark, fwmark)
-        )
+        oif = _iface("oifname")
+        iif = _iface("iifname")
+        tcp_ports = "{ %s }" % ports_tcp if ports_tcp else None
+        udp_ports = "{ %s }" % ports_udp if ports_udp else None
 
-        # TCP → NFQUEUE
-        if ports_tcp:
-            ports_nft = "{ %s }" % ports_tcp
-            cmds.append(
-                "add rule inet %s postrouting %s"
-                "tcp dport %s ct original packets 1-%d "
-                "queue num %d bypass" % (
-                    NFT_TABLE, oif_filter, ports_nft, tcp_pkt, qnum)
-            )
+        cmds = []
+        cmds.append("add table inet %s" % NFT_TABLE)
+        cmds.append("add chain inet %s postrouting "
+                    "{ type filter hook postrouting priority 150 ; }" % NFT_TABLE)
+        cmds.append("add chain inet %s prerouting "
+                    "{ type filter hook prerouting priority -150 ; }" % NFT_TABLE)
+        cmds.append("add chain inet %s natpost "
+                    "{ type nat hook postrouting priority 100 ; }" % NFT_TABLE)
 
-        # UDP → NFQUEUE
-        if ports_udp:
-            ports_nft = "{ %s }" % ports_udp
-            cmds.append(
-                "add rule inet %s postrouting %s"
-                "udp dport %s ct original packets 1-%d "
-                "queue num %d bypass" % (
-                    NFT_TABLE, oif_filter, ports_nft, udp_pkt, qnum)
-            )
+        # ─── postrouting (исходящий) ───
+        cmds.append("add rule inet %s postrouting %smeta mark and %s == %s return"
+                    % (NFT_TABLE, oif, mark_excl_raw, mark_excl_raw))
+        cmds.append("add rule inet %s postrouting %smeta mark and %s == %s return"
+                    % (NFT_TABLE, oif, fwmark, fwmark))
+        if tcp_ports:
+            cmds.append("add rule inet %s postrouting %stcp dport %s "
+                        "ct original packets 1-%d queue num %d bypass"
+                        % (NFT_TABLE, oif, tcp_ports, tcp_pkt, qnum))
+            cmds.append("add rule inet %s postrouting %stcp dport %s "
+                        "tcp flags fin queue num %d bypass"
+                        % (NFT_TABLE, oif, tcp_ports, qnum))
+            cmds.append("add rule inet %s postrouting %stcp dport %s "
+                        "tcp flags rst queue num %d bypass"
+                        % (NFT_TABLE, oif, tcp_ports, qnum))
+        if udp_ports:
+            cmds.append("add rule inet %s postrouting %sudp dport %s "
+                        "ct original packets 1-%d queue num %d bypass"
+                        % (NFT_TABLE, oif, udp_ports, udp_pkt, qnum))
+
+        # ─── prerouting (входящий/ответы) ───
+        cmds.append("add rule inet %s prerouting %smeta mark and %s == %s return"
+                    % (NFT_TABLE, iif, mark_excl_raw, mark_excl_raw))
+        cmds.append("add rule inet %s prerouting %smeta mark and %s == %s return"
+                    % (NFT_TABLE, iif, fwmark, fwmark))
+        if tcp_ports:
+            cmds.append("add rule inet %s prerouting %stcp sport %s "
+                        "ct reply packets 1-%d queue num %d bypass"
+                        % (NFT_TABLE, iif, tcp_ports, tcp_pkt_in, qnum))
+            cmds.append("add rule inet %s prerouting %stcp sport %s "
+                        "tcp flags syn,ack queue num %d bypass"
+                        % (NFT_TABLE, iif, tcp_ports, qnum))
+        if udp_ports:
+            cmds.append("add rule inet %s prerouting %sudp sport %s "
+                        "ct reply packets 1-%d queue num %d bypass"
+                        % (NFT_TABLE, iif, udp_ports, udp_pkt_in, qnum))
+
+        # ─── nat postrouting: MASQUERADE для переписанных nfqws2 пакетов ───
+        cmds.append("add rule inet %s natpost %smeta mark and %s == %s "
+                    "meta l4proto udp masquerade"
+                    % (NFT_TABLE, oif, fwmark, fwmark))
 
         ok = True
         rules = []

--- a/core/firewall.py
+++ b/core/firewall.py
@@ -214,6 +214,14 @@ class FirewallManager:
                 if ok:
                     self._applied = True
                     log.success("Правила firewall применены", source="firewall")
+                    # Персистентность на роутере: сохранить рантайм-конфиг и
+                    # установить ndm/hotplug-хуки, чтобы правила переживали
+                    # flush системного firewall (Keenetic NDMS / OpenWrt fw3).
+                    self._ensure_persistence(
+                        qnum, tcp, udp, fwmark, tcp_pkt, udp_pkt,
+                        tcp_pkt_in, udp_pkt_in, mark_exclude,
+                        disable_ipv6, wan4, wan6,
+                    )
                 else:
                     log.error("Ошибка при применении правил", source="firewall")
                 return ok
@@ -222,6 +230,40 @@ class FirewallManager:
                 log.error("Исключение при применении правил: %s" % e,
                           source="firewall")
                 return False
+
+    @staticmethod
+    def _ensure_persistence(qnum, tcp, udp, fwmark, tcp_pkt, udp_pkt,
+                            tcp_pkt_in, udp_pkt_in, mark_exclude,
+                            disable_ipv6, wan4, wan6):
+        """Записать рантайм-конфиг firewall и установить хуки (только роутер).
+
+        На обычных хостах (systemd/desktop) ndm/hotplug отсутствуют — тогда
+        ничего не делаем. Хуки no-op'ят, пока nfqws2 не запущен (проверяют PID).
+        """
+        try:
+            from core import firewall_persistence as fp
+            if not (fp.is_keenetic() or fp.is_openwrt_hotplug()):
+                return
+            ifaces = set(wan4 or [])
+            if wan6:
+                ifaces.update(wan6)
+            params = {
+                "queue_num": qnum,
+                "ports_tcp": tcp,
+                "ports_udp": udp,
+                "tcp_pkt_out": tcp_pkt,
+                "udp_pkt_out": udp_pkt,
+                "pkt_in": max(int(tcp_pkt_in), int(udp_pkt_in), 1),
+                "mark_processed": "%s/%s" % (fwmark, fwmark),
+                "mark_exclude": "%s/%s" % (mark_exclude, mark_exclude),
+                "ipv6_enabled": "0" if disable_ipv6 else "1",
+                "wan_ifaces": " ".join(sorted(ifaces)),
+            }
+            fp.write_runtime_conf(params)
+            fp.install_hooks()
+        except Exception as e:
+            log.warning("Персистентность firewall не настроена: %s" % e,
+                        source="firewall")
 
     def remove_rules(self) -> bool:
         """Снять все правила NFQUEUE, установленные GUI."""

--- a/core/firewall.py
+++ b/core/firewall.py
@@ -576,11 +576,55 @@ class FirewallManager:
         ("nat", "POSTROUTING"),
     )
 
+    # Именованные цепочки персистентного режима (reapply-хук создаёт их
+    # вместо вставки правил по комментарию). Чистим их тоже, чтобы после
+    # flush+reapply не оставались осиротевшие цепочки. (таблица, цепочка-хук,
+    # имя нашей цепочки).
+    _IPT_NAMED_CHAINS = (
+        ("mangle", "POSTROUTING", "nfqws_post"),
+        ("mangle", "PREROUTING", "nfqws_pre"),
+        ("nat", "POSTROUTING", "nfqws_nat"),
+    )
+
     def _remove_ipt_family(self, ipt_cmd) -> bool:
         """Удалить правила одного семейства из всех наших цепочек."""
         for table, chain in self._IPT_CHAINS:
             self._remove_ipt_chain(ipt_cmd, table, chain)
+        # Снести именованные цепочки персистентного режима, если остались.
+        for table, hook, name in self._IPT_NAMED_CHAINS:
+            self._remove_ipt_named_chain(ipt_cmd, table, hook, name)
         return True
+
+    def _remove_ipt_named_chain(self, ipt_cmd, table, hook, name) -> None:
+        """Отцепить и удалить именованную цепочку nfqws_* (best-effort).
+
+        Тихо выходим, если цепочки нет (обычный случай в GUI-режиме без
+        reapply) — чтобы не сыпать предупреждениями на каждый stop.
+        """
+        if not shutil.which(ipt_cmd):
+            return
+        try:
+            exists = subprocess.run(
+                [ipt_cmd, "-w", "-t", table, "-L", name, "-n"],
+                capture_output=True, text=True, timeout=5,
+            ).returncode == 0
+        except (subprocess.TimeoutExpired, OSError):
+            return
+        if not exists:
+            return
+
+        # Снять переходы из hook-цепочки (могут быть дубли).
+        for _ in range(10):
+            r = subprocess.run(
+                [ipt_cmd, "-w", "-t", table, "-C", hook, "-j", name],
+                capture_output=True, text=True, timeout=5,
+            )
+            if r.returncode != 0:
+                break
+            self._run_cmd([ipt_cmd, "-t", table, "-D", hook, "-j", name])
+        # Очистить и удалить саму цепочку.
+        self._run_cmd([ipt_cmd, "-t", table, "-F", name])
+        self._run_cmd([ipt_cmd, "-t", table, "-X", name])
 
     def _remove_ipt_chain(self, ipt_cmd, table, chain) -> None:
         """Удалить все правила с комментарием IPT_COMMENT из одной цепочки."""

--- a/core/firewall.py
+++ b/core/firewall.py
@@ -214,6 +214,10 @@ class FirewallManager:
                 if ok:
                     self._applied = True
                     log.success("Правила firewall применены", source="firewall")
+                    # Тюнинг conntrack: без be_liberal ядро отбрасывает
+                    # out-of-window сегменты, которые порождает десинхронизация
+                    # (split/disorder/fake с badseq) — обход не срабатывает.
+                    self._apply_sysctl_tuning()
                     # Персистентность на роутере: сохранить рантайм-конфиг и
                     # установить ndm/hotplug-хуки, чтобы правила переживали
                     # flush системного firewall (Keenetic NDMS / OpenWrt fw3).
@@ -230,6 +234,24 @@ class FirewallManager:
                 log.error("Исключение при применении правил: %s" % e,
                           source="firewall")
                 return False
+
+    @staticmethod
+    def _apply_sysctl_tuning():
+        """Настроить conntrack под десинхронизацию (как nfqws2-keenetic).
+
+        net.netfilter.nf_conntrack_tcp_be_liberal=1 — не дропать пакеты вне TCP
+        window (десинк намеренно их шлёт). nf_conntrack_checksum=0 — не считать
+        контрольные суммы (nfqws2 их портит намеренно, badsum). Best-effort.
+        """
+        for key, val in (
+            ("net.netfilter.nf_conntrack_tcp_be_liberal", "1"),
+            ("net.netfilter.nf_conntrack_checksum", "0"),
+        ):
+            try:
+                subprocess.run(["sysctl", "-w", "%s=%s" % (key, val)],
+                               capture_output=True, timeout=5)
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                pass
 
     @staticmethod
     def _ensure_persistence(qnum, tcp, udp, fwmark, tcp_pkt, udp_pkt,

--- a/core/firewall_persistence.py
+++ b/core/firewall_persistence.py
@@ -1,0 +1,351 @@
+# core/firewall_persistence.py
+"""
+Персистентность firewall-правил nfqws2 на роутерах.
+
+Проблема
+────────
+На Keenetic системный демон NDMS периодически делает flush iptables
+(переподключение WAN, смена политики, перезапуск файрвола). На OpenWrt то же
+делает fw3/fw4 при reload. После такого flush'а наши NFQUEUE-правила исчезают,
+nfqws2 продолжает работать, но трафик в него уже не попадает — обход «молча»
+перестаёт действовать. Это главная причина, по которой связка GUI+nfqws2
+«работает хуже», чем нативный пакет nfqws2-keenetic, у которого есть хук
+переустановки правил.
+
+Решение (портировано из nfqws2-keenetic)
+────────────────────────────────────────
+  • Keenetic: /opt/etc/ndm/netfilter.d/100-zapret-gui.sh — NDMS вызывает все
+    скрипты из netfilter.d после каждого изменения таблиц; хук переустанавливает
+    наши правила.
+  • OpenWrt: /etc/hotplug.d/firewall/90-zapret-gui — аналогичный механизм fw3/fw4.
+
+Оба хука вызывают reapply-скрипт, который:
+  1) если есть init-скрипт автозапуска (S99zapret) и nfqws2 запущен — зовёт
+     `S99zapret reapply` (пер-shell, быстро, как в nfqws2-keenetic);
+  2) иначе, если nfqws2 запущен под управлением GUI — переустанавливает правила
+     из сохранённого рантайм-конфига firewall.run теми же shell-функциями.
+
+Единый источник shell-логики firewall — FIREWALL_SH_FUNCTIONS: его же встраивает
+генератор init-скрипта автозапуска (core/autostart_manager).
+"""
+
+import os
+import stat
+import threading
+
+from core.log_buffer import log
+
+
+# Пути
+NDM_NETFILTER_DIR = "/opt/etc/ndm/netfilter.d"
+NDM_HOOK_PATH = os.path.join(NDM_NETFILTER_DIR, "100-zapret-gui.sh")
+
+HOTPLUG_FW_DIR = "/etc/hotplug.d/firewall"
+HOTPLUG_HOOK_PATH = os.path.join(HOTPLUG_FW_DIR, "90-zapret-gui")
+
+GUI_RUNTIME_DIR = "/opt/etc/zapret-gui"
+FW_RUN_CONF = os.path.join(GUI_RUNTIME_DIR, "firewall.run")
+REAPPLY_SCRIPT = os.path.join(GUI_RUNTIME_DIR, "reapply-firewall.sh")
+
+# PID-файлы, по которым reapply понимает, что nfqws2 жив.
+GUI_PID_FILE = "/var/run/zapret-gui-nfqws.pid"     # живой путь (NFQWSManager)
+AUTOSTART_PID_FILE = "/var/run/zapret-nfqws.pid"   # автозапуск (S99zapret)
+AUTOSTART_INIT = "/opt/etc/init.d/S99zapret"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+#  Единый источник shell-функций firewall (паритет с nfqws2-keenetic).
+#  Использует переменные окружения, которые задаются ВЫШЕ по скрипту
+#  (бейкингом в S99zapret либо `source firewall.run` в reapply):
+#    QUEUE_NUM PORTS_TCP PORTS_UDP MAX_PKT_OUT MAX_PKT_OUT_UDP MAX_PKT_IN
+#    MARK_PROCESSED MARK_EXCLUDE IPV6_ENABLED WAN_IFACES
+# ─────────────────────────────────────────────────────────────────────────
+FIREWALL_SH_FUNCTIONS = r"""
+IPT_GROUP_POST="nfqws_post"
+IPT_GROUP_PRE="nfqws_pre"
+IPT_GROUP_NAT="nfqws_nat"
+: "${MAX_PKT_IN:=15}"
+
+_jnfq() { echo "-j NFQUEUE --queue-num $QUEUE_NUM --queue-bypass"; }
+
+kernel_modules() {
+    modprobe -a -q nfnetlink_queue xt_multiport xt_connbytes xt_NFQUEUE xt_CONNMARK xt_connmark nf_conntrack 2>/dev/null
+}
+
+system_config() {
+    sysctl -w net.netfilter.nf_conntrack_checksum=0 >/dev/null 2>&1
+    sysctl -w net.netfilter.nf_conntrack_tcp_be_liberal=1 >/dev/null 2>&1
+}
+
+_iface_list() {
+    if [ -n "$WAN_IFACES" ]; then echo "$WAN_IFACES"; else echo "__ALL__"; fi
+}
+
+_firewall_start() {
+    CMD="$1"
+    JNFQ="$(_jnfq)"
+    CONN_CHECK="-m mark ! --mark $MARK_PROCESSED"
+    CB_ORIG="-m connbytes --connbytes-dir=original --connbytes-mode=packets"
+    CB_REPLY="-m connbytes --connbytes-dir=reply --connbytes-mode=packets"
+
+    $CMD -w -t mangle -N $IPT_GROUP_POST 2>/dev/null
+    $CMD -w -t mangle -F $IPT_GROUP_POST
+    $CMD -w -t mangle -C POSTROUTING -j $IPT_GROUP_POST 2>/dev/null || \
+        $CMD -w -t mangle -A POSTROUTING -j $IPT_GROUP_POST
+    $CMD -w -t mangle -N $IPT_GROUP_PRE 2>/dev/null
+    $CMD -w -t mangle -F $IPT_GROUP_PRE
+    $CMD -w -t mangle -C PREROUTING -j $IPT_GROUP_PRE 2>/dev/null || \
+        $CMD -w -t mangle -A PREROUTING -j $IPT_GROUP_PRE
+    if [ "$CMD" = "iptables" ]; then
+        $CMD -w -t nat -N $IPT_GROUP_NAT 2>/dev/null
+        $CMD -w -t nat -F $IPT_GROUP_NAT
+        $CMD -w -t nat -C POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null || \
+            $CMD -w -t nat -A POSTROUTING -j $IPT_GROUP_NAT
+    fi
+
+    for IFACE in $(_iface_list); do
+        if [ "$IFACE" = "__ALL__" ]; then OIF=""; IIF=""; else OIF="-o $IFACE"; IIF="-i $IFACE"; fi
+
+        $CMD -w -t mangle -A $IPT_GROUP_POST $OIF -m connmark --mark $MARK_EXCLUDE -j RETURN
+        if [ -n "$PORTS_UDP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p udp -m multiport --dports $PORTS_UDP $CB_ORIG --connbytes 1:$MAX_PKT_OUT_UDP $JNFQ
+        fi
+        if [ -n "$PORTS_TCP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP $CB_ORIG --connbytes 1:$MAX_PKT_OUT $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags fin fin $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags rst rst $JNFQ
+        fi
+
+        if [ "$CMD" = "iptables" ]; then
+            $CMD -w -t nat -A $IPT_GROUP_NAT $OIF -m mark --mark $MARK_PROCESSED -p udp -j MASQUERADE
+        fi
+
+        $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m connmark --mark $MARK_EXCLUDE -j RETURN
+        $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m mark --mark $MARK_PROCESSED -j RETURN
+        if [ -n "$PORTS_UDP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p udp -m multiport --sports $PORTS_UDP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
+        fi
+        if [ -n "$PORTS_TCP" ]; then
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags syn,ack syn,ack $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags fin fin $JNFQ
+            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags rst rst $JNFQ
+        fi
+    done
+}
+
+_firewall_stop() {
+    CMD="$1"
+    while $CMD -w -t mangle -C POSTROUTING -j $IPT_GROUP_POST 2>/dev/null; do
+        $CMD -w -t mangle -D POSTROUTING -j $IPT_GROUP_POST 2>/dev/null || break
+    done
+    while $CMD -w -t mangle -C PREROUTING -j $IPT_GROUP_PRE 2>/dev/null; do
+        $CMD -w -t mangle -D PREROUTING -j $IPT_GROUP_PRE 2>/dev/null || break
+    done
+    if [ "$CMD" = "iptables" ]; then
+        while $CMD -w -t nat -C POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null; do
+            $CMD -w -t nat -D POSTROUTING -j $IPT_GROUP_NAT 2>/dev/null || break
+        done
+    fi
+    $CMD -w -t mangle -F $IPT_GROUP_POST 2>/dev/null; $CMD -w -t mangle -X $IPT_GROUP_POST 2>/dev/null
+    $CMD -w -t mangle -F $IPT_GROUP_PRE 2>/dev/null;  $CMD -w -t mangle -X $IPT_GROUP_PRE 2>/dev/null
+    if [ "$CMD" = "iptables" ]; then
+        $CMD -w -t nat -F $IPT_GROUP_NAT 2>/dev/null; $CMD -w -t nat -X $IPT_GROUP_NAT 2>/dev/null
+    fi
+}
+
+firewall_iptables() {
+    command -v iptables >/dev/null 2>&1 && _firewall_start iptables
+}
+
+firewall_ip6tables() {
+    [ "$IPV6_ENABLED" = "1" ] || return 0
+    command -v ip6tables >/dev/null 2>&1 && _firewall_start ip6tables
+}
+
+firewall_stop() {
+    command -v iptables >/dev/null 2>&1 && _firewall_stop iptables
+    if [ "$IPV6_ENABLED" = "1" ] && command -v ip6tables >/dev/null 2>&1; then
+        _firewall_stop ip6tables
+    fi
+}
+
+apply_firewall() {
+    firewall_iptables
+    firewall_ip6tables
+}
+"""
+
+
+_lock = threading.Lock()
+
+
+# ─────────────────────────── рендеринг ───────────────────────────
+
+def render_run_conf(params: dict) -> str:
+    """Сформировать текст firewall.run (sourced shell-конфиг)."""
+    def q(v):
+        return '"%s"' % ("" if v is None else v)
+    return (
+        "# Сгенерировано zapret-gui. Не редактируйте вручную.\n"
+        "QUEUE_NUM=%s\n" % q(params.get("queue_num"))
+        + "PORTS_TCP=%s\n" % q(params.get("ports_tcp"))
+        + "PORTS_UDP=%s\n" % q(params.get("ports_udp"))
+        + "MAX_PKT_OUT=%s\n" % q(params.get("tcp_pkt_out"))
+        + "MAX_PKT_OUT_UDP=%s\n" % q(params.get("udp_pkt_out"))
+        + "MAX_PKT_IN=%s\n" % q(params.get("pkt_in", 15))
+        + "MARK_PROCESSED=%s\n" % q(params.get("mark_processed"))
+        + "MARK_EXCLUDE=%s\n" % q(params.get("mark_exclude"))
+        + "IPV6_ENABLED=%s\n" % q(params.get("ipv6_enabled"))
+        + "WAN_IFACES=%s\n" % q(params.get("wan_ifaces"))
+    )
+
+
+def build_reapply_script() -> str:
+    """reapply-скрипт для GUI-управляемого nfqws2 (источает firewall.run)."""
+    return (
+        "#!/bin/sh\n"
+        "# Переустановка firewall-правил nfqws2 (GUI-режим).\n"
+        "# Вызывается из ndm/hotplug-хука. Сгенерировано zapret-gui.\n"
+        'RUN_CONF="%s"\n' % FW_RUN_CONF
+        + '[ -f "$RUN_CONF" ] || exit 0\n'
+        + '. "$RUN_CONF"\n'
+        + FIREWALL_SH_FUNCTIONS
+        + "\napply_firewall\n"
+    )
+
+
+def _hook_body() -> str:
+    """Общее тело хука: переустановить правила, если nfqws2 запущен."""
+    return (
+        '# Если работает автозапуск (S99zapret) и nfqws2 жив — зовём его reapply.\n'
+        'if [ -f "%s" ] && [ -f "%s" ] && kill -0 "$(cat "%s" 2>/dev/null)" 2>/dev/null; then\n'
+        '    "%s" reapply >/dev/null 2>&1\n'
+        '    exit 0\n'
+        'fi\n'
+        '# Иначе — GUI-режим: nfqws2 под управлением веб-интерфейса.\n'
+        'if [ -f "%s" ] && kill -0 "$(cat "%s" 2>/dev/null)" 2>/dev/null; then\n'
+        '    [ -x "%s" ] && "%s" >/dev/null 2>&1\n'
+        'fi\n'
+        % (
+            AUTOSTART_INIT, AUTOSTART_PID_FILE, AUTOSTART_PID_FILE, AUTOSTART_INIT,
+            GUI_PID_FILE, GUI_PID_FILE, REAPPLY_SCRIPT, REAPPLY_SCRIPT,
+        )
+    )
+
+
+def build_ndm_hook() -> str:
+    """Хук Keenetic NDMS (/opt/etc/ndm/netfilter.d). NDMS зовёт после flush."""
+    return (
+        "#!/bin/sh\n"
+        "# zapret-gui: переустановка NFQUEUE-правил после flush'а NDMS.\n"
+        "# $table и $type выставляет NDMS.\n"
+        '[ "$table" != "mangle" ] && [ "$table" != "nat" ] && exit 0\n'
+        + _hook_body()
+        + "exit 0\n"
+    )
+
+
+def build_hotplug_hook() -> str:
+    """Хук OpenWrt (/etc/hotplug.d/firewall). fw3/fw4 зовёт при reload."""
+    return (
+        "#!/bin/sh\n"
+        "# zapret-gui: переустановка NFQUEUE-правил после reload firewall (OpenWrt).\n"
+        '[ "$ACTION" = "add" ] || exit 0\n'
+        + _hook_body()
+        + "exit 0\n"
+    )
+
+
+# ─────────────────────────── установка ───────────────────────────
+
+def _write_exec(path: str, content: str) -> bool:
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.chmod(path, 0o755 | stat.S_IRGRP | stat.S_IROTH)
+        return True
+    except (OSError, IOError) as e:
+        log.warning("Не удалось записать %s: %s" % (path, e),
+                    source="firewall")
+        return False
+
+
+def is_keenetic() -> bool:
+    """Keenetic — есть каталог netfilter.d (его наполняет NDMS)."""
+    return os.path.isdir("/opt/etc/ndm") or os.path.isdir(NDM_NETFILTER_DIR)
+
+
+def is_openwrt_hotplug() -> bool:
+    """OpenWrt с hotplug.d/firewall."""
+    return os.path.isdir("/etc/hotplug.d") or os.path.isdir(HOTPLUG_FW_DIR)
+
+
+def install_hooks() -> dict:
+    """Установить ndm/hotplug-хуки на поддерживаемых платформах.
+
+    Возвращает {ndm: bool, hotplug: bool, installed: [paths]}.
+    """
+    with _lock:
+        result = {"ndm": False, "hotplug": False, "installed": []}
+
+        if is_keenetic():
+            if _write_exec(NDM_HOOK_PATH, build_ndm_hook()):
+                result["ndm"] = True
+                result["installed"].append(NDM_HOOK_PATH)
+
+        if is_openwrt_hotplug():
+            if _write_exec(HOTPLUG_HOOK_PATH, build_hotplug_hook()):
+                result["hotplug"] = True
+                result["installed"].append(HOTPLUG_HOOK_PATH)
+
+        if result["installed"]:
+            log.info("Установлены хуки персистентности firewall: %s"
+                     % ", ".join(result["installed"]), source="firewall")
+        return result
+
+
+def remove_hooks() -> dict:
+    """Удалить установленные ndm/hotplug-хуки."""
+    with _lock:
+        removed = []
+        for path in (NDM_HOOK_PATH, HOTPLUG_HOOK_PATH):
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+                    removed.append(path)
+            except OSError as e:
+                log.warning("Не удалось удалить %s: %s" % (path, e),
+                            source="firewall")
+        if removed:
+            log.info("Удалены хуки персистентности: %s" % ", ".join(removed),
+                     source="firewall")
+        return {"removed": removed}
+
+
+def write_runtime_conf(params: dict) -> bool:
+    """Записать firewall.run + reapply-скрипт для GUI-режима."""
+    ok = True
+    try:
+        os.makedirs(GUI_RUNTIME_DIR, exist_ok=True)
+        with open(FW_RUN_CONF, "w", encoding="utf-8") as f:
+            f.write(render_run_conf(params))
+    except (OSError, IOError) as e:
+        log.warning("Не удалось записать %s: %s" % (FW_RUN_CONF, e),
+                    source="firewall")
+        ok = False
+    ok = _write_exec(REAPPLY_SCRIPT, build_reapply_script()) and ok
+    return ok
+
+
+def get_status() -> dict:
+    """Статус хуков для API/диагностики."""
+    return {
+        "keenetic": is_keenetic(),
+        "openwrt_hotplug": is_openwrt_hotplug(),
+        "ndm_hook_installed": os.path.isfile(NDM_HOOK_PATH),
+        "hotplug_hook_installed": os.path.isfile(HOTPLUG_HOOK_PATH),
+        "reapply_script_installed": os.path.isfile(REAPPLY_SCRIPT),
+        "runtime_conf_exists": os.path.isfile(FW_RUN_CONF),
+    }

--- a/core/nfqws_manager.py
+++ b/core/nfqws_manager.py
@@ -114,18 +114,9 @@ class NFQWSManager:
             # Стратегические аргументы
             strategy_args = list(args) if args else []
 
-            # Собираем базовые аргументы (--user/--fwmark/--qnum)
-            base_args = self._build_base_args(cfg)
-
-            # Лua-скрипты: core + нужные extensions, в правильном порядке.
-            lua_path = cfg.get("zapret", "lua_path") or "/opt/zapret2/lua"
-            lua_args = self._build_lua_init_args(strategy_args, lua_path)
-
-            # Дедуп --lua-init=@... между нашими и теми, что уже в стратегии:
-            # сохраняем порядок, выкидываем повторы.
-            full_args = self._dedup_lua_init(
-                [binary] + base_args + lua_args + strategy_args
-            )
+            # Полная команда (binary + base + lua-init + strategy), дедуп lua.
+            full_args = self.compose_command(strategy_args, binary=binary,
+                                              cfg=cfg)
             self._last_args = strategy_args
 
             log.info("Запуск nfqws2...", source="nfqws")
@@ -309,6 +300,45 @@ class NFQWSManager:
             "exit_code": self._exit_code,
         }
 
+    # ─────────────────────── command builder ───────────────────────
+
+    def compose_command(self, strategy_args: list, binary: str = None,
+                         cfg=None) -> list:
+        """Собрать полную команду запуска nfqws2.
+
+        Единый источник истины для argv: используется и при живом запуске
+        (start), и при генерации init-скрипта автозапуска — чтобы команды
+        были идентичны (одни и те же base-args, lua-init, blob-декларации).
+
+        Порядок: [binary] + base(--user/--fwmark/--qnum[/--bind-fix*]) +
+                 lua-init(core+ext) + strategy_args, с дедупом --lua-init.
+
+        Args:
+            strategy_args: Аргументы стратегии (то, что вернул
+                           StrategyManager.build_nfqws_args — уже с
+                           blob-декларациями и резолвленными путями).
+            binary: Путь к бинарнику nfqws2 (берётся из конфига, если None).
+            cfg: ConfigManager (получаем сами, если None).
+
+        Returns:
+            list[str] — полный argv (включая путь к бинарнику).
+        """
+        if cfg is None:
+            from core.config_manager import get_config_manager
+            cfg = get_config_manager()
+        if binary is None:
+            binary = cfg.get("zapret", "nfqws_binary")
+
+        strategy_args = list(strategy_args or [])
+        base_args = self._build_base_args(cfg)
+
+        lua_path = cfg.get("zapret", "lua_path") or "/opt/zapret2/lua"
+        lua_args = self._build_lua_init_args(strategy_args, lua_path)
+
+        return self._dedup_lua_init(
+            [binary] + base_args + lua_args + strategy_args
+        )
+
     # ─────────────────────── internal helpers ───────────────────────
 
     def _build_base_args(self, cfg) -> list:
@@ -331,7 +361,34 @@ class NFQWSManager:
         queue_num = cfg.get("nfqws", "queue_num", default=300)
         args.append("--qnum=%d" % int(queue_num))
 
+        # --bind-fix4/6 при нескольких WAN-интерфейсах. Без этого nfqws2
+        # биндит raw-сокет только к первому интерфейсу, и на multi-WAN
+        # (например, основной + резервный канал) обход на втором не работает.
+        # Логика как в nfqws2-keenetic (_startup_args).
+        try:
+            wan4 = self._detect_wan_interfaces(cfg, "wan")
+            if len(wan4) > 1:
+                args.append("--bind-fix4")
+                disable_ipv6 = cfg.get("nfqws", "disable_ipv6", default=True)
+                if not disable_ipv6:
+                    args.append("--bind-fix6")
+        except Exception:
+            # Детект интерфейсов не должен мешать запуску.
+            pass
+
         return args
+
+    @staticmethod
+    def _detect_wan_interfaces(cfg, role: str) -> list:
+        """WAN-интерфейсы из конфига или авто-детект по таблице маршрутов."""
+        val = cfg.get("interfaces", role, default="")
+        if isinstance(val, str):
+            val = val.strip()
+        if val:
+            return val.split()
+        from core.firewall import _detect_wan_from_routes, _detect_wan6_from_routes
+        return _detect_wan6_from_routes() if role == "wan6" \
+            else _detect_wan_from_routes()
 
     @staticmethod
     def _build_lua_init_args(strategy_args: list, lua_path: str) -> list:

--- a/core/strategy_builder.py
+++ b/core/strategy_builder.py
@@ -303,13 +303,16 @@ class StrategyManager:
         if not strategy or "profiles" not in strategy:
             return []
 
-        # Определяем hostlist из конфига если не задан
-        if hostlist_path is None:
-            from core.config_manager import get_config_manager
-            cfg = get_config_manager()
-            lists_path = cfg.get("zapret", "lists_path",
-                                 default="/opt/zapret2/lists")
-            hostlist_path = os.path.join(lists_path, "other.txt")
+        # Флаги списков (--hostlist / --hostlist-auto / --hostlist-exclude),
+        # которые надо подмешать в каждый профиль.
+        #   • hostlist_path задан явно (сканер) → один --hostlist=<path>
+        #     (обратная совместимость);
+        #   • иначе — по режиму filter.mode из конфига.
+        if hostlist_path is not None:
+            list_flags = (["--hostlist=%s" % hostlist_path]
+                          if os.path.isfile(hostlist_path) else [])
+        else:
+            list_flags = self._compute_list_flags()
 
         enabled_profiles = [
             p for p in strategy["profiles"]
@@ -331,11 +334,11 @@ class StrategyManager:
             # Парсим args из профиля
             profile_args = self._parse_profile_args(profile["args"])
 
-            # Вставляем --hostlist= перед --payload (если есть hostlist и
-            # профиль содержит filter)
-            if hostlist_path and os.path.isfile(hostlist_path):
-                profile_args = self._inject_hostlist(
-                    profile_args, hostlist_path
+            # Вставляем флаги списков перед --payload (если профиль их ещё
+            # не содержит).
+            if list_flags:
+                profile_args = self._inject_list_flags(
+                    profile_args, list_flags
                 )
 
             all_args.extend(profile_args)
@@ -402,19 +405,56 @@ class StrategyManager:
 
         return result
 
-    def _inject_hostlist(self, args: list, hostlist_path: str) -> list:
-        """
-        Вставить --hostlist=path в список аргументов профиля.
+    @staticmethod
+    def _compute_list_flags() -> list:
+        """Вычислить флаги списков по режиму filter.mode (паритет nfqws2-keenetic).
 
-        Вставляет после --filter-* аргументов, перед --payload.
-        Если --hostlist уже есть — не дублируем.
+        Режимы (config.filter.mode):
+          • none          — без списков: десинк применяется ко всему трафику,
+                            попавшему под --filter-* (MODE_ALL без exclude);
+          • hostlist      — только домены из other.txt (+ exclude netrogat);
+          • autohostlist  — other.txt + авто-список auto.txt, куда nfqws2 сам
+                            добавляет недоступные домены (+ exclude);
+          • ipset         — фильтрация по IP (--ipset), hostlist не подмешиваем.
+
+        Файл exclude (netrogat.txt) и hostlist (other.txt) добавляются только
+        если существуют; auto.txt добавляется всегда (nfqws2 создаёт его сам).
         """
-        # Проверяем: не содержит ли уже hostlist
+        from core.config_manager import get_config_manager
+        cfg = get_config_manager()
+        mode = (cfg.get("filter", "mode", default="hostlist") or "hostlist").lower()
+        lists_path = cfg.get("zapret", "lists_path",
+                             default="/opt/zapret2/lists")
+
+        if mode in ("ipset", "none"):
+            return []
+
+        flags = []
+        other = os.path.join(lists_path, "other.txt")
+        if os.path.isfile(other):
+            flags.append("--hostlist=%s" % other)
+
+        if mode in ("autohostlist", "auto"):
+            auto = os.path.join(lists_path, "auto.txt")
+            flags.append("--hostlist-auto=%s" % auto)
+
+        netrogat = os.path.join(lists_path, "netrogat.txt")
+        if os.path.isfile(netrogat):
+            flags.append("--hostlist-exclude=%s" % netrogat)
+
+        return flags
+
+    @staticmethod
+    def _inject_list_flags(args: list, list_flags: list) -> list:
+        """Вставить флаги списков в профиль (после --filter-*, перед --payload).
+
+        Если профиль уже содержит какой-либо --hostlist*/--ipset* — не трогаем
+        (полные winws2-пресеты несут свои списки).
+        """
         for a in args:
-            if a.startswith("--hostlist=") or a.startswith("--hostlist-exclude="):
-                return args  # Уже есть
+            if a.startswith("--hostlist") or a.startswith("--ipset"):
+                return args  # профиль сам задаёт списки
 
-        # Ищем позицию: после последнего --filter-* и перед --payload
         insert_pos = 0
         for i, a in enumerate(args):
             if a.startswith("--filter-"):
@@ -424,7 +464,8 @@ class StrategyManager:
                 break
 
         result = list(args)
-        result.insert(insert_pos, "--hostlist=%s" % hostlist_path)
+        for j, flag in enumerate(list_flags):
+            result.insert(insert_pos + j, flag)
         return result
 
     def build_preview_command(self, strategy: dict,

--- a/core/strategy_builder.py
+++ b/core/strategy_builder.py
@@ -340,6 +340,17 @@ class StrategyManager:
 
             all_args.extend(profile_args)
 
+        # Регистрация именованных blob'ов. Компактные каталоги (basic/advanced)
+        # ссылаются на blob=tls_google и т.п. через метаполе `blobs =`, но саму
+        # декларацию --blob=NAME:@bin/file.bin не несут — без неё nfqws2 шлёт
+        # ПУСТОЙ fake и обход не работает. Подмешиваем недостающие декларации
+        # ОДИН раз в начало (blob-декларации в nfqws2 глобальны, до первого
+        # --new). Уже объявленные в стратегии (полные winws2-пресеты) не дублируем.
+        from core.blob_registry import build_blob_declarations
+        blob_decls = build_blob_declarations(all_args)
+        if blob_decls:
+            all_args = blob_decls + all_args
+
         # Резолвим @lua/, @bin/, lists/ → абсолютные пути zapret2
         from core.catalog_loader import CatalogManager
         from core.config_manager import get_config_manager
@@ -510,6 +521,7 @@ def _catalog_entry_to_strategy(entry) -> dict:
         "label": entry.label,
         "author": entry.author,
         "protocol": entry.protocol,
+        "blobs": list(getattr(entry, "blobs", []) or []),
         "profiles": profiles,
     }
 

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.19.29"
+GUI_VERSION = "0.20.0"

--- a/tests/test_autostart_script.py
+++ b/tests/test_autostart_script.py
@@ -1,0 +1,75 @@
+# tests/test_autostart_script.py
+"""Тесты генерации init-скрипта автозапуска (S99zapret).
+
+Проверяем главное, что было сломано до портирования из nfqws2-keenetic:
+согласованность fwmark / queue-num между firewall-правилами скрипта и
+командой запуска nfqws2, наличие PREROUTING/NAT/TCP-flags правил и
+валидность shell-синтаксиса.
+"""
+
+import shutil
+import subprocess
+import unittest
+
+from core.autostart_manager import get_autostart_manager
+from core.config_manager import get_config_manager
+
+
+class TestGeneratedScript(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = get_autostart_manager()._generate_script()
+        cls.cfg = get_config_manager()
+
+    def test_queue_num_matches_config(self):
+        qnum = str(self.cfg.get("nfqws", "queue_num", default=300))
+        self.assertIn('QUEUE_NUM="%s"' % qnum, self.script)
+        # Не остался старый рассинхронизированный дефолт firewall.queue_num=200.
+        self.assertNotIn('QUEUE_NUM="200"', self.script)
+
+    def test_mark_matches_config(self):
+        mark = self.cfg.get("nfqws", "desync_mark", default="0x40000000")
+        self.assertIn("MARK_PROCESSED=\"%s/%s\"" % (mark, mark), self.script)
+        # Старый хардкод 0x10000 должен исчезнуть.
+        self.assertNotIn("0x10000", self.script)
+
+    def test_has_prerouting_chain(self):
+        self.assertIn("nfqws_pre", self.script)
+        self.assertIn("PREROUTING", self.script)
+
+    def test_has_nat_masquerade(self):
+        self.assertIn("nfqws_nat", self.script)
+        self.assertIn("MASQUERADE", self.script)
+
+    def test_has_tcp_flag_rules(self):
+        self.assertIn("--tcp-flags syn,ack syn,ack", self.script)
+        self.assertIn("--tcp-flags fin fin", self.script)
+        self.assertIn("--tcp-flags rst rst", self.script)
+
+    def test_has_conntrack_tuning(self):
+        self.assertIn("nf_conntrack_tcp_be_liberal=1", self.script)
+        self.assertIn("nf_conntrack_checksum=0", self.script)
+
+    def test_has_reapply_subcommands(self):
+        # Нужны для ndm/hotplug-хуков переустановки правил.
+        for cmd in ("firewall_iptables", "firewall_ip6tables",
+                    "firewall_stop", "reapply"):
+            self.assertIn(cmd, self.script)
+
+    def test_no_unsubstituted_placeholders(self):
+        self.assertNotIn("@", self.script.split("NFQWS_ARGS=")[0])
+
+    def test_shell_syntax_valid(self):
+        sh = shutil.which("sh")
+        if not sh:
+            self.skipTest("sh недоступен")
+        proc = subprocess.run(
+            [sh, "-n"], input=self.script,
+            text=True, capture_output=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_blob_registry.py
+++ b/tests/test_blob_registry.py
@@ -1,0 +1,108 @@
+# tests/test_blob_registry.py
+"""Тесты реестра именованных blob'ов (core/blob_registry.py)."""
+
+import unittest
+
+from core import blob_registry as br
+
+
+class TestReferencedBlobNames(unittest.TestCase):
+
+    def test_extracts_from_lua_desync(self):
+        args = ["--lua-desync=fake:blob=tls_google:repeats=6"]
+        self.assertEqual(br.referenced_blob_names(args), ["tls_google"])
+
+    def test_unique_in_order(self):
+        args = [
+            "--lua-desync=fake:blob=tls7",
+            "--lua-desync=multisplit:seqovl_pattern=tls7",
+            "--lua-desync=fake:blob=tls_max",
+        ]
+        # seqovl_pattern=tls7 не содержит blob=, поэтому только blob= ссылки
+        self.assertEqual(br.referenced_blob_names(args), ["tls7", "tls_max"])
+
+    def test_empty(self):
+        self.assertEqual(br.referenced_blob_names(["--lua-desync=multisplit"]), [])
+
+
+class TestBuildBlobDeclarations(unittest.TestCase):
+
+    def test_known_name_declared(self):
+        decls = br.build_blob_declarations(["--lua-desync=fake:blob=tls_google"])
+        self.assertEqual(
+            decls,
+            ["--blob=tls_google:@bin/tls_clienthello_www_google_com.bin"],
+        )
+
+    def test_builtin_skipped(self):
+        self.assertEqual(
+            br.build_blob_declarations(["--lua-desync=fake:blob=fake_default_tls"]),
+            [],
+        )
+
+    def test_inline_hex_skipped(self):
+        self.assertEqual(
+            br.build_blob_declarations(["--lua-desync=fake:blob=0x00000000"]),
+            [],
+        )
+
+    def test_already_declared_not_duplicated(self):
+        args = [
+            "--blob=tls7:@bin/tls_clienthello_7.bin",
+            "--lua-desync=fake:blob=tls7",
+        ]
+        self.assertEqual(br.build_blob_declarations(args), [])
+
+    def test_unknown_name_skipped(self):
+        self.assertEqual(
+            br.build_blob_declarations(["--lua-desync=fake:blob=does_not_exist_xyz"]),
+            [],
+        )
+
+    def test_multiple_names(self):
+        args = [
+            "--lua-desync=fake:blob=tls_google",
+            "--new",
+            "--lua-desync=fake:blob=quic_google",
+        ]
+        decls = br.build_blob_declarations(args)
+        self.assertEqual(len(decls), 2)
+        self.assertTrue(any("tls_google" in d for d in decls))
+        self.assertTrue(any("quic_google" in d for d in decls))
+
+
+class TestRegistryContent(unittest.TestCase):
+
+    def test_fallback_aliases_present(self):
+        # Реестр должен содержать ключевые имена даже без каталогов.
+        for name in ("tls_google", "tls7", "quic_google", "stun_pat", "dtls_w3"):
+            self.assertIsNotNone(br.get_blob_value(name), name)
+
+    def test_reload_does_not_crash(self):
+        br.reload_registry()
+        self.assertIsNotNone(br.get_blob_value("tls_google"))
+
+
+class TestStrategyBuilderIntegration(unittest.TestCase):
+
+    def test_basic_strategy_gets_blob_declaration(self):
+        from core.strategy_builder import get_strategy_manager
+        sm = get_strategy_manager()
+        sm.load_strategies()
+        s = sm.get_strategy("censorliber_tls_google_syndata_tcpack_fake")
+        if s is None:
+            self.skipTest("каталог basic недоступен в тестовой среде")
+        args = sm.build_nfqws_args(s, hostlist_path=None)
+        # Должна появиться декларация blob'а tls_google (с резолвом @bin/).
+        blob_decls = [a for a in args if a.startswith("--blob=tls_google:")]
+        self.assertEqual(len(blob_decls), 1)
+        self.assertIn("tls_clienthello_www_google_com.bin", blob_decls[0])
+        # И декларация должна идти ДО ссылки на неё.
+        decl_idx = args.index(blob_decls[0])
+        ref_idx = next(i for i, a in enumerate(args) if "blob=tls_google" in a
+                       and not a.startswith("--blob="))
+        self.assertLess(decl_idx, ref_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_ports_migration.py
+++ b/tests/test_config_ports_migration.py
@@ -1,0 +1,45 @@
+# tests/test_config_ports_migration.py
+"""Тесты миграции портов: расширяем только нетронутые узкие дефолты."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from core.config_manager import ConfigManager
+
+
+def _load_with(saved: dict):
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "settings.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(saved, f)
+    cm = ConfigManager(config_dir=d)
+    cm.load()
+    return cm
+
+
+class TestPortsMigration(unittest.TestCase):
+
+    def test_old_default_tcp_widened(self):
+        cm = _load_with({"nfqws": {"ports_tcp": "80,443", "ports_udp": "443"}})
+        self.assertNotEqual(cm.get("nfqws", "ports_tcp"), "80,443")
+        self.assertIn("5222", cm.get("nfqws", "ports_tcp"))
+        self.assertIn("49152:65535", cm.get("nfqws", "ports_udp"))
+
+    def test_custom_tcp_preserved(self):
+        cm = _load_with({"nfqws": {"ports_tcp": "80,443,9999",
+                                   "ports_udp": "443,1234"}})
+        self.assertEqual(cm.get("nfqws", "ports_tcp"), "80,443,9999")
+        self.assertEqual(cm.get("nfqws", "ports_udp"), "443,1234")
+
+    def test_fresh_install_has_wide_defaults(self):
+        d = tempfile.mkdtemp()
+        cm = ConfigManager(config_dir=d)
+        cm.load()
+        self.assertIn("8443", cm.get("nfqws", "ports_tcp"))
+        self.assertIn("3478:3481", cm.get("nfqws", "ports_udp"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_firewall_persistence.py
+++ b/tests/test_firewall_persistence.py
@@ -1,0 +1,101 @@
+# tests/test_firewall_persistence.py
+"""Тесты персистентности firewall-правил (ndm/hotplug-хуки + reapply)."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from core import firewall_persistence as fp
+
+
+def _sh_ok(text):
+    sh = shutil.which("sh")
+    if not sh:
+        return True  # нет sh — пропускаем проверку
+    return subprocess.run([sh, "-n"], input=text, text=True,
+                          capture_output=True).returncode == 0
+
+
+class TestGeneratedScripts(unittest.TestCase):
+
+    def test_reapply_script_valid_shell(self):
+        self.assertTrue(_sh_ok(fp.build_reapply_script()))
+
+    def test_ndm_hook_valid_shell(self):
+        self.assertTrue(_sh_ok(fp.build_ndm_hook()))
+
+    def test_hotplug_hook_valid_shell(self):
+        self.assertTrue(_sh_ok(fp.build_hotplug_hook()))
+
+    def test_shared_funcs_valid_shell(self):
+        # Функции должны быть валидны при заданных переменных.
+        prelude = (
+            'QUEUE_NUM=300\nPORTS_TCP="80,443"\nPORTS_UDP="443"\n'
+            'MAX_PKT_OUT=20\nMAX_PKT_OUT_UDP=5\n'
+            'MARK_PROCESSED="0x40000000/0x40000000"\n'
+            'MARK_EXCLUDE="0x20000000/0x20000000"\n'
+            'IPV6_ENABLED=0\nWAN_IFACES="eth0"\n'
+        )
+        self.assertTrue(_sh_ok(prelude + fp.FIREWALL_SH_FUNCTIONS))
+
+    def test_ndm_hook_filters_table(self):
+        body = fp.build_ndm_hook()
+        self.assertIn("mangle", body)
+        self.assertIn("nat", body)
+        self.assertIn("reapply", body)
+
+    def test_hooks_check_pidfiles(self):
+        for body in (fp.build_ndm_hook(), fp.build_hotplug_hook()):
+            self.assertIn(fp.AUTOSTART_PID_FILE, body)
+            self.assertIn(fp.GUI_PID_FILE, body)
+
+
+class TestRunConf(unittest.TestCase):
+
+    def test_render_contains_all_keys(self):
+        conf = fp.render_run_conf({
+            "queue_num": 300, "ports_tcp": "80,443", "ports_udp": "443",
+            "tcp_pkt_out": 20, "udp_pkt_out": 5, "pkt_in": 15,
+            "mark_processed": "0x40000000/0x40000000",
+            "mark_exclude": "0x20000000/0x20000000",
+            "ipv6_enabled": "0", "wan_ifaces": "eth0",
+        })
+        for key in ("QUEUE_NUM", "PORTS_TCP", "PORTS_UDP", "MAX_PKT_OUT",
+                    "MARK_PROCESSED", "MARK_EXCLUDE", "WAN_IFACES"):
+            self.assertIn(key + "=", conf)
+
+
+class TestInstallRemove(unittest.TestCase):
+
+    def test_install_and_remove_in_tempdirs(self):
+        with tempfile.TemporaryDirectory() as d:
+            ndm = os.path.join(d, "ndm", "100-zapret-gui.sh")
+            hot = os.path.join(d, "hotplug", "90-zapret-gui")
+            with mock.patch.object(fp, "NDM_HOOK_PATH", ndm), \
+                 mock.patch.object(fp, "HOTPLUG_HOOK_PATH", hot), \
+                 mock.patch.object(fp, "is_keenetic", return_value=True), \
+                 mock.patch.object(fp, "is_openwrt_hotplug", return_value=True):
+                res = fp.install_hooks()
+                self.assertTrue(res["ndm"])
+                self.assertTrue(res["hotplug"])
+                self.assertTrue(os.path.isfile(ndm))
+                self.assertTrue(os.path.isfile(hot))
+                # Исполняемый бит выставлен.
+                self.assertTrue(os.access(ndm, os.X_OK))
+
+                rem = fp.remove_hooks()
+                self.assertIn(ndm, rem["removed"])
+                self.assertFalse(os.path.isfile(ndm))
+
+    def test_install_noop_when_not_router(self):
+        with mock.patch.object(fp, "is_keenetic", return_value=False), \
+             mock.patch.object(fp, "is_openwrt_hotplug", return_value=False):
+            res = fp.install_hooks()
+            self.assertEqual(res["installed"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_firewall_rules.py
+++ b/tests/test_firewall_rules.py
@@ -1,0 +1,101 @@
+# tests/test_firewall_rules.py
+"""Тесты состава правил FirewallManager (iptables / nftables).
+
+Не выполняем реальные iptables-команды — перехватываем _run_cmd и проверяем,
+что после портирования из nfqws2-keenetic появились правила обоих направлений,
+NAT MASQUERADE и обработка TCP-флагов.
+"""
+
+import unittest
+from unittest import mock
+
+from core.firewall import FirewallManager
+
+
+def _capture_iptables(fw):
+    """Запустить _apply_ipt_family для iptables, вернуть список команд (списки)."""
+    captured = []
+
+    def fake_run(cmd):
+        captured.append(cmd)
+        return True
+
+    with mock.patch.object(fw, "_run_cmd", side_effect=fake_run), \
+            mock.patch("core.firewall.shutil.which", return_value="/sbin/iptables"):
+        rules = []
+        fw._apply_ipt_family(
+            "iptables", 300, "80,443", "443",
+            "0x40000000", 20, 5, ["eth0"], rules,
+        )
+    return captured
+
+
+class TestIptablesRules(unittest.TestCase):
+
+    def setUp(self):
+        self.fw = FirewallManager()
+        self.cmds = _capture_iptables(self.fw)
+        self.flat = [" ".join(c) for c in self.cmds]
+
+    def test_has_postrouting_and_prerouting(self):
+        self.assertTrue(any("POSTROUTING" in c for c in self.flat))
+        self.assertTrue(any("PREROUTING" in c for c in self.flat))
+
+    def test_has_nat_masquerade(self):
+        nat = [c for c in self.flat if "nat" in c and "MASQUERADE" in c]
+        self.assertTrue(nat, "ожидалось NAT MASQUERADE правило")
+
+    def test_has_tcp_flag_rules(self):
+        self.assertTrue(any("--tcp-flags syn,ack syn,ack" in c for c in self.flat))
+        self.assertTrue(any("--tcp-flags fin fin" in c for c in self.flat))
+        self.assertTrue(any("--tcp-flags rst rst" in c for c in self.flat))
+
+    def test_has_mark_exclude_return(self):
+        ret = [c for c in self.flat if "connmark" in c and "RETURN" in c]
+        self.assertTrue(ret, "ожидался RETURN для MARK_EXCLUDE")
+
+    def test_reply_connbytes_in_prerouting(self):
+        pre_reply = [c for c in self.flat
+                     if "PREROUTING" in c and "connbytes-dir=reply" in c]
+        self.assertTrue(pre_reply)
+
+    def test_outgoing_uses_dports_incoming_uses_sports(self):
+        post = [c for c in self.flat if "POSTROUTING" in c and "multiport" in c]
+        pre = [c for c in self.flat if "PREROUTING" in c and "multiport" in c]
+        self.assertTrue(all("--dports" in c for c in post))
+        self.assertTrue(all("--sports" in c for c in pre))
+
+
+class TestNftablesRules(unittest.TestCase):
+
+    def setUp(self):
+        self.fw = FirewallManager()
+        captured = []
+
+        def fake_run(cmd):
+            captured.append(" ".join(cmd))
+            return True
+
+        with mock.patch.object(self.fw, "_run_cmd", side_effect=fake_run):
+            self.fw._apply_nftables(
+                300, "80,443", "443", "0x40000000", 20, 5,
+                ["eth0"], None,
+            )
+        self.flat = captured
+
+    def test_three_chains_created(self):
+        joined = "\n".join(self.flat)
+        self.assertIn("postrouting", joined)
+        self.assertIn("prerouting", joined)
+        self.assertIn("natpost", joined)
+
+    def test_has_masquerade(self):
+        self.assertTrue(any("masquerade" in c for c in self.flat))
+
+    def test_has_tcp_flags(self):
+        joined = "\n".join(self.flat)
+        self.assertIn("tcp flags syn,ack", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_strategy_list_modes.py
+++ b/tests/test_strategy_list_modes.py
@@ -1,0 +1,73 @@
+# tests/test_strategy_list_modes.py
+"""Тесты режимов списков (filter.mode) при сборке аргументов стратегии."""
+
+import os
+import tempfile
+import unittest
+
+from core.config_manager import get_config_manager
+from core.strategy_builder import get_strategy_manager
+
+
+class TestListFlagModes(unittest.TestCase):
+
+    def setUp(self):
+        self.cfg = get_config_manager()
+        self.cfg.load()
+        self.d = tempfile.mkdtemp()
+        with open(os.path.join(self.d, "other.txt"), "w") as f:
+            f.write("youtube.com\n")
+        with open(os.path.join(self.d, "netrogat.txt"), "w") as f:
+            f.write("vk.com\n")
+        self.cfg.set("zapret", "lists_path", self.d)
+        self.sm = get_strategy_manager()
+
+    def _flags(self, mode):
+        self.cfg.set("filter", "mode", mode)
+        return self.sm._compute_list_flags()
+
+    def test_hostlist_mode(self):
+        flags = self._flags("hostlist")
+        self.assertTrue(any(f.startswith("--hostlist=") for f in flags))
+        self.assertTrue(any(f.startswith("--hostlist-exclude=") for f in flags))
+        self.assertFalse(any("--hostlist-auto=" in f for f in flags))
+
+    def test_autohostlist_mode_adds_auto(self):
+        flags = self._flags("autohostlist")
+        self.assertTrue(any(f.startswith("--hostlist-auto=") for f in flags))
+
+    def test_none_mode_empty(self):
+        self.assertEqual(self._flags("none"), [])
+
+    def test_ipset_mode_empty(self):
+        self.assertEqual(self._flags("ipset"), [])
+
+    def test_inject_respects_existing_hostlist(self):
+        args = ["--filter-tcp=443", "--hostlist=/x/custom.txt",
+                "--lua-desync=multisplit"]
+        out = self.sm._inject_list_flags(args, ["--hostlist=/y/other.txt"])
+        self.assertEqual(out, args)  # не трогаем — профиль сам задал список
+
+    def test_inject_after_filter(self):
+        args = ["--filter-tcp=443", "--lua-desync=multisplit"]
+        out = self.sm._inject_list_flags(args, ["--hostlist=/y/other.txt"])
+        self.assertEqual(out[0], "--filter-tcp=443")
+        self.assertEqual(out[1], "--hostlist=/y/other.txt")
+
+    def test_explicit_path_backward_compat(self):
+        # Явный hostlist_path (как у сканера) → один --hostlist=<path>.
+        path = os.path.join(self.d, "other.txt")
+        strategy = {
+            "id": "t", "name": "t", "profiles": [
+                {"id": "p1", "args": "--filter-tcp=443 --lua-desync=multisplit",
+                 "enabled": True}
+            ],
+        }
+        args = self.sm.build_nfqws_args(strategy, hostlist_path=path)
+        hl = [a for a in args if a.startswith("--hostlist=")]
+        self.assertEqual(len(hl), 1)
+        self.assertIn(path, hl[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR ports critical firewall and configuration management features from nfqws2-keenetic to achieve feature parity and fix silent bypass failures. The main issues addressed are:

1. **Named blob registration** — compact catalogs referenced blobs like `blob=tls_google` without declaring them, causing nfqws2 to send empty fake packets
2. **Firewall rule persistence** — system firewall flushes (Keenetic NDMS, OpenWrt fw3/fw4) would silently drop NFQUEUE rules, breaking bypass
3. **Autostart desynchronization** — generated S99zapret used hardcoded `fwmark=0x10000` and `queue=200` instead of config values, causing mark mismatches

## Key Changes

### New Modules
- **`core/blob_registry.py`** — Registry of named blob aliases (59 entries from upstream catalogs). Automatically generates missing `--blob=NAME:@bin/file.bin` declarations before first `--new` in strategy args.
- **`core/firewall_persistence.py`** — Persistence layer for router environments (Keenetic NDM, OpenWrt hotplug). Provides:
  - `FIREWALL_SH_FUNCTIONS` — unified shell firewall logic (ported from nfqws2-keenetic)
  - NDM hook (`/opt/etc/ndm/netfilter.d/100-zapret-gui.sh`)
  - OpenWrt hotplug hook (`/etc/hotplug.d/firewall/90-zapret-gui`)
  - Runtime config persistence (`/opt/etc/zapret-gui/firewall.run`)
  - Reapply script for rule restoration after system firewall flush

### Core Refactoring
- **`core/autostart_manager.py`**
  - Replaced hardcoded init-script template with `_S99ZAPRET_TEMPLATE` (118 lines)
  - Added `_is_openwrt_procd()` detection for pure OpenWrt with procd
  - `_generate_script()` now uses actual config values (queue_num, marks, ports) instead of hardcoded defaults
  - Integrated blob registry and firewall persistence hooks
  - Generates firewall rules matching nfqws2-keenetic schema: separate chains (nfqws_post/nfqws_pre/nfqws_nat), MARK_PROCESSED/MARK_EXCLUDE, bidirectional rules, NAT MASQUERADE for UDP, TCP flag handling

- **`core/firewall.py`**
  - Added `_extra` dict for PREROUTING/NAT/TCP-flag parameters (tcp_pkt_in, udp_pkt_in, mark_exclude)
  - `_apply_ipt_family()` now generates rules for both directions (POSTROUTING + PREROUTING)
  - Added NAT MASQUERADE rules for IPv4 UDP
  - Added TCP flag rules (syn,ack / fin / rst)
  - Added `_apply_sysctl_tuning()` for conntrack tuning (be_liberal, checksum)
  - Added `_ensure_persistence()` to save runtime config and install hooks

- **`core/nfqws_manager.py`**
  - Extracted `compose_command()` method — unified command builder used by both live start and autostart script generation
  - Ensures identical argv between modes (base args, lua-init, blob declarations)

- **`core/strategy_builder.py`**
  - Added `_compute_list_flags()` to generate `--hostlist/--hostlist-auto/--hostlist-exclude` based on `filter.mode` config
  - Replaced `_inject_hostlist()` with `_inject_list_flags()` for flexibility
  - Integrated blob registry: `build_blob_declarations()` generates missing `--blob=` declarations

- **`core/config_manager.py`**
  - Expanded default ports to match nfqws2-keenetic: TCP includes Cloudflare alt-ports (2053

https://claude.ai/code/session_015eeqpW4GfH9h4xNvcDJPrV