### PR TITLE
BlockCheck2: pin only found strategies, full-body (20KB) toggle, para…

### DIFF
--- a/.claude/skills/nfqws2-strategies/SKILL.md
+++ b/.claude/skills/nfqws2-strategies/SKILL.md
@@ -287,6 +287,19 @@ nfqws2 --qnum 200 --debug \
   инкрементального polling (`output?offset=N`). Путь — `zapret.blockcheck2_path`
   или автопоиск в `base_path`. Это НЕ путать с `core/blockcheck.py` (наша
   Python-реализация проб для GUI-тестера).
+  - **Примороженные итоги (`highlights`)** — `_HIGHLIGHT_RE` ловит ТОЛЬКО
+    найденные рабочие стратегии (`working strategy found …`) и заголовки
+    `* SUMMARY`/`* COMMON`, с дедупом и чисткой `!!!!!`. НЕ примораживать
+    `AVAILABLE`/`UNAVAILABLE` (вдобавок `AVAILABLE` — подстрока `UNAVAILABLE`,
+    на этом горел старый фильтр).
+  - **Обход блока по ~20КБ** — env `CURL_HTTPS_GET=1` (GUI-галка «Качать полное
+    тело»): HTTPS-проба делает GET всего тела вместо HEAD (`-I`). Ловит DPI,
+    который пускает первые ~16-20 КБ и рвёт (`curl code=28`). Аналог нашего
+    `BODY_PROBE_MIN_BYTES` в `strategy_scanner`. Прочие env (полный список — в
+    шапке `blockcheck2.sh`): `HTTP/HTTPS/QUIC_PORT`, `CURL_MAX_TIME[_QUIC|_DOH]`,
+    `MIN_TTL`/`MAX_TTL`, `SKIP_PKTWS`/`SKIP_IPBLOCK`/`SKIP_DNSCHECK`,
+    `UNBLOCKED_DOM`, `SECURE_DNS`/`DOH_SERVERS`. Документированы в help-топике
+    `blockcheck2` (`web/js/components/help.js`).
 - **nfqws2 `--debug`** — конфиг `nfqws.debug=true` добавляет `--debug` и
   поднимает stderr nfqws2 до INFO (см. §5).
 

--- a/core/blockcheck2.py
+++ b/core/blockcheck2.py
@@ -53,8 +53,16 @@ _ENV_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 # Домен/хост (как в api/diagnostics._validate_host).
 _HOST_RE = re.compile(r"^[a-zA-Z0-9.:_-]+$")
 
-# Строки-«итоги» blockcheck (для подсветки в телеметрии).
-_HIGHLIGHT_RE = re.compile(r"!!!!!|AVAILABLE|BLOCKED|summary| play these", re.I)
+# Строки-«итоги» для приморозки сверху телеметрии. Примораживаем ТОЛЬКО
+# найденные рабочие стратегии и заголовки секций итогов — а НЕ каждую попытку
+# AVAILABLE/UNAVAILABLE (их сотни; вдобавок "AVAILABLE" — подстрока
+# "UNAVAILABLE", из-за чего старый фильтр ловил мусор). blockcheck печатает
+# найденную стратегию строкой вида:
+#   !!!!! curl_test_http: working strategy found for ipv4 host : nfqws ... !!!!!
+# и финальные секции «* SUMMARY» / «* COMMON» (стратегии, рабочие для всех целей).
+_HIGHLIGHT_RE = re.compile(
+    r"working\s+strategy\s+found|^\s*\*\s*(?:SUMMARY|COMMON)\b", re.I
+)
 
 
 class Blockcheck2Runner:
@@ -67,6 +75,7 @@ class Blockcheck2Runner:
 
         self._lines: list[str] = []
         self._highlights: list[str] = []
+        self._highlight_seen: set[str] = set()
         self._started_at: float = 0.0
         self._finished_at: float = 0.0
         self._exit_code: Optional[int] = None
@@ -196,6 +205,7 @@ class Blockcheck2Runner:
             self._proc = proc
             self._lines = []
             self._highlights = []
+            self._highlight_seen = set()
             self._started_at = time.time()
             self._finished_at = 0.0
             self._exit_code = None
