### PR TITLE
Fix #123: kill stray nfqws2 processes on switch; full CLI reference i…

### DIFF
--- a/.claude/skills/nfqws2-strategies/SKILL.md
+++ b/.claude/skills/nfqws2-strategies/SKILL.md
@@ -71,7 +71,7 @@ nfqws2 --qnum 300 \
 | `--ipset=FILE` / `--ipset-exclude=FILE` | Матч по IP |
 | `--new` | Разделитель ПРОФИЛЕЙ (мультистратегия) |
 | `--lua-desync=FN:p1=v1:p2=v2` | Вызов desync-функции (несколько — выполняются последовательно) |
-| `--debug` | Подробный пер-пакетный лог. **Главный инструмент отладки.** |
+| `--debug[=0\|1\|syslog\|@file]` | Пер-пакетный лог. Бэйр `--debug` ≡ `--debug=1`. **Главный инструмент отладки.** Полный справочник опций — §8. |
 
 ### Desync-функции и частые параметры
 
@@ -282,3 +282,130 @@ nfqws2 --qnum 200 --debug \
 - При генерации стратегий «на лету» (`strategy_generator`) дедуп по
   нормализованным args (`_norm_args`).
 - Тестировать всегда на ЗАБЛОКИРОВАННОМ ресурсе, иначе baseline-aware даст 0%.
