### PR TITLE
Wire remaining desync lua scripts into load map; implement --dry-run …

### DIFF
--- a/.claude/skills/nfqws2-strategies/SKILL.md
+++ b/.claude/skills/nfqws2-strategies/SKILL.md
@@ -51,9 +51,21 @@ nfqws2 --qnum 300 \
    `multidisorder`, `fakedsplit`, `pktmod`, `wssize`, `syndata`, `luaexec` и т.д.
    **Без него `--lua-desync=fake:...` — это вызов несуществующей функции:
    nfqws2 либо падает на старте, либо десинк просто не применяется.**
-3. Extension-скрипты (`zapret-multishake.lua`, `fakemultisplit.lua`,
-   `fakemultidisorder.lua`) нужны только если стратегия использует функции
-   `hostfakesplit_*`, `fakemultisplit`, `fakemultidisorder`.
+3. Extension-скрипты подключаются `--lua-init` ТОЛЬКО если стратегия реально
+   вызывает их функции (`--lua-desync=FN`), см. `_EXTENSION_LUA_FILES` в
+   `nfqws_manager.py`. Карта (файл → его экспортируемые функции-триггеры):
+   - `zapret-multishake.lua` — `hostfakesplit_stealth/chaos/multi/gradual/decoy/blend/soft`, `snifakesplit`;
+   - `fakemultisplit.lua` — `fakemultisplit`; `fakemultidisorder.lua` — `fakemultidisorder`;
+   - `zapret-obfs.lua` — `wgobfs`, `ippxor`, `udp2icmp`, `synhide` (надмножество `zapret-wgobfs.lua`, последний поэтому НЕ грузим — иначе `wgobfs` определится дважды);
+   - `zapret-16kb.lua` — `flood_white`, `ttl_ladder`, `white_sandwich`, `seqovl_white`;
+   - `zapret-rst-flood.lua` — `rst_flood`; `zapret-pcap.lua` — `pcap` (требует `--writeable`).
+   **Инвариант:** набор-триггер каждого файла обязан совпадать с его
+   глобальными функциями (`grep '^function ' import/lua/<file>.lua`) — иначе
+   вызов «выпавшей» функции = тихий 0%. Сторожит `tests/test_nfqws_lua_map.py`.
+   Скрипты-оркестраторы/детекторы (`combined-detector`, `domain-grouping`,
+   `strategy-stats`, `strategy-lock-manager`, `silent-drop-detector`) — это
+   companion'ы роутерного auto-оркестратора, а НЕ desync-действия; в GUI-потоке
+   детекцию делает Python-сканер, поэтому в desync-путь они не подключаются.
 4. `--qnum N` **обязан** совпадать с номером очереди в правиле firewall
    (`queue num N`). Иначе пакеты уходят в очередь, которую никто не слушает.
 