@@ -265,7 +275,7 @@ class Blockcheck2Runner:
                 "exit_code": self._exit_code,
                 "elapsed_seconds": round(elapsed, 1),
                 "error": self._error,
-                "highlights": list(self._highlights[-20:]),
+                "highlights": list(self._highlights[-50:]),
             }
 
     def get_output(self, offset: int = 0) -> dict[str, Any]:
@@ -300,7 +310,14 @@ class Blockcheck2Runner:
                         drop = len(self._lines) - _MAX_OUTPUT_LINES
                         del self._lines[:drop]
                     if line and _HIGHLIGHT_RE.search(line):
-                        self._highlights.append(line)
+                        # Чистим декоративные «!!!!!» и пробелы по краям, и
+                        # дедупим: одна и та же стратегия печатается и при
+                        # находке, и в секции SUMMARY/COMMON — в «примороженном»
+                        # списке нужна по разу.
+                        clean = line.strip().strip("!").strip()
+                        if clean and clean not in self._highlight_seen:
+                            self._highlight_seen.add(clean)
+                            self._highlights.append(clean)
                 if line:
                     log.info(line, source="blockcheck2")
         except Exception:

--- a/tests/test_blockcheck2_highlights.py
+++ b/tests/test_blockcheck2_highlights.py
@@ -1,0 +1,76 @@
+# tests/test_blockcheck2_highlights.py
+"""Регрессия: в «примороженные» итоги blockcheck2 попадают ТОЛЬКО найденные
+рабочие стратегии, а не шум AVAILABLE/UNAVAILABLE.
+
+Старый фильтр ловил `UNAVAILABLE code=28` (т.к. "AVAILABLE" — подстрока
+"UNAVAILABLE") и каждую попытку `!!!!! AVAILABLE !!!!!`. Новый — только строки
+`working strategy found …` и заголовки секций `* SUMMARY` / `* COMMON`.
+"""
+
+import unittest
+
+from core import blockcheck2
+from core.blockcheck2 import Blockcheck2Runner, _HIGHLIGHT_RE
+
+
+class TestHighlightRegex(unittest.TestCase):
+
+    def test_matches_found_strategy_and_sections(self):
+        self.assertTrue(_HIGHLIGHT_RE.search(
+            "!!!!! curl_test_http: working strategy found for ipv4 "
+            "rutracker.org : nfqws2 --filter-tcp=443 --lua-desync=fake !!!!!"))
+        self.assertTrue(_HIGHLIGHT_RE.search("* SUMMARY"))
+        self.assertTrue(_HIGHLIGHT_RE.search("  * COMMON"))
+
+    def test_ignores_noise(self):
+        for noise in (
+            "[attempt 1] UNAVAILABLE code=28",
+            "UNAVAILABLE code=7",
+            "!!!!! AVAILABLE !!!!!",
+            "* AVAILABLE",
+        ):
+            self.assertIsNone(_HIGHLIGHT_RE.search(noise),
+                              "ложное срабатывание на: %r" % noise)
+
+
+class _FakeProc:
+    """Минимальный двойник Popen для _read_output."""
+    def __init__(self, lines):
+        self.stdout = iter([l + "\n" for l in lines])
+        self._rc = 0
+
+    def wait(self):
+        return self._rc
+
+
+class TestReadOutputHighlights(unittest.TestCase):
+
+    def test_only_strategies_pinned_and_deduped(self):
+        runner = Blockcheck2Runner()
+        strat = ("!!!!! curl_test_https_tls13: working strategy found for "
+                 "ipv4 rutracker.org : nfqws2 --filter-tcp=443 !!!!!")
+        lines = [
+            "[attempt 1] UNAVAILABLE code=28",
+            "!!!!! AVAILABLE !!!!!",
+            strat,                       # найдена стратегия
+            "[attempt 2] UNAVAILABLE code=28",
+            "* SUMMARY",
+            strat,                       # повтор той же стратегии в сводке
+        ]
+        runner._read_output(_FakeProc(lines))
+
+        hl = runner._highlights
+        # Шум не попал.
+        self.assertFalse(any("UNAVAILABLE" in h for h in hl))
+        self.assertFalse(any(h == "AVAILABLE" for h in hl))
+        # Стратегия попала ровно один раз (дедуп) и без декоративных "!".
+        strat_hits = [h for h in hl if "working strategy found" in h]
+        self.assertEqual(len(strat_hits), 1)
+        self.assertFalse(strat_hits[0].startswith("!"))
+        self.assertFalse(strat_hits[0].endswith("!"))
+        # Заголовок секции примораживается.
+        self.assertIn("* SUMMARY", hl)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/css/blockcheck_scan.css
+++ b/web/css/blockcheck_scan.css
@@ -42,6 +42,14 @@
     gap: 4px;
     margin-bottom: 10px;
 }
