### PR TITLE
fix(firewall): nft диапазоны портов через дефис, а не двоеточие (issu…

### DIFF
--- a/core/firewall.py
+++ b/core/firewall.py
@@ -32,6 +32,26 @@ NFT_TABLE = "zapret_gui"
 IPT_COMMENT = "zapret-gui"
 
 
+def _nft_port_set(spec: str) -> str:
+    """
+    Преобразовать iptables/multiport-список портов в nftables-синтаксис.
+
+    Диапазоны в nft записываются через дефис (`3478-3481`), тогда как
+    iptables-multiport и наш конфиг используют двоеточие (`3478:3481`).
+    Без конверсии nft падает с «Could not resolve service: Servname not
+    supported for ai_socktype» (issue #101).
+
+      "443,3478:3481,5349"  →  "443, 3478-3481, 5349"
+    """
+    parts = []
+    for tok in str(spec or "").split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        parts.append(tok.replace(":", "-"))
+    return ", ".join(parts)
+
+
 # При запуске от обычного пользователя на Debian/Ubuntu (`python3 app.py`)
 # в PATH отсутствуют /sbin и /usr/sbin, где живут iptables/nft. Из-за
 # этого shutil.which() и subprocess не находят бинарники, и весь модуль
@@ -708,8 +728,8 @@ class FirewallManager:
 
         oif = _iface("oifname")
         iif = _iface("iifname")
-        tcp_ports = "{ %s }" % ports_tcp if ports_tcp else None
-        udp_ports = "{ %s }" % ports_udp if ports_udp else None
+        tcp_ports = "{ %s }" % _nft_port_set(ports_tcp) if ports_tcp else None
+        udp_ports = "{ %s }" % _nft_port_set(ports_udp) if ports_udp else None
 
         cmds = []
         cmds.append("add table inet %s" % NFT_TABLE)

--- a/tests/test_firewall_rules.py
+++ b/tests/test_firewall_rules.py
@@ -97,5 +97,37 @@ class TestNftablesRules(unittest.TestCase):
         self.assertIn("tcp flags syn,ack", joined)
 
 
+    def test_port_ranges_use_dash_not_colon(self):
+        """Регрессия #101: nft диапазоны портов — через дефис."""
+        fw = FirewallManager()
+        captured = []
+        with mock.patch.object(fw, "_run_cmd",
+                               side_effect=lambda c: captured.append(" ".join(c)) or True):
+            fw._apply_nftables(
+                300, "80,443", "443,3478:3481,19294:19344,49152:65535",
+                "0x40000000", 20, 5, ["eth0"], None)
+        joined = "\n".join(captured)
+        self.assertIn("3478-3481", joined)
+        self.assertIn("19294-19344", joined)
+        self.assertIn("49152-65535", joined)
+        # старого двоеточного синтаксиса в udp dport/sport быть не должно
+        self.assertNotIn("3478:3481", joined)
+
+
+class TestNftPortSet(unittest.TestCase):
+
+    def test_converts_colon_to_dash(self):
+        from core.firewall import _nft_port_set
+        self.assertEqual(_nft_port_set("443,3478:3481,5349"),
+                         "443, 3478-3481, 5349")
+
+    def test_single_port(self):
+        from core.firewall import _nft_port_set
+        self.assertEqual(_nft_port_set("443"), "443")
+
+    def test_strips_blanks(self):
+        from core.firewall import _nft_port_set
+        self.assertEqual(_nft_port_set("443, , 80:90,"), "443, 80-90")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…e #101)

На nftables-системах (Debian 13/trixie) правила падали с «Could not resolve service: Servname not supported for ai_socktype», потому что порт-диапазоны передавались в iptables-multiport-синтаксисе (3478:3481). nft требует дефис (3478-3481).

- core/firewall._nft_port_set(): конвертирует список портов (443,3478:3481,...) в nft-формат (443, 3478-3481, ...); применяется в _apply_nftables к tcp/udp dport/sport.
- iptables-путь и firewall_persistence (iptables) не тронуты — там ':' корректен.
- tests: _nft_port_set + регрессия в TestNftablesRules (диапазоны с дефисом).

https://claude.ai/code/session_01ThK9hE9JG4obCy8ioJiWkq