@@ -395,10 +407,15 @@ mtproto_initial bt_handshake utp_bt_handshake`.
 
 ### 8.7 Важные следствия для zapret-gui
 
-- **`--dry-run`** — штатный способ валидировать собранную стратегию без
-  поднятия NFQUEUE (можно прикрутить к `build_preview_command`/линтеру
-  стратегий: собрать argv через `compose_command`, заменить запуск на
-  `--dry-run`, проверить код возврата 0).
+- **`--dry-run`** — штатная валидация собранной стратегии без поднятия
+  NFQUEUE. **Реализовано:** `NFQWSManager.dry_run(strategy_args)` собирает argv
+  тем же `compose_command`, убирает `--user=` (чтобы не было setuid вне
+  рантайма), добавляет `--dry-run`, запускает и проверяет `returncode==0`.
+  Ловит вызовы несуществующих lua-функций, битые `--blob`/`--lua-init`, плохой
+  синтаксис `--lua-desync`. API: `POST /api/strategies/<sid>/validate` и
+  `POST /api/strategies/preview` с `{"validate": true}` → поле `validation:
+  {ok, available, returncode, output, command}`. `available=false` — бинарника
+  нет (dev-машина без zapret2).
 - **`--version`** даёт `lua_compat_ver` — полезно при диагностике
   несовместимости lua-скриптов с версией движка.
 - **`--fwmark` дефолт `0x40000000`** совпадает с нашим `nfqws.desync_mark` —

--- a/api/strategies.py
+++ b/api/strategies.py
@@ -383,7 +383,7 @@ def register(app):
         command = sm.build_preview_command(strategy)
         args = sm.build_nfqws_args(strategy)
 
-        return {
+        result = {
             "ok": True,
             "command": command,
             "args": args,
@@ -392,6 +392,41 @@ def register(app):
                 if p.get("enabled", True)
             ]),
         }
+
+        # Опциональная валидация через nfqws2 --dry-run (без NFQUEUE):
+        # ловит несуществующие lua-функции, битые --blob/--lua-init и пр.
+        if body.get("validate"):
+            from core.nfqws_manager import get_nfqws_manager
+            result["validation"] = get_nfqws_manager().dry_run(args)
+
+        return result
+
+    @app.post("/api/strategies/<sid>/validate")
+    def api_strategies_validate(sid):
+        """Проверить стратегию через `nfqws2 --dry-run` (без поднятия NFQUEUE).
+
+        Собирает argv тем же путём, что и реальный запуск, и валидирует
+        параметры + lua-init. Возвращает validation: {ok, available,
+        returncode, output, command}.
+        """
+        response.content_type = "application/json; charset=utf-8"
+
+        from core.strategy_builder import get_strategy_manager
+        from core.nfqws_manager import get_nfqws_manager
+
+        sm = get_strategy_manager()
+        strategy = sm.get_strategy(sid)
+        if not strategy:
+            response.status = 404
+            return {"ok": False, "error": "Стратегия не найдена: %s" % sid}
+
+        args = sm.build_nfqws_args(strategy)
+        if not args:
+            response.status = 400
+            return {"ok": False, "error": "Нет включённых профилей в стратегии"}
+
+        validation = get_nfqws_manager().dry_run(args)
+        return {"ok": True, "validation": validation}
 
     # ═══════════════════ Категории ═══════════════════
 

--- a/core/nfqws_manager.py
+++ b/core/nfqws_manager.py
@@ -34,6 +34,12 @@ PID_FILE = "/var/run/zapret-gui-nfqws.pid"
 _CORE_LUA_FILES = (
     "zapret-lib.lua",
     "zapret-antidpi.lua",
+    # init_vars.lua грузится ПОСЛЕ lib+antidpi (так задокументировано в самом
+    # файле): объявляет именованные SNI/pattern-переменные (tls_google и т.п.,
+    # используются как seqovl_pattern=/pattern=) и invert_bytes — примитив, от
+    # которого зависят obfs-скрипты. Поэтому держим его в core (всегда грузим
+    # при наличии --lua-desync), а не как extension.
+    "init_vars.lua",
     "zapret-auto.lua",
     "custom_funcs.lua",
     "custom_diag.lua",
@@ -60,6 +66,23 @@ _EXTENSION_LUA_FILES = {
     },
     "fakemultisplit.lua": {"fakemultisplit"},
     "fakemultidisorder.lua": {"fakemultidisorder"},
+    # WireGuard/UDP-обфускация и туннелирование. wgobfs определён и в
+    # zapret-wgobfs.lua, но zapret-obfs.lua — надмножество (wgobfs + ippxor +
+    # udp2icmp + synhide), поэтому маршрутизируем все эти функции в него, а
+    # zapret-wgobfs.lua не подключаем (дубль), чтобы не грузить wgobfs дважды.
+    "zapret-obfs.lua": {"wgobfs", "ippxor", "udp2icmp", "synhide"},
+    # 16KB-обход (фейк-флуд белым SNI, ttl-лесенка и пр.). Зависит от
+    # lib+antidpi (оба в core).
+    "zapret-16kb.lua": {
+        "flood_white", "ttl_ladder", "white_sandwich", "seqovl_white",
+    },
+    # Флуд RST с подобранным TTL до DPI. Зависит от lib+antidpi (core).
+    "zapret-rst-flood.lua": {"rst_flood"},
+    # Запись pcap из lua (требует --writeable). Триггер — pcap; вспомогательные
+    # pcap_write* включены, чтобы набор зеркалил экспорт скрипта (см. тест).
+    "zapret-pcap.lua": {
+        "pcap", "pcap_write", "pcap_write_packet", "pcap_write_header",
+    },
 }
 
 _LUA_DESYNC_FUNC_RE = re.compile(r"--lua-desync=([a-zA-Z0-9_]+)")
@@ -375,6 +398,72 @@ class NFQWSManager:
         return self._dedup_lua_init(
             [binary] + base_args + lua_args + unified_args + strategy_args
         )
+
+    def dry_run(self, strategy_args: list, timeout: float = 8.0) -> dict:
+        """Проверить стратегию через `nfqws2 --dry-run` без поднятия NFQUEUE.
+
+        Собирает argv тем же `compose_command` (единый источник истины), что
+        и реальный запуск, затем заменяет запуск на валидацию: nfqws2
+        разбирает параметры, прогоняет lua-init (то есть ловит вызовы
+        несуществующих lua-функций, битые `--blob`/`--lua-init`, плохой
+        синтаксис `--lua-desync`) и выходит с кодом 0 при успехе. NFQUEUE не
+        открывается, трафик не затрагивается.
+
+        Из argv убираем `--user=` — иначе nfqws2 при старте пытается setuid и
+        без root падает не по делу (к валидации синтаксиса это не относится).
+        `--daemon` мы и так не добавляем.
+
+        Returns:
+            dict: { ok, available, returncode, output, command }.
+                  available=False — бинарник недоступен (валидацию не
+                  провести, например, на dev-машине без zapret2).
+        """
+        from core.config_manager import get_config_manager
+        cfg = get_config_manager()
+        binary = cfg.get("zapret", "nfqws_binary")
+
+        if (not binary or not os.path.isfile(binary)
+                or not os.access(binary, os.X_OK)):
+            return {
+                "ok": False, "available": False,
+                "error": "Бинарник nfqws2 недоступен: %s" % binary,
+                "returncode": None, "output": "", "command": "",
+            }
+
+        argv = self.compose_command(list(strategy_args or []),
+                                    binary=binary, cfg=cfg)
+        argv = [a for a in argv if not a.startswith("--user=")]
+        if "--dry-run" not in argv:
+            argv.append("--dry-run")
+
+        try:
+            proc = subprocess.run(
+                argv, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                timeout=timeout, check=False,
+            )
+            out = (proc.stdout.decode("utf-8", errors="replace")
+                   if proc.stdout else "")
+            rc = proc.returncode
+        except subprocess.TimeoutExpired:
+            return {
+                "ok": False, "available": True, "returncode": None,
+                "output": "Таймаут валидации (%.0fс)" % timeout,
+                "command": " ".join(argv),
+            }
+        except OSError as e:
+            return {
+                "ok": False, "available": True, "returncode": None,
+                "output": "Ошибка запуска валидации: %s" % e,
+                "command": " ".join(argv),
+            }
+
+        return {
+            "ok": rc == 0,
+            "available": True,
+            "returncode": rc,
+            "output": out.strip(),
+            "command": " ".join(argv),
+        }
 
     # ─────────────────────── internal helpers ───────────────────────
 

--- a/tests/test_nfqws_stray_sweep.py
+++ b/tests/test_nfqws_stray_sweep.py
@@ -99,5 +99,72 @@ class TestStraySweep(unittest.TestCase):
         sweep.assert_called_once()
 
 
+class TestDryRun(unittest.TestCase):
+
+    def setUp(self):
+        with mock.patch.object(NFQWSManager, "_recover_pid"):
+            self.mgr = NFQWSManager()
+
+    def test_unavailable_when_binary_missing(self):
+        cfg = mock.Mock()
+        cfg.get.return_value = "/no/such/nfqws2"
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=cfg), \
+             mock.patch("core.nfqws_manager.os.path.isfile",
+                        return_value=False):
+            res = self.mgr.dry_run(["--filter-tcp=443"])
+        self.assertFalse(res["ok"])
+        self.assertFalse(res["available"])
+
+    def _patched_run(self, returncode, output=b""):
+        completed = mock.Mock(returncode=returncode, stdout=output)
+        cfg = mock.Mock()
+        cfg.get.return_value = "/opt/zapret2/nfq2/nfqws2"
+        return cfg, completed
+
+    def test_appends_dry_run_and_strips_user(self):
+        cfg, completed = self._patched_run(0, b"all ok")
+        seen = {}
+
+        def fake_run(argv, **kw):
+            seen["argv"] = argv
+            return completed
+
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=cfg), \
+             mock.patch("core.nfqws_manager.os.path.isfile",
+                        return_value=True), \
+             mock.patch("core.nfqws_manager.os.access", return_value=True), \
+             mock.patch.object(self.mgr, "compose_command",
+                               return_value=["/opt/zapret2/nfq2/nfqws2",
+                                             "--user=nobody", "--qnum=300",
+                                             "--filter-tcp=443"]), \
+             mock.patch("core.nfqws_manager.subprocess.run",
+                        side_effect=fake_run):
+            res = self.mgr.dry_run(["--filter-tcp=443"])
+
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["returncode"], 0)
+        self.assertIn("--dry-run", seen["argv"])
+        self.assertNotIn("--user=nobody", seen["argv"])  # setuid не нужен
+
+    def test_nonzero_returncode_is_failure(self):
+        cfg, completed = self._patched_run(1, b"lua error: function 'foo' nil")
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=cfg), \
+             mock.patch("core.nfqws_manager.os.path.isfile",
+                        return_value=True), \
+             mock.patch("core.nfqws_manager.os.access", return_value=True), \
+             mock.patch.object(self.mgr, "compose_command",
+                               return_value=["/opt/zapret2/nfq2/nfqws2",
+                                             "--lua-desync=foo"]), \
+             mock.patch("core.nfqws_manager.subprocess.run",
+                        return_value=completed):
+            res = self.mgr.dry_run(["--lua-desync=foo"])
+        self.assertFalse(res["ok"])
+        self.assertEqual(res["returncode"], 1)
+        self.assertIn("lua error", res["output"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…validation

Load map (nfqws_manager.py):
- _EXTENSION_LUA_FILES now also covers the desync-action scripts that were vendored but never loaded: zapret-obfs.lua (wgobfs/ippxor/udp2icmp/synhide; superset of zapret-wgobfs.lua, which is left out to avoid defining wgobfs twice), zapret-16kb.lua (flood_white/ttl_ladder/white_sandwich/seqovl_white), zapret-rst-flood.lua (rst_flood), zapret-pcap.lua (pcap). Triggers mirror each script's global exports exactly (guarded by test_nfqws_lua_map).
- init_vars.lua promoted to _CORE_LUA_FILES (after lib+antidpi as its header requires): it declares named SNI/pattern vars (tls_google etc., used as seqovl_pattern=/pattern=) and invert_bytes, a primitive the obfs scripts need.
- Orchestrator/detector companions (combined-detector, domain-grouping, strategy-stats, strategy-lock-manager, silent-drop-detector) are intentionally NOT wired into the desync path — they belong to the router-side auto orchestrator, while the GUI does detection in Python. Documented in skill §1.

--dry-run validation (the previously-only-suggested feature, now implemented):
- NFQWSManager.dry_run(strategy_args): builds argv via compose_command, strips --user= (no setuid outside runtime), appends --dry-run, runs and checks rc==0. Catches undefined lua functions, broken --blob/--lua-init, bad --lua-desync. Returns {ok, available, returncode, output, command}; available=False when the binary is absent (dev machine without zapret2).
- API: POST /api/strategies/<sid>/validate, and POST /api/strategies/preview with {"validate": true} -> validation field.

skill §1/§8.7 updated to match. Tests: dry_run cases + expanded lua-map coverage.