+
+---
+
+## 8. Полный справочник CLI nfqws2 (`nfqws2 -?`, v0.9.5.2)
+
+Дамп `./nfqws2 -?` движка `bol-van/zapret2`. Версия движка печатается так:
+`github version v0.9.5.2 (<git-hash>) lua_compat_ver 5`. Это **источник истины**
+по опциям — сверяться с ним, а не угадывать. Опции с `[0|1]`/`[=val]` имеют
+необязательный аргумент (без него включаются дефолтом, обычно `=1`).
+
+### 8.1 Глобальные / общие
+
+| Опция | Назначение |
+|---|---|
+| `@<config_file>` / `$<config_file>` | Читать опции из файла. **Должен быть единственным аргументом** — остальные игнорируются. |
+| `--debug=0\|1\|syslog\|@<filename>` | Уровень/назначение отладочного лога. Бэйр `--debug` ≡ `=1`. |
+| `--version` | Печать версии и выход. |
+| `--dry-run` | Проверить параметры и выйти с кодом 0 при успехе. **Использовать для валидации стратегии без запуска** (preview/lint). |
+| `--comment=<text>` | Комментарий (no-op, для читабельности конфига). |
+| `--intercept=0\|1` | Включить перехват. Если выключить — выполнить только lua-init и выйти. |
+| `--qnum=<n>` | Номер NFQUEUE (== firewall `queue num`). |
+| `--daemon` | Демонизироваться. **GUI запускает БЕЗ него** (foreground-child + Popen). С ним работает только автозапуск `S99zapret` (свой `--pidfile`). |
+| `--chdir[=path]` | Сменить рабочий каталог (без аргумента — EXEDIR). |
+| `--pidfile=<file>` | Записать PID в файл. |
+| `--user=<username>` | Сбросить root-привилегии на пользователя. |
+| `--uid=uid[:gid1,gid2,...]` | Сбросить привилегии по uid/gid. |
+| `--bind-fix4` / `--bind-fix6` | Фикс выбора исходящего интерфейса для генерируемых IPv4/IPv6 пакетов (multi-WAN). |
+| `--fwmark=<int\|0xHEX>` | fwmark генерируемых пакетов. **Дефолт `0x40000000` (1073741824)**. |
+| `--ctrack-timeouts=S:E:F[:U]` | Таймауты внутреннего conntrack: TCP SYN, ESTABLISHED, FIN, UDP. Дефолт `60:300:60:60`. |
+| `--ctrack-disable[=0\|1]` | Отключить внутренний conntrack. |
+| `--payload-disable[=type[,type]]` | Не детектировать эти типы payload (без аргумента — все). |
+| `--server[=0\|1]` | Менять обработку src/dst ip/port для входящих соединений (серверный режим). |
+| `--ipcache-lifetime=<int>` | TTL кэша hop-count/имени домена, сек (дефолт 7200, 0 = вечно). |
+| `--ipcache-hostname[=0\|1]` | Кэшировать ip→hostname. |
+| `--reasm-disable[=type[,type]]` | Отключить reasm для L7 payload: `tls_client_hello`, `quic_initial` (без аргумента — все). |
+
+### 8.2 DESYNC ENGINE INIT
+
+| Опция | Назначение |
+|---|---|
+| `--writeable[=<dir>]` | Создать writeable-каталог для LUA-скриптов, путь → env `WRITEABLE` (только один). |
+| `--blob=<name>:[+ofs]@<file>\|0xHEX` | Загрузить blob в LUA-переменную `<name>`. Поддержан offset `+ofs`. |
+| `--lua-init=@<file>\|<lua_text>` | Загрузить LUA из файла или строки. **Порядок нескольких сохраняется.** Поддержаны gzip-файлы. |
+| `--lua-gc=<int>` | Принудительный GC каждые N сек (дефолт 60, триггерится при приходе пакета, 0 = выкл). |
+
+### 8.3 MULTI-STRATEGY (профили)
+
+| Опция | Назначение |
+|---|---|
+| `--new[=<name>]` | Начать новый профиль (опционально имя). |
+| `--skip` | Не использовать этот профиль. |
+| `--name=<name>` | Задать имя профиля. |
+| `--template[=<name>]` | Использовать профиль как шаблон (должен быть именованным). |
+| `--cookie[=<str>]` | Передать в LUA строку, привязанную к профилю. |
+| `--import=<name>` | Заполнить текущий профиль данными шаблона. |
+| `--filter-l3=ipv4\|ipv6` | Фильтр L3 (через запятую). |
+| `--filter-tcp=[~]port1[-port2]\|*` | Фильтр TCP-портов. `~` — отрицание. Список через запятую. Задание tcp-фильтра без прочих запрещает прочие. |
+| `--filter-udp=[~]port1[-port2]\|*` | Фильтр UDP-портов (аналогично). |
+| `--filter-icmp=type[:code]\|*` | Фильтр ICMP type+code. |
+| `--filter-ipp=proto` | Фильтр IP-протокола. |
+| `--filter-l7=proto[,proto]` | L6-L7 фильтр. Полный список ниже (§8.6). |
+| `--filter-ssid=ssid1[,...]` | Пер-профильный Wi-Fi SSID-фильтр. |
+| `--ipset=<file>` | Include по IP/CIDR (ipv4+ipv6, gzip, несколько). |
+| `--ipset-ip=<list>` | Фиксированный список подсетей через запятую. |
+| `--ipset-exclude=<file>` / `--ipset-exclude-ip=<list>` | Exclude по IP. |
+| `--hostlist=<file>` | Десинк только для перечисленных хостов (поддомены автоматически, gzip, несколько). |
+| `--hostlist-domains=<list>` | Фиксированный список доменов через запятую. |
+| `--hostlist-exclude=<file>` / `--hostlist-exclude-domains=<list>` | Исключения по хостам. |
+| `--hostlist-auto=<file>` | Автодетект DPI-блокировок и построение hostlist. |
+| `--hostlist-auto-fail-threshold=<int>` | Сколько фейлов добавляют хост в auto-hostlist (дефолт 3). |
+| `--hostlist-auto-fail-time=<int>` | Все фейлы в пределах N сек (дефолт 60). |
+| `--hostlist-auto-retrans-threshold=<int>` | Сколько ретрансмиссий запроса = провал попытки (дефолт 3). |
+| `--hostlist-auto-retrans-maxseq=<int>` | Считать ретрансмиссии только в пределах rel-seq (дефолт 32768). |
+| `--hostlist-auto-retrans-reset=[0\|1]` | Слать RST ретрансмиттеру (дефолт 1). |
+| `--hostlist-auto-incoming-maxseq=<int>` | Считать соединение успешным, если входящий rel-seq превысил порог (дефолт 4096). |
+| `--hostlist-auto-udp-out=<int>` | UDP-провал: отправлено ≥ udp_out пакетов (дефолт 4). |
+| `--hostlist-auto-udp-in=<int>` | UDP-провал: получено ≤ udp_in пакетов (дефолт 1). |
+| `--hostlist-auto-debug=<logfile>` | Лог срабатываний auto-hostlist (глобальный параметр). |
+
+### 8.4 LUA PACKET PASS MODE
+
+| Опция | Назначение |
+|---|---|
+| `--payload=type[,type]` | Какие типы payload обрабатывают следующие LUA-функции. Полный список — §8.6. |
+| `--out-range=[(n\|a\|d\|s\|p)<int>](-\|<)[...]` | Диапазон исходящих пакетов для следующих LUA-функций. |
+| `--in-range=[(n\|a\|d\|s\|p)<int>](-\|<)[...]` | Диапазон входящих пакетов. |
+
+Префиксы диапазона: `n` — номер пакета, `d` — номер data-пакета, `s` — rel-seq,
+`p` — позиция данных в rel-seq, `b` — счётчик байт, `x` — никогда, `a` — всегда.
+`-` включает конечную позицию, `<` — не включает.
+
+### 8.5 LUA DESYNC ACTION
+
+| Опция | Назначение |
+|---|---|
+| `--lua-desync=<function>[:p1=v1[:p2=v2]]` | Вызвать LUA-функцию при приходе пакета. |
+
+### 8.6 Справочные списки значений
+
+**`--filter-l7`:** `all unknown known http tls dtls quic wireguard dht discord
+stun xmpp dns mtproto bt utp_bt`.
+
+**`--payload` (типы):** `all unknown empty known ipv4 ipv6 icmp http_req
+http_reply tls_client_hello tls_server_hello dtls_client_hello
+dtls_server_hello quic_initial wireguard_initiation wireguard_response
+wireguard_cookie wireguard_keepalive wireguard_data dht discord_ip_discovery
+stun xmpp_stream xmpp_starttls xmpp_proceed xmpp_features dns_query dns_response
+mtproto_initial bt_handshake utp_bt_handshake`.
+
+**`--reasm-disable` (типы):** `tls_client_hello quic_initial`.
+
+### 8.7 Важные следствия для zapret-gui
+
+- **`--dry-run`** — штатный способ валидировать собранную стратегию без
+  поднятия NFQUEUE (можно прикрутить к `build_preview_command`/линтеру
+  стратегий: собрать argv через `compose_command`, заменить запуск на
+  `--dry-run`, проверить код возврата 0).
+- **`--version`** даёт `lua_compat_ver` — полезно при диагностике
+  несовместимости lua-скриптов с версией движка.
+- **`--fwmark` дефолт `0x40000000`** совпадает с нашим `nfqws.desync_mark` —
+  не путать с firewall MARK_PROCESSED/MARK_EXCLUDE (другой слой).
+- `@<config_file>` обязан быть **единственным** аргументом — нельзя
+  смешивать файл-конфиг с inline-опциями. Мы собираем всё inline через
+  `compose_command`, файл-конфиг не используем.
+- `--daemon` использует только автозапуск `S99zapret`; GUI ведёт процесс
+  как foreground-child. Один nfqws2 на NFQUEUE — дубли зачищает
+  `NFQWSManager._sweep_stray_processes` (issue #123).

--- a/core/nfqws_manager.py
+++ b/core/nfqws_manager.py
@@ -115,6 +115,12 @@ class NFQWSManager:
             # Режим отладки: при --debug stderr nfqws2 показываем на INFO.
             self._debug = bool(cfg.get("nfqws", "debug", default=False))
 
+            # Зачищаем любые «осиротевшие»/дублирующие nfqws2 перед
+            # стартом, чтобы на NFQUEUE остался ровно один наш процесс
+            # (issue #123). Сюда попадаем только если _is_running_locked()
+            # вернул False, т.е. отслеживаемого живого процесса у нас нет.
+            self._sweep_stray_processes()
+
             # Стратегические аргументы
             strategy_args = list(args) if args else []
 
@@ -184,54 +190,63 @@ class NFQWSManager:
             True если процесс остановлен (или не был запущен).
         """
         with self._lock:
+            result = True
+
             if not self._is_running_locked():
                 log.info("nfqws2 не запущен", source="nfqws")
                 self._cleanup()
-                return True
+            else:
+                pid = self._pid
+                log.info("Останавливаем nfqws2 (PID %d)..." % pid,
+                         source="nfqws")
+                result = self._stop_tracked_locked(pid)
 
-            pid = self._pid
-            log.info("Останавливаем nfqws2 (PID %d)..." % pid,
-                     source="nfqws")
+            # В любом случае добиваем возможные дубли/сироты, чтобы «стоп»
+            # действительно останавливал весь обход (issue #123): nfqws2
+            # из автозапуска S99zapret или оставшийся от прошлой сессии.
+            self._sweep_stray_processes()
+            return result
 
-            # Пробуем SIGTERM
-            try:
-                os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
-                log.info("Процесс уже завершён", source="nfqws")
-                self._cleanup()
-                return True
-            except PermissionError:
-                log.error("Нет прав для остановки PID %d" % pid,
-                          source="nfqws")
-                return False
-
-            # Ждём завершения (до 3 секунд)
-            for _ in range(30):
-                time.sleep(0.1)
-                if not self._check_pid_alive(pid):
-                    log.success("nfqws2 остановлен (SIGTERM)", source="nfqws")
-                    self._cleanup()
-                    return True
-
-            # Не остановился — SIGKILL
-            log.warning(
-                "nfqws2 не ответил на SIGTERM, отправляем SIGKILL",
-                source="nfqws"
-            )
-            try:
-                os.kill(pid, signal.SIGKILL)
-                time.sleep(0.5)
-            except ProcessLookupError:
-                pass
-
-            if not self._check_pid_alive(pid):
-                log.success("nfqws2 остановлен (SIGKILL)", source="nfqws")
-                self._cleanup()
-                return True
-
-            log.error("Не удалось остановить nfqws2 (PID %d)" % pid,
-                      source="nfqws")
+    def _stop_tracked_locked(self, pid: int) -> bool:
+        """Завершить отслеживаемый процесс pid (SIGTERM→SIGKILL). Под lock."""
+        # Пробуем SIGTERM
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            log.info("Процесс уже завершён", source="nfqws")
+            self._cleanup()
+            return True
+        except PermissionError:
+            log.error("Нет прав для остановки PID %d" % pid, source="nfqws")
             return False
+
+        # Ждём завершения (до 3 секунд)
+        for _ in range(30):
+            time.sleep(0.1)
+            if not self._check_pid_alive(pid):
+                log.success("nfqws2 остановлен (SIGTERM)", source="nfqws")
+                self._cleanup()
+                return True
+
+        # Не остановился — SIGKILL
+        log.warning(
+            "nfqws2 не ответил на SIGTERM, отправляем SIGKILL",
+            source="nfqws"
+        )
+        try:
+            os.kill(pid, signal.SIGKILL)
+            time.sleep(0.5)
+        except ProcessLookupError:
+            pass
+
+        if not self._check_pid_alive(pid):
+            log.success("nfqws2 остановлен (SIGKILL)", source="nfqws")
+            self._cleanup()
+            return True
+
+        log.error("Не удалось остановить nfqws2 (PID %d)" % pid,
+                  source="nfqws")
+        return False
 
     def restart(self, args: list = None) -> bool:
         """
@@ -460,16 +475,30 @@ class NFQWSManager:
         if self._process is not None:
             rc = self._process.poll()
             if rc is not None:
-                # Процесс завершился
+                # Процесс завершился — но мог быть подменён другим
+                # воркером/демоном, поэтому не выходим сразу, а проверяем
+                # PID-файл ниже.
                 self._exit_code = rc
                 self._process = None
                 self._remove_pid_file()
-                return False
-            return True
+            else:
+                return True
 
-        # Нет Popen, но есть PID (восстановлен из файла)
+        # Нет живого Popen. Пробуем PID из памяти ИЛИ из PID-файла — файл
+        # мог записать другой воркер bottle или восстановиться после
+        # перезапуска GUI. Без этого менеджер «не видит» живой nfqws2 и
+        # на следующем apply запускает дубль (issue #123).
+        if self._pid is None:
+            self._pid = self._read_pid_file()
+
         if self._pid is not None:
             if self._check_pid_alive(self._pid):
+                if self._start_time is None:
+                    try:
+                        self._start_time = os.stat(
+                            "/proc/%d" % self._pid).st_mtime
+                    except OSError:
+                        self._start_time = time.time()
                 return True
             else:
                 self._pid = None
@@ -478,6 +507,84 @@ class NFQWSManager:
                 return False
 
         return False
+
+    @staticmethod
+    def _find_nfqws_pids() -> list:
+        """Все PID процессов nfqws/nfqws2 в системе (по basename argv[0]).
+
+        Используется для зачистки «осиротевших» процессов (issue #123):
+        nfqws2 мог быть поднят автозапуском S99zapret (--daemon, чужой
+        PID-файл), остаться от упавшего GUI или от другого воркера. Все
+        они висят на одной NFQUEUE и мешают друг другу.
+        """
+        pids = []
+        try:
+            for d in os.listdir("/proc"):
+                if not d.isdigit():
+                    continue
+                pid = int(d)
+                try:
+                    with open("/proc/%d/cmdline" % pid, "rb") as f:
+                        raw = f.read()
+                except (IOError, OSError):
+                    continue
+                if not raw:
+                    continue
+                argv0 = raw.split(b"\x00", 1)[0].decode(
+                    "utf-8", errors="replace")
+                if argv0 and os.path.basename(argv0) in ("nfqws", "nfqws2"):
+                    pids.append(pid)
+        except OSError:
+            pass
+        return pids
+
+    def _sweep_stray_processes(self, exclude_pid=None):
+        """Завершить все процессы nfqws/nfqws2, кроме exclude_pid.
+
+        Гарантирует, что в системе не накапливаются параллельные nfqws2
+        (issue #123 «стакаются процессы запрета»). SIGTERM → ожидание →
+        SIGKILL. Чужие PID-файлы, указывающие на убитые процессы,
+        вычищаются, чтобы статус автозапуска не врал.
+        """
+        strays = [p for p in self._find_nfqws_pids() if p != exclude_pid]
+        if not strays:
+            return
+
+        log.warning(
+            "Обнаружены лишние процессы nfqws2 (PID %s) — завершаем во "
+            "избежание дублей на NFQUEUE" % ", ".join(
+                str(p) for p in strays),
+            source="nfqws"
+        )
+
+        for p in strays:
+            try:
+                os.kill(p, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            strays = [p for p in strays if self._check_pid_alive(p)]
+            if not strays:
+                break
+            time.sleep(0.1)
+
+        for p in strays:
+            try:
+                os.kill(p, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+        # Подчищаем чужие PID-файлы, указывающие на мёртвый теперь процесс.
+        for pf in ("/var/run/zapret-nfqws.pid", PID_FILE):
+            try:
+                with open(pf, "r") as f:
+                    fp = int(f.read().strip())
+                if not self._check_pid_alive(fp) and fp != exclude_pid:
+                    os.remove(pf)
+            except (IOError, OSError, ValueError):
+                pass
 
     @staticmethod
     def _check_pid_alive(pid: int) -> bool:

--- a/tests/test_nfqws_stray_sweep.py
+++ b/tests/test_nfqws_stray_sweep.py
@@ -1,0 +1,103 @@
+# tests/test_nfqws_stray_sweep.py
+"""Регрессия issue #123: при переключении стратегий стакаются процессы nfqws2.
+
+Менеджер обязан:
+  - «усыновлять» живой PID из PID-файла, даже если потерял Popen (другой
+    воркер/перезапуск GUI), чтобы не плодить дубли;
+  - перед стартом и на стопе зачищать любые посторонние nfqws/nfqws2.
+"""
+
+import unittest
+from unittest import mock
+
+from core.nfqws_manager import NFQWSManager
+
+
+class TestStraySweep(unittest.TestCase):
+
+    def setUp(self):
+        # Свежий менеджер без восстановления PID из реального файла.
+        with mock.patch.object(NFQWSManager, "_recover_pid"):
+            self.mgr = NFQWSManager()
+
+    def test_sweep_kills_strays_except_excluded(self):
+        killed = []
+
+        def fake_kill(pid, sig):
+            killed.append((pid, sig))
+
+        with mock.patch.object(NFQWSManager, "_find_nfqws_pids",
+                               return_value=[111, 222, 333]), \
+             mock.patch.object(NFQWSManager, "_check_pid_alive",
+                               return_value=False), \
+             mock.patch("core.nfqws_manager.os.kill", side_effect=fake_kill), \
+             mock.patch("builtins.open", side_effect=IOError):
+            self.mgr._sweep_stray_processes(exclude_pid=222)
+
+        sent_pids = {pid for pid, _ in killed}
+        self.assertIn(111, sent_pids)
+        self.assertIn(333, sent_pids)
+        self.assertNotIn(222, sent_pids)  # исключённый не трогаем
+
+    def test_sweep_noop_when_no_strays(self):
+        with mock.patch.object(NFQWSManager, "_find_nfqws_pids",
+                               return_value=[]), \
+             mock.patch("core.nfqws_manager.os.kill") as k:
+            self.mgr._sweep_stray_processes()
+        k.assert_not_called()
+
+    def test_sweep_sigkills_survivors(self):
+        # Процесс пережил SIGTERM → должен получить SIGKILL.
+        import signal as _sig
+        killed = []
+        with mock.patch.object(NFQWSManager, "_find_nfqws_pids",
+                               return_value=[999]), \
+             mock.patch.object(NFQWSManager, "_check_pid_alive",
+                               return_value=True), \
+             mock.patch("core.nfqws_manager.time.time",
+                        side_effect=[0.0, 0.0, 5.0, 5.0]), \
+             mock.patch("core.nfqws_manager.time.sleep"), \
+             mock.patch("core.nfqws_manager.os.kill",
+                        side_effect=lambda p, s: killed.append((p, s))), \
+             mock.patch("builtins.open", side_effect=IOError):
+            self.mgr._sweep_stray_processes()
+        self.assertIn((999, _sig.SIGTERM), killed)
+        self.assertIn((999, _sig.SIGKILL), killed)
+
+    def test_is_running_adopts_pid_from_file(self):
+        # Popen потерян (None), но PID-файл указывает на живой nfqws2 →
+        # менеджер должен считать его запущенным, а не плодить дубль.
+        self.mgr._process = None
+        self.mgr._pid = None
+        with mock.patch.object(NFQWSManager, "_read_pid_file",
+                               return_value=4242), \
+             mock.patch.object(NFQWSManager, "_check_pid_alive",
+                               return_value=True), \
+             mock.patch("core.nfqws_manager.os.stat") as st:
+            st.return_value = mock.Mock(st_mtime=100.0)
+            self.assertTrue(self.mgr._is_running_locked())
+        self.assertEqual(self.mgr._pid, 4242)
+
+    def test_is_running_drops_dead_pid_from_file(self):
+        self.mgr._process = None
+        self.mgr._pid = None
+        with mock.patch.object(NFQWSManager, "_read_pid_file",
+                               return_value=4242), \
+             mock.patch.object(NFQWSManager, "_check_pid_alive",
+                               return_value=False), \
+             mock.patch.object(NFQWSManager, "_remove_pid_file"):
+            self.assertFalse(self.mgr._is_running_locked())
+        self.assertIsNone(self.mgr._pid)
+
+    def test_stop_sweeps_even_when_not_running(self):
+        # /api/stop должен зачищать сирот, даже если свой процесс не отслеживается.
+        with mock.patch.object(NFQWSManager, "_is_running_locked",
+                               return_value=False), \
+             mock.patch.object(self.mgr, "_sweep_stray_processes") as sweep, \
+             mock.patch.object(self.mgr, "_cleanup"):
+            self.assertTrue(self.mgr.stop())
+        sweep.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…n skill

Issue #123: switching strategies stacked multiple nfqws2 processes on the same NFQUEUE. NFQWSManager only tracked its own Popen/PID file, so a process started by the S99zapret autostart daemon (own pidfile), an orphan from a prior GUI run, or another bottle worker was invisible — is_running() returned False and apply() spawned a duplicate.

nfqws_manager.py:
- _is_running_locked() now adopts a live PID from the PID file even after the Popen handle is lost (cross-worker / GUI restart), so we never spawn a dup.
- _find_nfqws_pids() + _sweep_stray_processes(): SIGTERM->SIGKILL any nfqws/nfqws2 except the tracked one, and clean stale pidfiles. Called before every start (exactly one process survives) and on every stop (so "stop" really tears down the bypass, incl. the autostart daemon).
- stop() refactored to always sweep at the end via _stop_tracked_locked().

skill: appended §8 — full `nfqws2 -?` (v0.9.5.2) CLI reference (global, desync-init, multi-strategy, payload/range, desync action, value lists) plus zapret-gui implications (--dry-run validation, --daemon ownership, sweep).

tests/test_nfqws_stray_sweep.py: regression coverage for sweep + PID adoption.