### PR TITLE
catalogs: стратегии z2k, реально использующие новые движки

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,26 @@
   `DELETE /api/strategies/state[/host/<h>|/key/<k>]` с опциональным
   `?reload=1` для SIGHUP nfqws2 (`api/strategies.py`,
   `core/strategy_state.py`, `web/js/pages/strategies.js`).
+- **Стратегии z2k в каталоге (используют новые движки)** — раньше были
+  добавлены только Lua-скрипты z2k, но ни одна стратегия их не вызывала
+  (детекторы/QUIC-morph/dynamic-TTL грузились, но «спали»). Теперь есть
+  стратегии, которые их реально задействуют, — они видны в списке
+  (автор `necronicle/z2k`) и участвуют в подборе:
+  - `catalogs/builtin/z2k_circular.txt` — **z2k TLS/HTTP авто (умные
+    детекторы)**: circular-автоподбор с `failure_detector=z2k_mid_stream_stall`
+    (ловит TLS-stall и молчание в потоке 8–32KB), `success_detector=
+    z2k_http_success_positive_only` (не закрепляется на блок-страницах
+    РКН / отказе сервера), `hostkey=z2k_nohost_key` (общий бакет для
+    бесхостовых потоков). Самодостаточна (встроенные блобы + hex-паттерны).
+    Видна в фильтре «⟳ Авто (circular)».
+  - `catalogs/advanced/udp_z2k_advanced.txt` — приёмы `z2k_quic_morph_v2`
+    (морфинг QUIC Initial) и `z2k_game_udp` (UDP-fake для игр/Discord),
+    тестируются при подборе UDP (режим full).
+  - `catalogs/advanced/tcp_z2k_advanced.txt` — приёмы с
+    `fool=z2k_dynamic_ttl` (TTL фейка = реальный−1, с первого пакета),
+    тестируются при подборе TCP (режим full).
+  - Новый value-триггер `fool=z2k_*` подгружает `z2k-fooling-ext.lua`
+    для не-circular приёмов (`core/nfqws_manager._FOOL_EXT_TRIGGER_RE`).
 - **Фильтр «⟳ Авто (circular)» в списке стратегий** — быстро показать
   только авто-стратегии (которые сами перебирают приёмы и запоминают
   рабочий). Карточка «Выученные стратегии» теперь видна всегда: при пустом

--- a/catalogs/advanced/tcp_z2k_advanced.txt
+++ b/catalogs/advanced/tcp_z2k_advanced.txt
@@ -1,0 +1,26 @@
+# Приёмы z2k для TCP (TLS/HTTP).
+# Источник: github.com/necronicle/z2k (z2k-fooling-ext.lua, z2k-modern-core.lua).
+# Это «приёмы» — сканер оборачивает под цель (--filter-tcp/--filter-l7/
+# --payload/--hostlist). fool=z2k_dynamic_ttl грузит z2k-fooling-ext.lua
+# по value-триггеру (см. nfqws_manager._FOOL_EXT_TRIGGER_RE).
+
+[z2k_fake_dyn_ttl]
+name = z2k Fake + динамический TTL
+author = necronicle/z2k
+label = recommended
+description = Fake TLS с TTL = (реальный TTL − 1), без зависимости от ipcache — работает с первого пакета потока. Против ТСПУ, сверяющего TTL фейка.
+--lua-desync=fake:blob=fake_default_tls:fool=z2k_dynamic_ttl:tls_mod=rnd,dupsid
+
+[z2k_fake_dyn_ttl_repeats]
+name = z2k Fake + дин. TTL (повторы)
+author = necronicle/z2k
+label = stable
+description = Fake TLS с динамическим TTL и 6 повторами для надёжного прохода.
+--lua-desync=fake:blob=fake_default_tls:fool=z2k_dynamic_ttl:repeats=6:tls_mod=rnd,dupsid
+
+[z2k_fake_dyn_ttl_split]
+name = z2k Fake дин.TTL + multisplit
+author = necronicle/z2k
+label = stable
+description = Fake с динамическим TTL, затем multisplit по SNI — комбинация фейка и сегментации.
+--lua-desync=fake:blob=fake_default_tls:fool=z2k_dynamic_ttl:tls_mod=rnd --lua-desync=multisplit:pos=1,midsld