+.bc2-hl-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .4px;
+    color: var(--success, #34d399);
+    margin-bottom: 2px;
+}
 .bc2-hl {
     font-family: var(--font-mono);
     font-size: 12px;

--- a/web/js/components/help.js
+++ b/web/js/components/help.js
@@ -216,12 +216,50 @@ const Help = (() => {
         body: 'Запускает ШТАТНЫЙ скрипт <code>blockcheck2.sh</code> из ' +
               'zapret2 (bol-van) как есть и стримит его вывод (телеметрию) ' +
               'в реальном времени. Подбирает рабочую стратегию средствами ' +
-              'самого zapret2. Параметры (домены, IP-версия, уровень ' +
-              'сканирования, протоколы) передаются скрипту через окружение ' +
-              '(BATCH-режим, без интерактивных вопросов). Это «эталон» — '+
-              'в отличие от BlockCheck(mod), который перебирает наш каталог.',
+              'самого zapret2 (BATCH-режим, без интерактивных вопросов). Это ' +
+              '«эталон» — в отличие от BlockCheck(mod), который перебирает наш ' +
+              'каталог.<br><br>' +
+              'Сверху телеметрии «примораживаются» <b>только найденные рабочие ' +
+              'стратегии</b> (строки <code>working strategy found … : &lt;движок ' +
+              'параметры&gt;</code>) и секции <code>* SUMMARY</code> / ' +
+              '<code>* COMMON</code> (стратегии, рабочие сразу для всех целей). ' +
+              'Попытки <code>UNAVAILABLE code=NN</code> и отдельные ' +
+              '<code>AVAILABLE</code> в шапку не выносятся — только в общий лог.' +
+              '<br><br>' +
+              '<b>Качать полное тело (обход блока по ~20КБ)</b> — выставляет ' +
+              '<code>CURL_HTTPS_GET=1</code>: HTTPS-проба тянет всё тело сайта ' +
+              '(GET) вместо заголовков (HEAD/<code>-I</code>). Нужно, когда DPI ' +
+              'пускает первые ~16-20 КБ и затем рвёт соединение (curl выдаёт ' +
+              '<code>code=28</code> — таймаут): без полного тела такой блок не ' +
+              'виден и стратегия ложно считается рабочей.<br><br>' +
+              '<b>Параметры скрипта (env).</b> Передаются через расширенные ' +
+              'поля «Доп. переменные окружения» (<code>KEY=VALUE</code>):' +
+              '<br>• <code>DOMAINS</code> — домены (по умолч. rutracker.org); ' +
+              '<code>IPVS</code> — версии IP (4 / 6 / 46);' +
+              '<br>• <code>ENABLE_HTTP</code>, <code>ENABLE_HTTPS_TLS12</code>, ' +
+              '<code>ENABLE_HTTPS_TLS13</code>, <code>ENABLE_HTTP3</code> — какие ' +
+              'протоколы проверять (0/1);' +
+              '<br>• <code>HTTP_PORT</code>=80, <code>HTTPS_PORT</code>=443, ' +
+              '<code>QUIC_PORT</code>=443 — порты;' +
+              '<br>• <code>SCANLEVEL</code> — quick / standard / force (глубина ' +
+              'перебора); <code>REPEATS</code> — повторов на тест (фильтр ' +
+              'нестабильных); <code>PARALLEL</code>=1 — параллельный прогон;' +
+              '<br>• <code>CURL_MAX_TIME</code>=2, <code>CURL_MAX_TIME_QUIC</code>, ' +
+              '<code>CURL_MAX_TIME_DOH</code>=2 — таймауты curl (сек); ' +
+              '<code>CURL_HTTPS_GET</code>=1 — GET вместо HEAD (см. выше); ' +
+              '<code>CURL_VERBOSE</code>=1 — подробный curl;' +
+              '<br>• <code>SKIP_PKTWS</code> — не тестировать pkt-движок (nfqws2); ' +
+              '<code>SKIP_IPBLOCK</code> — пропустить проверку блока по IP; ' +
+              '<code>SKIP_DNSCHECK</code> — пропустить проверку подмены DNS;' +
+              '<br>• <code>UNBLOCKED_DOM</code>=iana.org — эталонный незаблок. ' +
+              'домен; <code>SECURE_DNS</code> — использовать DoH при спуфинге ' +
+              'DNS; <code>DOH_SERVERS</code>, <code>DNSCHECK_DNS</code> — списки ' +
+              'серверов.<br>' +
+              'Полный перечень — в шапке самого <code>blockcheck2.sh</code>.',
         examples: [
             { label: 'Типовая цель', code: 'rutracker.org, IP=4, SCANLEVEL=standard' },
+            { label: 'Обход блока по 20КБ', code: 'CURL_HTTPS_GET=1 (галка «Качать полное тело»)' },
+            { label: 'TTL-диапазон (доп. env)', code: 'MIN_TTL=1\nMAX_TTL=12' },
         ],
     });
 

--- a/web/js/pages/blockcheck2.js
+++ b/web/js/pages/blockcheck2.js
@@ -93,10 +93,24 @@ const Blockcheck2Page = (() => {
                     <div class="form-group">
                         <label class="form-label">Дополнительно</label>
                         <div class="bc2-checks">
-                            <label class="bc2-check"><input type="checkbox" id="bc2-skip-tpws" checked> SKIP_TPWS</label>
-                            <label class="bc2-check"><input type="checkbox" id="bc2-skip-pktws"> SKIP_PKTWS</label>
-                            <label class="bc2-check"><input type="checkbox" id="bc2-parallel"> PARALLEL</label>
-                            <label class="bc2-check"><input type="checkbox" id="bc2-curl-verbose"> CURL_VERBOSE</label>
+                            <label class="bc2-check" title="CURL_HTTPS_GET=1 — качать всё тело сайта (GET) вместо заголовков (HEAD, -I). Ловит блокировку, когда DPI пускает первые ~16-20 КБ и обрывает соединение.">
+                                <input type="checkbox" id="bc2-https-get"> Качать полное тело (обход блока по ~20КБ)
+                            </label>
+                            <label class="bc2-check" title="SKIP_PKTWS — не тестировать pkt-движок (nfqws2).">
+                                <input type="checkbox" id="bc2-skip-pktws"> SKIP_PKTWS
+                            </label>
+                            <label class="bc2-check" title="SKIP_IPBLOCK — пропустить проверку блокировки по IP.">
+                                <input type="checkbox" id="bc2-skip-ipblock"> SKIP_IPBLOCK
+                            </label>
+                            <label class="bc2-check" title="SKIP_DNSCHECK — пропустить проверку подмены DNS.">
+                                <input type="checkbox" id="bc2-skip-dnscheck"> SKIP_DNSCHECK
+                            </label>
+                            <label class="bc2-check" title="PARALLEL=1 — параллельный прогон тестов (быстрее, вывод вперемешку).">
+                                <input type="checkbox" id="bc2-parallel"> PARALLEL
+                            </label>
+                            <label class="bc2-check" title="CURL_VERBOSE=1 — подробный вывод curl.">
+                                <input type="checkbox" id="bc2-curl-verbose"> CURL_VERBOSE
+                            </label>
                         </div>
                     </div>
 
@@ -191,8 +205,11 @@ const Blockcheck2Page = (() => {
         params.ENABLE_HTTPS_TLS13 = _chk('bc2-tls13') ? '1' : '0';
         params.ENABLE_HTTP3 = _chk('bc2-http3') ? '1' : '0';
 
-        if (_chk('bc2-skip-tpws')) params.SKIP_TPWS = '1';
+        // CURL_HTTPS_GET=1 — GET всего тела вместо HEAD (обход блока по ~20КБ).
+        if (_chk('bc2-https-get')) params.CURL_HTTPS_GET = '1';
         if (_chk('bc2-skip-pktws')) params.SKIP_PKTWS = '1';
+        if (_chk('bc2-skip-ipblock')) params.SKIP_IPBLOCK = '1';
+        if (_chk('bc2-skip-dnscheck')) params.SKIP_DNSCHECK = '1';
         if (_chk('bc2-parallel')) params.PARALLEL = '1';
         if (_chk('bc2-curl-verbose')) params.CURL_VERBOSE = '1';
 
@@ -321,9 +338,10 @@ const Blockcheck2Page = (() => {
     }
 
     function lineClass(line) {
-        if (/!!!!!|AVAILABLE/i.test(line)) return 'ln-hl';
-        if (/\bOK\b|success|доступ/i.test(line)) return 'ln-ok';
-        if (/BLOCK|FAIL|error|ошиб|недоступ/i.test(line)) return 'ln-bad';
+        if (/working strategy found/i.test(line)) return 'ln-hl';
+        // UNAVAILABLE проверяем РАНЬШE AVAILABLE (это её подстрока).
+        if (/UNAVAILABLE|BLOCK|FAIL|error|ошиб|недоступ/i.test(line)) return 'ln-bad';
+        if (/\bAVAILABLE\b|\bOK\b|success|доступ/i.test(line)) return 'ln-ok';
         return '';
     }
 
@@ -331,7 +349,8 @@ const Blockcheck2Page = (() => {
         const el = document.getElementById('bc2-highlights');
         if (!el) return;
         if (!highlights.length) { el.innerHTML = ''; return; }
-        el.innerHTML = highlights.map(h => `<div class="bc2-hl">${escapeHtml(h)}</div>`).join('');
+        const items = highlights.map(h => `<div class="bc2-hl">${escapeHtml(h)}</div>`).join('');
+        el.innerHTML = `<div class="bc2-hl-title">Найденные рабочие стратегии</div>${items}`;
     }
 
     /* ───────── helpers ───────── */


### PR DESCRIPTION
…m help

Verified against bol-van/zapret2 blockcheck2.sh (not zapret v1).

Telemetry highlights (the pinned block at top):
- _HIGHLIGHT_RE matched "AVAILABLE", which is a substring of "UNAVAILABLE", so it froze every `UNAVAILABLE code=28` and per-attempt `!!!!! AVAILABLE !!!!!` line — meaningless noise. Now it pins ONLY found working strategies (`working strategy found …` lines, which carry the engine+params) plus the `* SUMMARY` / `* COMMON` section headers. Highlights are de-duplicated (the same strategy is printed on discovery and again in the summary) and stripped of the decorative `!!!!!`. Frontend lineClass also fixed (UNAVAILABLE checked before AVAILABLE) and the pinned area gets a "Найденные рабочие стратегии" title.

20KB-hang bypass: new checkbox "Качать полное тело (обход блока по ~20КБ)" sets CURL_HTTPS_GET=1 — blockcheck2's HTTPS probe then does a full-body GET instead of HEAD (-I), so DPI that passes the first ~16-20KB and then stalls (curl code=28) is detected instead of a false pass. Also surfaced the zapret2-correct SKIP_PKTWS/SKIP_IPBLOCK/SKIP_DNSCHECK toggles (dropped the v1-only SKIP_TPWS).

Help ("?") for the BlockCheck2 tab now documents the full blockcheck2.sh env parameter set (DOMAINS/IPVS/ENABLE_*/ports/SCANLEVEL/REPEATS/PARALLEL/CURL_*/ TTL/SKIP_*/DNS), the highlight behavior, and the CURL_HTTPS_GET knob.

Tests: highlight regex + _read_output dedup/cleanup. skill §6 updated. 1006 passed.