--- a/catalogs/advanced/udp_z2k_advanced.txt
+++ b/catalogs/advanced/udp_z2k_advanced.txt
@@ -1,0 +1,39 @@
+# Приёмы z2k для UDP (QUIC / игры / Discord voice).
+# Источник: github.com/necronicle/z2k (z2k-modern-core.lua).
+# Это «приёмы» (один --lua-desync) — сканер оборачивает их под цель
+# (--filter-udp/--filter-l7/--payload/--hostlist), см. strategy_scanner.
+
+[z2k_quic_morph]
+name = z2k QUIC morph
+author = necronicle/z2k
+label = recommended
+description = Морфинг QUIC Initial: фрагментация + модификация version/CID/token + шумовые пакеты. Против DPI, распознающего QUIC по сигнатуре первого пакета.
+--lua-desync=z2k_quic_morph_v2
+
+[z2k_quic_morph_frag2]
+name = z2k QUIC morph (профиль фрагментации 2)
+author = necronicle/z2k
+label = stable
+description = QUIC morph с явным профилем фрагментации 2 (две части).
+--lua-desync=z2k_quic_morph_v2:frag=2
+
+[z2k_quic_morph_frag3_noise]
+name = z2k QUIC morph (3 фрагмента + шум)
+author = necronicle/z2k
+label = stable
+description = QUIC morph с 3 фрагментами и генерацией шумового пакета — для агрессивного DPI.
+--lua-desync=z2k_quic_morph_v2:frag=3:noise=1
+
+[z2k_game_udp]
+name = z2k Game UDP fake
+author = necronicle/z2k
+label = recommended
+description = Инъекция поддельных UDP-датаграмм для игровых протоколов (с TTL/повторами). Для голоса Discord, игровых серверов, STUN.
+--lua-desync=z2k_game_udp:repeats=2
+
+[z2k_game_udp_ttl]
+name = z2k Game UDP fake + TTL
+author = necronicle/z2k
+label = stable
+description = Game UDP fake с авто-TTL для прохождения мимо ТСПУ.
+--lua-desync=z2k_game_udp:repeats=3:ip_autottl=-2,3-20:ip6_autottl=-2,3-20

--- a/catalogs/builtin/z2k_circular.txt
+++ b/catalogs/builtin/z2k_circular.txt
@@ -1,0 +1,39 @@
+# Полный circular-пресет z2k с УМНЫМИ детекторами.
+# Источник: github.com/necronicle/z2k (z2k-detectors.lua, z2k-modern-core.lua).
+#
+# Отличие от штатных circular-пресетов (youtubediscord): здесь circular
+# использует расширенные детекторы z2k, которые ловят провалы, невидимые
+# стандартному детектору:
+#   failure_detector=z2k_mid_stream_stall — TLS fatal-alert + «второй
+#     ClientHello без ServerHello» + молчание в потоке (8–32KB) после
+#     хендшейка (DPI пускает начало ответа и рвёт середину).
+#   success_detector=z2k_http_success_positive_only — успехом считается
+#     только 2xx/304/same-SLD-3xx; блок-страницы РКН/редиректы на
+#     warn./deny. НЕ закрепляются как «рабочая стратегия».
+#   hostkey=z2k_nohost_key — бесхостовые потоки (нет SNI) делят один
+#     бакет ротации, а не плодят состояние по dest-IP.
+#
+# Стратегия самодостаточна: только встроенные блобы (fake_default_tls/http)
+# и hex-паттерны seqovl — без --blob и init_vars. state.tsv (выученная
+# стратегия) сохраняется автоматически через z2k-state-persist.
+
+[z2k_tls_circular_smart]
+name = z2k TLS/HTTP авто (умные детекторы)
+author = necronicle/z2k
+label = recommended
+description = circular-автоподбор с детекторами z2k: ловит TLS-stall, молчание в потоке и блок-страницы РКН, не закрепляется на отказе сервера. Запоминает рабочую стратегию по доменам (переживает рестарт). Открывайте заблокированные сайты — подбор идёт сам.
+--filter-tcp=80,443 --filter-l7=tls,http --ipcache-hostname=1 --out-range=-s34228 --in-range=-s5556
+--lua-desync=circular:fails=3:retrans=3:nld=3:failure_detector=z2k_mid_stream_stall:success_detector=z2k_http_success_positive_only:hostkey=z2k_nohost_key
+--in-range=x
+--payload=tls_client_hello
+--lua-desync=fake:blob=fake_default_tls:tls_mod=rnd,dupsid:tcp_md5:repeats=2:strategy=1
+--lua-desync=multidisorder:pos=1,midsld:strategy=2
+--lua-desync=multisplit:pos=1:seqovl=5:seqovl_pattern=0x1603030000:strategy=3
+--lua-desync=fake:blob=fake_default_tls:fool=z2k_dynamic_ttl:tls_mod=rnd:strategy=4
+--lua-desync=fake:blob=fake_default_tls:tls_mod=rnd:strategy=5 --lua-desync=multisplit:pos=1,midsld:strategy=5
+--lua-desync=multisplit:pos=host:strategy=6
+--payload=http_req
+--lua-desync=fake:blob=fake_default_http:tcp_md5:strategy=1
+--lua-desync=fake:blob=fake_default_http:fool=z2k_dynamic_ttl:strategy=2
+--lua-desync=multisplit:pos=method+2,host:strategy=3
+--lua-desync=multidisorder:pos=method+2,host:strategy=4

--- a/core/nfqws_manager.py
+++ b/core/nfqws_manager.py
@@ -202,6 +202,14 @@ _RANGE_RAND_TRIGGER_RE = re.compile(
     r"(?:repeats|seqovl|tcp_seq|tcp_ts)=-?\d+-(?:-)?\d+")
 _RANGE_RAND_LUA_FILE = "z2k-range-rand.lua"
 
+# z2k-fooling-ext: fool=z2k_dynamic_ttl ссылается на кастомную fool-функцию,
+# которая НЕ является --lua-desync (значит, не триггерится extension-картой по
+# имени). Для circular она грузится в orchestrator-bundle, но для обычного
+# приёма (например, fake:fool=z2k_dynamic_ttl) нужен отдельный value-триггер.
+# Грузится по значению fool=z2k_*.
+_FOOL_EXT_TRIGGER_RE = re.compile(r"\bfool=(z2k_[A-Za-z0-9_]+)")
+_FOOL_EXT_LUA_FILE = "z2k-fooling-ext.lua"
+
 # Путь к state-каталогу (Z2K_STATE_DIR_OVERRIDE для z2k-state-persist.lua).
 # Пишем в наш GUI-каталог, а не в /opt/zapret2/extra_strats — чтобы state
 # выживал переустановку zapret2 и был частью бекапа GUI.
@@ -783,6 +791,11 @@ class NFQWSManager:
         # подгрузка — дедуп уберёт повтор.
         if _RANGE_RAND_TRIGGER_RE.search(joined):
             _add(out, _RANGE_RAND_LUA_FILE)
+
+        # z2k-fooling-ext по value-триггеру fool=z2k_* (для не-circular приёмов;
+        # для circular уже подтянут bundle'ом — дедуп уберёт повтор).
+        if _FOOL_EXT_TRIGGER_RE.search(joined):
+            _add(out, _FOOL_EXT_LUA_FILE)
 
         return out
 

--- a/tests/test_nfqws_lua_map.py
+++ b/tests/test_nfqws_lua_map.py
@@ -265,6 +265,22 @@ class TestBuildLuaInitArgs(unittest.TestCase):
             ["--lua-desync=fake:blob=fake_default_tls:tcp_seq=-1000-1000"])
         self.assertIn("z2k-range-rand.lua", files)
 
+    # ──────────────── z2k fool=z2k_dynamic_ttl ────────────────
+
+    def test_fool_ext_triggered_by_dynamic_ttl(self):
+        """fake:fool=z2k_dynamic_ttl (НЕ circular) тянет z2k-fooling-ext.lua
+        по value-триггеру — иначе fool-функция не определена."""
+        files = self._files(
+            ["--lua-desync=fake:blob=fake_default_tls:fool=z2k_dynamic_ttl"])
+        self.assertIn("z2k-fooling-ext.lua", files)
+        # zapret-auto (orchestrator) НЕ должен подтягиваться без circular
+        self.assertNotIn("zapret-auto.lua", files)
+
+    def test_fool_ext_not_triggered_without_z2k_fool(self):
+        files = self._files(
+            ["--lua-desync=fake:blob=fake_default_tls:ip_autottl=-2,3-20"])
+        self.assertNotIn("z2k-fooling-ext.lua", files)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Закрывает пробел из фидбэка: ранее были добавлены только Lua-скрипты z2k, но НИ ОДНА стратегия их не вызывала — детекторы / QUIC-morph / dynamic-TTL грузились, но «спали». z2k-state-persist работал для всех circular (оборачивает circular() при загрузке), но детекторы и техники z2k не участвовали ни в подборе, ни в списке. Теперь есть стратегии, которые их задействуют (автор necronicle/z2k):

- catalogs/builtin/z2k_circular.txt — «z2k TLS/HTTP авто (умные детекторы)»: circular с failure_detector=z2k_mid_stream_stall (TLS-stall + молчание в потоке 8–32KB), success_detector=z2k_http_success_positive_only (не закрепляется на блок-страницах РКН / отказе сервера), hostkey=z2k_nohost_key. Самодостаточна (встроенные блобы fake_default_*
  + hex-паттерны seqovl, без --blob/init_vars). Видна в фильтре «⟳ Авто (circular)», применяется напрямую из списка.

- catalogs/advanced/udp_z2k_advanced.txt — приёмы z2k_quic_morph_v2 (морфинг QUIC Initial: фрагментация + version/CID/token + шум) и z2k_game_udp (UDP-fake для игр/Discord/STUN). Тестируются при подборе UDP (режим full).

- catalogs/advanced/tcp_z2k_advanced.txt — приёмы fake с fool=z2k_dynamic_ttl (TTL фейка = реальный−1, без ipcache, с первого пакета). Тестируются при подборе TCP (режим full).

Инфраструктура:

- Новый value-триггер fool=z2k_* (_FOOL_EXT_TRIGGER_RE) подгружает z2k-fooling-ext.lua для не-circular приёмов — для circular он уже в orchestrator-bundle; дедуп _dedup_lua_init убирает повтор (проверено: z2k-state-persist грузится ровно 1 раз → circular оборачивается единожды).

Проверено:
- 9 z2k-стратегий появились в списке (автор necronicle/z2k);
- circular-пресет ловится фильтром «Авто (circular)»;
- circular-пресет подгружает все z2k-companion'ы (detectors/modern-core/ fooling-ext/state-persist + zapret-auto), дубли дедуплицируются;
- z2k-приёмы входят в full-набор подбора (TCP/UDP);
- catalog loadability-инвариант (test_nfqws_lua_map) проходит — все --lua-desync функции загружаемы.

Замечание: advanced-приёмы не попадают в quick/standard, т.к. basic-набор (361 TCP / 135 UDP) уже перекрывает лимит standard=80 — это существующее поведение для ВСЕХ advanced-стратегий, не только z2k. z2k-приёмы доступны в режиме full и напрямую из списка.

Тесты: +2 (fool-триггер). Итого 1086 зелёных.

https://claude.ai/code/session_01KfxPSb5opDMycPFsP6zTtT