### PR TITLE
feat(gui): улучшения blockcheck2, стратегий и поиска по спискам

### DIFF
--- a/web/css/blockcheck_scan.css
+++ b/web/css/blockcheck_scan.css
@@ -67,12 +67,23 @@
     display: none;
 }
 .bc2-found-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
     font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: .4px;
     color: var(--success, #34d399);
     margin-bottom: 6px;
+}
+.bc2-found-copy {
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 500;
+    flex-shrink: 0;
 }
 .bc2-found-chips {
     display: flex;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -980,6 +980,47 @@ input:focus, textarea:focus, select:focus {
     align-items: center;
 }
 
+/* Чекбокс выделения карточки для объединения (§7) */
+.strategy-select-label {
+    display: flex;
+    align-items: center;
+    padding-top: 2px;
+    flex-shrink: 0;
+    cursor: pointer;
+}
+.strategy-select {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+.strategy-card.selected {
+    border-color: var(--accent, #5b9ef4);
+    box-shadow: inset 0 0 0 1px var(--accent, #5b9ef4);
+}
+
+/* Плавающая панель массовых действий */
+.strat-bulkbar {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    z-index: 550;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    box-shadow: var(--shadow-lg);
+}
+.strat-bulkbar-count {
+    font-size: 13px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
 /* Profile badges */
 .profile-badge {
     display: inline-flex;
@@ -1105,6 +1146,54 @@ input:focus, textarea:focus, select:focus {
 
 .modal-content.modal-lg {
     max-width: 680px;
+}
+
+/* Растягиваемое/перемещаемое окно редактора стратегии (§5).
+   Геометрию (left/top/width/height) задаёт JS; шапка тянет окно, ручки по
+   8 сторонам — ресайз. Тело прокручивается, шапка остаётся на месте. */
+.modal-content.modal-resizable {
+    position: fixed;
+    margin: 0;
+    max-width: none;
+    max-height: none;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    animation: none;
+}
+.modal-content.modal-resizable .modal-header {
+    flex: 0 0 auto;
+    cursor: move;
+    user-select: none;
+}
+.modal-content.modal-resizable .modal-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+}
+.modal-resize-handle {
+    position: absolute;
+    z-index: 5;
+    touch-action: none;
+}
+.modal-resize-handle.mrh-n { top: 0; left: 0; right: 0; height: 6px; cursor: ns-resize; }
+.modal-resize-handle.mrh-s { bottom: 0; left: 0; right: 0; height: 6px; cursor: ns-resize; }
+.modal-resize-handle.mrh-e { top: 0; bottom: 0; right: 0; width: 6px; cursor: ew-resize; }
+.modal-resize-handle.mrh-w { top: 0; bottom: 0; left: 0; width: 6px; cursor: ew-resize; }
+.modal-resize-handle.mrh-ne { top: 0; right: 0; width: 14px; height: 14px; cursor: nesw-resize; z-index: 6; }
+.modal-resize-handle.mrh-nw { top: 0; left: 0; width: 14px; height: 14px; cursor: nwse-resize; z-index: 6; }
+.modal-resize-handle.mrh-se { bottom: 0; right: 0; width: 16px; height: 16px; cursor: nwse-resize; z-index: 6; }
+.modal-resize-handle.mrh-sw { bottom: 0; left: 0; width: 14px; height: 14px; cursor: nesw-resize; z-index: 6; }
+/* Уголок снизу-справа — визуальная «риска», как у нативного resize. */
+.modal-content.modal-resizable .modal-resize-handle.mrh-se::after {
+    content: "";
+    position: absolute;
+    right: 3px;
+    bottom: 3px;
+    width: 7px;
+    height: 7px;
+    border-right: 2px solid var(--text-muted);
+    border-bottom: 2px solid var(--text-muted);
+    opacity: 0.5;
 }
 
 @keyframes modal-slide-in {
@@ -1490,12 +1579,27 @@ input:focus, textarea:focus, select:focus {
 }
 
 /* ===== Lists Tabs (Phase 3) ===== */
+/* Поиск файла по имени над табами списков (§6) */
+.lists-filebar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    background: var(--bg-secondary);
+}
+.lists-filebar-status {
+    font-size: 12px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
 .lists-tabs {
     display: flex;
     gap: 0;
     background: var(--bg-secondary);
     border-bottom: 1px solid var(--border);
-    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
 }

--- a/web/js/pages/blockcheck2.js
+++ b/web/js/pages/blockcheck2.js
@@ -23,6 +23,12 @@ const Blockcheck2Page = (() => {
     let foundStrategies = [];     // структурные находки для кликабельных бейджей
     let foundKeys = new Set();    // дедуп бейджей (ipv|test|domain|strategy)
     let bcCur = null;             // текущий разбираемый блок стратегии
+    let formState = null;         // сохранённые значения формы (домены, галки) между переключениями вкладок
+
+    // Поля формы, состояние которых переживает уход/возврат на вкладку (SKILL-task §8).
+    const FORM_TEXT_IDS = ['bc2-domains', 'bc2-scanlevel', 'bc2-ipvs', 'bc2-repeats', 'bc2-env', 'bc2-args'];
+    const FORM_CHECK_IDS = ['bc2-http', 'bc2-tls12', 'bc2-tls13', 'bc2-http3', 'bc2-https-get',
+        'bc2-skip-pktws', 'bc2-skip-ipblock', 'bc2-skip-dnscheck', 'bc2-parallel', 'bc2-curl-verbose'];
 
     /* ───────── lifecycle ───────── */
 
@@ -159,13 +165,54 @@ const Blockcheck2Page = (() => {
             </div>
         `;
 
+        // Восстанавливаем заполненные ранее домены/галки (форма пересоздаётся
+        // при каждом render, а бейджи живут в module-state — SKILL-task §8).
+        restoreFormState();
+
         loadScript();
         // Подтянуть текущее состояние (вдруг запуск уже идёт).
         outOffset = 0;
         fetchStatus(true);
     }
 
-    function destroy() { stopPolling(); }
+    function destroy() {
+        // Сохраняем значения формы перед уничтожением DOM, чтобы при возврате
+        // на вкладку домены и галки не потерялись.
+        captureFormState();
+        stopPolling();
+    }
+
+    /* ───────── сохранение/восстановление формы ───────── */
+
+    function captureFormState() {
+        const st = {};
+        let any = false;
+        FORM_TEXT_IDS.forEach(id => {
+            const e = document.getElementById(id);
+            if (e) { st[id] = e.value; any = true; }
+        });
+        FORM_CHECK_IDS.forEach(id => {
+            const e = document.getElementById(id);
+            if (e) { st[id] = e.checked; any = true; }
+        });
+        const adv = document.getElementById('bc2-advanced');
+        if (adv) { st._adv = adv.open; any = true; }
+        if (any) formState = st;
+    }
+
+    function restoreFormState() {
+        if (!formState) return;
+        FORM_TEXT_IDS.forEach(id => {
+            const e = document.getElementById(id);
+            if (e && formState[id] != null) e.value = formState[id];
+        });
+        FORM_CHECK_IDS.forEach(id => {
+            const e = document.getElementById(id);
+            if (e && formState[id] != null) e.checked = formState[id];
+        });
+        const adv = document.getElementById('bc2-advanced');
+        if (adv && formState._adv != null) adv.open = formState._adv;
+    }
 
     /* ───────── script discovery ───────── */
 
@@ -481,13 +528,10 @@ const Blockcheck2Page = (() => {
     // (фильтр из типа теста + дословный --payload/--lua-desync, SKILL §3).
     // Полностью успешные (вердикт «!!!!! AVAILABLE !!!!!», напр. 3/3) — вверху
     // и зелёные; частичные (напр. 2/3) — ниже и янтарные.
-    function renderFoundChips() {
-        const el = document.getElementById('bc2-found');
-        if (!el) return;
-        if (!foundStrategies.length) { el.innerHTML = ''; return; }
-
-        // Индексы в исходном массиве сохраняем для useStrategy(i).
-        const order = foundStrategies
+    // Порядок бейджей: сначала полностью успешные, затем по убыванию ok/total.
+    // Общий для отрисовки чипов и «копировать все» (task §2).
+    function _foundOrder() {
+        return foundStrategies
             .map((f, i) => ({ f, i }))
             .sort((a, b) => {
                 if (!!b.f.full - !!a.f.full) return (b.f.full ? 1 : 0) - (a.f.full ? 1 : 0);
@@ -495,6 +539,36 @@ const Blockcheck2Page = (() => {
                 const rb = (b.f.ok || 0) / (b.f.total || 1);
                 return rb - ra;
             });
+    }
+
+    // Реконструкция дословных args приёма: фильтр (из типа теста) + опционально
+    // --hostlist-domains=<домены> + payload (если нет в стратегии) + сама стратегия.
+    function _buildArgs(f, domains) {
+        const strat = String(f.strategy || '');
+        let args = `--filter-${f.proto}=${f.port} --filter-l7=${f.l7} `;
+        if (domains && domains.length && !/--hostlist-domains=/.test(strat)) {
+            args += `--hostlist-domains=${domains.join(',')} `;
+        }
+        if (!/--payload=/.test(strat) && f.payload) {
+            args += `--payload=${f.payload} `;
+        }
+        args += strat;
+        return args.trim();
+    }
+
+    // Домены из поля формы (по одному на строку) — для --hostlist-domains (task §1).
+    function _domainsFromForm() {
+        const t = (document.getElementById('bc2-domains') || {}).value || '';
+        return t.split('\n').map(s => s.trim()).filter(Boolean);
+    }
+
+    function renderFoundChips() {
+        const el = document.getElementById('bc2-found');
+        if (!el) return;
+        if (!foundStrategies.length) { el.innerHTML = ''; return; }
+
+        // Индексы в исходном массиве сохраняем для useStrategy(i).
+        const order = _foundOrder();
 
         const chips = order.map(({ f, i }) => {
             const rate = (f.ok != null && f.total != null) ? (f.ok + '/' + f.total) : '';
@@ -509,9 +583,57 @@ const Blockcheck2Page = (() => {
                 + `<span class="bc2-found-arrow">→ создать</span></button>`;
         }).join('');
         const full = foundStrategies.filter(f => f.full).length;
-        el.innerHTML = `<div class="bc2-found-title">Рабочие стратегии blockcheck2 `
-            + `(${full} полных · ${foundStrategies.length} всего · клик — создать)</div>`
+        el.innerHTML = `<div class="bc2-found-title">`
+            + `<span>Рабочие стратегии blockcheck2 `
+            + `(${full} полных · ${foundStrategies.length} всего · клик — создать)</span>`
+            + `<button class="btn btn-ghost btn-sm bc2-found-copy" onclick="Blockcheck2Page.copyAllFound()" `
+            + `title="Скопировать все найденные стратегии в буфер обмена — потом сами скомпонуете нужные через --new">`
+            + `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="13" height="13" style="margin-right:4px;">`
+            + `<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>`
+            + `<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`
+            + `Копировать все</button></div>`
             + `<div class="bc2-found-chips">${chips}</div>`;
+    }
+
+    // Копировать список всех найденных стратегий в буфер обмена (task §2).
+    // Каждый приём — комментарий с доменом/успехом + готовая строка args,
+    // чтобы пользователь сам скомпоновал нужные профили через --new.
+    function copyAllFound() {
+        if (!foundStrategies.length) { Toast && Toast.info && Toast.info('Пока нет найденных стратегий'); return; }
+        const lines = [`# Рабочие стратегии blockcheck2 (${foundStrategies.length})`, ''];
+        _foundOrder().forEach(({ f }) => {
+            const rate = (f.ok != null && f.total != null) ? `${f.ok}/${f.total}` : '';
+            lines.push(`# ${f.label || ''} · ${f.domain || ''}`
+                + (rate ? ` · успех ${rate}` : '') + (f.full ? '' : ' (не все попытки)'));
+            lines.push(`${f.engine || 'nfqws2'} ${_buildArgs(f, null)}`);
+            lines.push('');
+        });
+        _copyText(lines.join('\n').trim() + '\n', `Скопировано стратегий: ${foundStrategies.length}`);
+    }
+
+    // Копирование в буфер с fallback на execCommand (как в strategies.js).
+    function _copyText(text, okMsg) {
+        const done = () => Toast && Toast.success && Toast.success(okMsg || 'Скопировано');
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(() => _copyFallback(text, done));
+        } else {
+            _copyFallback(text, done);
+        }
+    }
+    function _copyFallback(text, done) {
+        try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            done();
+        } catch (_e) {
+            Toast && Toast.error && Toast.error('Не удалось скопировать');
+        }
     }
 
     function useStrategy(index) {
@@ -521,18 +643,17 @@ const Blockcheck2Page = (() => {
             Toast && Toast.error && Toast.error('Страница стратегий недоступна');
             return;
         }
-        const strat = String(f.strategy || '');
-        let args = `--filter-${f.proto}=${f.port} --filter-l7=${f.l7} `;
-        if (!/--payload=/.test(strat) && f.payload) {
-            args += `--payload=${f.payload} `;
-        }
-        args += strat;
+        // Домены для --hostlist-domains берём из поля формы; если пусто —
+        // используем сам протестированный домен (task §1).
+        const formDomains = _domainsFromForm();
+        const domList = formDomains.length ? formDomains : (f.domain ? [f.domain] : []);
+        const args = _buildArgs(f, domList);
         const rate = (f.ok != null && f.total != null) ? ` ${f.ok}/${f.total}` : '';
         StrategiesPage.prefillCreate({
             name: `${f.domain} · ${f.label}${rate} (blockcheck2)`,
             description: `Найдено blockcheck2 для ipv${f.ipv} ${f.domain}`
                 + (rate ? ` · успех${rate}` + (f.full ? '' : ' (не все попытки)') : ''),
-            args: args.trim(),
+            args: args,
         });
     }
 
@@ -549,5 +670,5 @@ const Blockcheck2Page = (() => {
             .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
 
-    return { render, destroy, start, stop, clearOutput, useStrategy };
+    return { render, destroy, start, stop, clearOutput, useStrategy, copyAllFound };
 })();

--- a/web/js/pages/hostlists.js
+++ b/web/js/pages/hostlists.js
@@ -22,6 +22,7 @@ const HostlistsPage = (() => {
     let originalContent = '';
     let hasUnsaved = false;
     let loading = false;
+    let fileQuery = '';     // §6 — фильтр по имени файла (табы/карточки)
 
     // ══════════════════ Render ══════════════════
 
@@ -54,6 +55,23 @@ const HostlistsPage = (() => {
 
             <!-- Табы -->
             <div class="card" style="padding: 0;">
+                <!-- Поиск файла по имени (когда списков много — §6) -->
+                <div class="lists-filebar">
+                    <div class="list-ui-search" style="flex:1; min-width:160px; max-width:340px;">
+                        <svg class="list-ui-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                            <circle cx="11" cy="11" r="8"/>
+                            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                        </svg>
+                        <input type="text" class="form-input list-ui-search-input" id="hl-file-search"
+                               placeholder="Поиск файла по имени…" spellcheck="false" autocomplete="off">
+                        <button class="list-ui-search-clear" id="hl-file-search-clear" title="Очистить" style="display:none;">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">
+                                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <span class="lists-filebar-status" id="hl-file-search-status"></span>
+                </div>
                 <div class="lists-tabs" id="hl-tabs"></div>
 
                 <div class="lists-content" id="hl-content">
@@ -294,6 +312,60 @@ const HostlistsPage = (() => {
                 updateSearchStatus('');
             });
         }
+
+        // Поиск файла по имени (фильтрует табы и карточки-статистику — §6).
+        const fileSearch = document.getElementById('hl-file-search');
+        const fileSearchClear = document.getElementById('hl-file-search-clear');
+        if (fileSearch) {
+            fileSearch.value = fileQuery;
+            if (fileSearchClear) fileSearchClear.style.display = fileQuery ? '' : 'none';
+            fileSearch.addEventListener('input', e => {
+                fileQuery = e.target.value;
+                if (fileSearchClear) fileSearchClear.style.display = fileQuery ? '' : 'none';
+                applyFileFilter();
+            });
+            fileSearch.addEventListener('keydown', e => {
+                if (e.key === 'Escape') {
+                    fileQuery = '';
+                    fileSearch.value = '';
+                    if (fileSearchClear) fileSearchClear.style.display = 'none';
+                    applyFileFilter();
+                }
+            });
+        }
+        if (fileSearchClear) {
+            fileSearchClear.addEventListener('click', () => {
+                fileQuery = '';
+                if (fileSearch) { fileSearch.value = ''; fileSearch.focus(); }
+                fileSearchClear.style.display = 'none';
+                applyFileFilter();
+            });
+        }
+    }
+
+    // ══════════════════ Поиск файла по имени (§6) ══════════════════
+
+    // Скрывает табы и карточки-статистику, чьё имя/метка не содержат запрос.
+    function applyFileFilter() {
+        const q = (fileQuery || '').trim().toLowerCase();
+        let vis = 0;
+        document.querySelectorAll('#hl-tabs .lists-tab').forEach(el => {
+            const name = (el.dataset.tab || '').toLowerCase();
+            const labelEl = el.querySelector('.lists-tab-name');
+            const label = (labelEl ? labelEl.textContent : '').toLowerCase();
+            const match = !q || name.includes(q) || label.includes(q);
+            el.style.display = match ? '' : 'none';
+            if (match) vis++;
+        });
+        document.querySelectorAll('#hl-stats-grid .status-card').forEach(el => {
+            const name = (el.dataset.name || '').toLowerCase();
+            const labelEl = el.querySelector('.status-card-label');
+            const label = (labelEl ? labelEl.textContent : '').toLowerCase();
+            const match = !q || name.includes(q) || label.includes(q);
+            el.style.display = match ? '' : 'none';
+        });
+        const status = document.getElementById('hl-file-search-status');
+        if (status) status.textContent = q ? (vis ? `найдено: ${vis}` : 'ничего не найдено') : '';
     }
 
     // ══════════════════ Search в редакторе ══════════════════
@@ -392,6 +464,7 @@ const HostlistsPage = (() => {
                 <span class="lists-tab-count" id="hl-tab-count-${escapeAttr(t.name)}">—</span>
             </button>
         `).join('');
+        applyFileFilter();
     }
 
     function tabsFromFiles(files) {
@@ -416,7 +489,7 @@ const HostlistsPage = (() => {
             const grid = document.getElementById('hl-stats-grid');
             if (grid) {
                 grid.innerHTML = (result.files || []).map(f => `
-                    <div class="status-card" style="cursor:pointer;" onclick="HostlistsPage.switchTab('${escapeAttr(f.name)}')">
+                    <div class="status-card" style="cursor:pointer;" data-name="${escapeAttr(f.name)}" onclick="HostlistsPage.switchTab('${escapeAttr(f.name)}')">
                         <div class="status-card-header">
                             <svg class="status-card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
@@ -437,6 +510,9 @@ const HostlistsPage = (() => {
                 const cnt = document.getElementById('hl-tab-count-' + f.name);
                 if (cnt) cnt.textContent = f.count;
             });
+
+            // Применяем фильтр по имени к свежепостроенным карточкам/табам (§6).
+            applyFileFilter();
 
             // Загружаем содержимое активной вкладки
             loadTab(activeTab);
@@ -832,6 +908,7 @@ const HostlistsPage = (() => {
     function destroy() {
         hasUnsaved = false;
         loading = false;
+        fileQuery = '';
     }
 
     // ══════════════════ Public API ══════════════════

--- a/web/js/pages/ipsets.js
+++ b/web/js/pages/ipsets.js
@@ -16,6 +16,7 @@ const IPSetsPage = (() => {
     let originalContent = '';
     let hasUnsaved = false;
     let loading = false;
+    let fileQuery = '';     // §6 — фильтр по имени файла (табы/карточки)
 
     // ══════════════════ Render ══════════════════
 
@@ -48,6 +49,23 @@ const IPSetsPage = (() => {
 
             <!-- Табы -->
             <div class="card" style="padding: 0;">
+                <!-- Поиск файла по имени (когда списков много — §6) -->
+                <div class="lists-filebar">
+                    <div class="list-ui-search" style="flex:1; min-width:160px; max-width:340px;">
+                        <svg class="list-ui-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                            <circle cx="11" cy="11" r="8"/>
+                            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                        </svg>
+                        <input type="text" class="form-input list-ui-search-input" id="ip-file-search"
+                               placeholder="Поиск файла по имени…" spellcheck="false" autocomplete="off">
+                        <button class="list-ui-search-clear" id="ip-file-search-clear" title="Очистить" style="display:none;">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">
+                                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <span class="lists-filebar-status" id="ip-file-search-status"></span>
+                </div>
                 <div class="lists-tabs" id="ip-tabs"></div>
 
                 <div class="lists-content" id="ip-content">
@@ -274,6 +292,59 @@ const IPSetsPage = (() => {
                 updateSearchStatus('');
             });
         }
+
+        // Поиск файла по имени (фильтрует табы и карточки-статистику — §6).
+        const fileSearch = document.getElementById('ip-file-search');
+        const fileSearchClear = document.getElementById('ip-file-search-clear');
+        if (fileSearch) {
+            fileSearch.value = fileQuery;
+            if (fileSearchClear) fileSearchClear.style.display = fileQuery ? '' : 'none';
+            fileSearch.addEventListener('input', e => {
+                fileQuery = e.target.value;
+                if (fileSearchClear) fileSearchClear.style.display = fileQuery ? '' : 'none';
+                applyFileFilter();
+            });
+            fileSearch.addEventListener('keydown', e => {
+                if (e.key === 'Escape') {
+                    fileQuery = '';
+                    fileSearch.value = '';
+                    if (fileSearchClear) fileSearchClear.style.display = 'none';
+                    applyFileFilter();
+                }
+            });
+        }
+        if (fileSearchClear) {
+            fileSearchClear.addEventListener('click', () => {
+                fileQuery = '';
+                if (fileSearch) { fileSearch.value = ''; fileSearch.focus(); }
+                fileSearchClear.style.display = 'none';
+                applyFileFilter();
+            });
+        }
+    }
+
+    // ══════════════════ Поиск файла по имени (§6) ══════════════════
+
+    function applyFileFilter() {
+        const q = (fileQuery || '').trim().toLowerCase();
+        let vis = 0;
+        document.querySelectorAll('#ip-tabs .lists-tab').forEach(el => {
+            const name = (el.dataset.tab || '').toLowerCase();
+            const labelEl = el.querySelector('.lists-tab-name');
+            const label = (labelEl ? labelEl.textContent : '').toLowerCase();
+            const match = !q || name.includes(q) || label.includes(q);
+            el.style.display = match ? '' : 'none';
+            if (match) vis++;
+        });
+        document.querySelectorAll('#ip-stats-grid .status-card').forEach(el => {
+            const name = (el.dataset.name || '').toLowerCase();
+            const labelEl = el.querySelector('.status-card-label');
+            const label = (labelEl ? labelEl.textContent : '').toLowerCase();
+            const match = !q || name.includes(q) || label.includes(q);
+            el.style.display = match ? '' : 'none';
+        });
+        const status = document.getElementById('ip-file-search-status');
+        if (status) status.textContent = q ? (vis ? `найдено: ${vis}` : 'ничего не найдено') : '';
     }
 
     // ══════════════════ Search в редакторе ══════════════════
@@ -369,6 +440,7 @@ const IPSetsPage = (() => {
                 <span class="lists-tab-count" id="ip-tab-count-${escapeAttr(t.name)}">—</span>
             </button>
         `).join('');
+        applyFileFilter();
     }
 
     function renderAsnTargetOptions() {
@@ -411,7 +483,7 @@ const IPSetsPage = (() => {
             const grid = document.getElementById('ip-stats-grid');
             if (grid) {
                 grid.innerHTML = (result.files || []).map(f => `
-                    <div class="status-card" style="cursor:pointer;" onclick="IPSetsPage.switchTab('${escapeAttr(f.name)}')">
+                    <div class="status-card" style="cursor:pointer;" data-name="${escapeAttr(f.name)}" onclick="IPSetsPage.switchTab('${escapeAttr(f.name)}')">
                         <div class="status-card-header">
                             <svg class="status-card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <circle cx="12" cy="12" r="10"/>
@@ -433,6 +505,9 @@ const IPSetsPage = (() => {
                 const cnt = document.getElementById('ip-tab-count-' + f.name);
                 if (cnt) cnt.textContent = f.count;
             });
+
+            // Применяем фильтр по имени к свежепостроенным карточкам/табам (§6).
+            applyFileFilter();
 
             loadTab(activeTab);
         } catch (err) {
@@ -805,6 +880,7 @@ const IPSetsPage = (() => {
     function destroy() {
         hasUnsaved = false;
         loading = false;
+        fileQuery = '';
     }
 
     // ══════════════════ Public API ══════════════════

--- a/web/js/pages/strategies.js
+++ b/web/js/pages/strategies.js
@@ -13,6 +13,13 @@ const StrategiesPage = (() => {
     let hostlistFiles = [];  // [{name, filename, path, is_builtin}] — для дропдауна в редакторе
     let pendingPrefill = null;  // стратегия из blockcheck2-бейджа, открыть после навигации
 
+    // §3/§4/§5/§7 — буфер обмена, ESC, ресайз окна, массовое объединение.
+    let selectedIds = new Set();   // выделенные карточки для объединения (§7)
+    let editorOnSaved = null;      // коллбэк после успешного сохранения редактора
+    let escKeyHandler = null;      // document keydown (ESC) — закрыть редактор/превью (§4)
+    let pasteHandler = null;       // document paste (Ctrl+V) — вставка стратегии (§3)
+    let modalResize = null;        // активный ресайзер окна редактора (§5)
+
     // Пресеты «+ фильтр…» — значения согласованы с дефолтами ScanTarget и
     // авто-обёрткой бэкенда (SKILL §3). Вставляются в НАЧАЛО args профиля.
     const FILTER_PRESETS = {
@@ -39,6 +46,13 @@ const StrategiesPage = (() => {
                             <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"/>
                         </svg>
                         <span id="strat-update-btn-label">Обновить стратегии</span>
+                    </button>
+                    <button class="btn btn-ghost" onclick="StrategiesPage.pasteStrategyFromClipboard()" title="Вставить стратегию из буфера обмена (или Ctrl+V на странице) — откроется создание новой стратегии с профилями из буфера">
+                        <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
+                            <rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>
+                        </svg>
+                        Вставить из буфера
                     </button>
                     <button class="btn btn-primary" onclick="StrategiesPage.openCreate()">
                         <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -180,6 +194,9 @@ const StrategiesPage = (() => {
                 </div>
             </div>
 
+            <!-- Панель массовых действий (объединение выбранных стратегий) -->
+            <div id="strat-bulkbar" class="strat-bulkbar" style="display:none;"></div>
+
             <!-- Модальное окно: редактор стратегии -->
             <div id="strategy-modal" class="modal-backdrop" style="display:none;">
                 <div class="modal-content modal-lg">
@@ -231,6 +248,10 @@ const StrategiesPage = (() => {
         refreshDebugToggle();
         refreshState();
         refreshHealthcheck();
+        // ESC закрывает редактор/превью (§4), Ctrl+V на странице вставляет
+        // стратегию из буфера (§3).
+        attachGlobalKeys();
+        renderBulkBar();
         // Если пришли сюда из blockcheck2-бейджа — открыть редактор с приёмом.
         consumePendingPrefill();
     }
@@ -971,8 +992,14 @@ const StrategiesPage = (() => {
             currentId = active ? active.id : null;
             favorites = strategies.filter(s => s.is_favorite).map(s => s.id);
 
+            // Чистим выделение от исчезнувших стратегий (напр. после объединения).
+            Array.from(selectedIds).forEach(id => {
+                if (!strategies.find(s => s.id === id)) selectedIds.delete(id);
+            });
+
             renderActiveCard(active);
             renderList(strategies);
+            renderBulkBar();
         } catch (err) {
             const host = document.getElementById('strategies-list-host');
             if (host) {
@@ -1074,6 +1101,7 @@ const StrategiesPage = (() => {
         const isActive = s.id === currentId;
         const isFav = s.is_favorite;
         const isBuiltin = s.is_builtin;
+        const isSelected = selectedIds.has(s.id);
 
         const labelTag = s.label
             ? `<span class="label ${escapeAttr(s.label)}">${escapeHtml(s.label)}</span>` : '';
@@ -1100,8 +1128,11 @@ const StrategiesPage = (() => {
         }).join('');
 
         return `
-            <div class="strategy-card compact${isActive ? ' active' : ''}" data-id="${s.id}" data-list-ui-card>
+            <div class="strategy-card compact${isActive ? ' active' : ''}${isSelected ? ' selected' : ''}" data-id="${s.id}" data-list-ui-card>
                 <div class="strategy-card-header">
+                    <label class="strategy-select-label" title="Выделить для объединения с другими стратегиями" onclick="event.stopPropagation();">
+                        <input type="checkbox" class="strategy-select"${isSelected ? ' checked' : ''} onclick="StrategiesPage.toggleSelect(event, '${escapeAttr(s.id)}')">
+                    </label>
                     <div class="strategy-card-info">
                         <div class="strategy-card-name">
                             ${isActive ? '<span class="status-dot running" style="width:8px;height:8px;"></span>' : ''}
@@ -1134,6 +1165,13 @@ const StrategiesPage = (() => {
                             <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
                         </svg>
                         Превью
+                    </button>
+                    <button class="btn btn-ghost btn-sm" onclick="StrategiesPage.copyStrategyToClipboard('${s.id}')" title="Скопировать стратегию со всеми профилями (через --new) в буфер обмена">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                        </svg>
+                        В буфер
                     </button>
                     ${!isBuiltin ? `
                         <button class="btn btn-ghost btn-sm" onclick="StrategiesPage.openEdit('${s.id}')" title="Редактировать">
@@ -1370,6 +1408,9 @@ const StrategiesPage = (() => {
 
         // Грузим список hostlist-файлов и перерисовываем форму, чтобы дропдаун был актуален
         renderEditorForm(body);
+        // Делаем окно растягиваемым во все стороны (ширина по умолчанию 2× — §5).
+        // Вызываем ПОСЛЕ renderEditorForm, чтобы измерить высоту формы.
+        enableModalResize();
         attachAutocompleteToProfiles();
         loadHostlistFiles().then(() => {
             // Перерисовываем только список профилей, не трогая остальные поля
@@ -1775,8 +1816,11 @@ const StrategiesPage = (() => {
 
             if (result.ok) {
                 Toast.success(editorMode === 'create' ? 'Стратегия создана' : 'Стратегия обновлена');
+                // Забираем отложенный коллбэк ДО closeModal (он его сбрасывает).
+                const onSaved = editorOnSaved;
                 closeModal();
                 fetchStrategies();
+                if (typeof onSaved === 'function') onSaved();
             } else {
                 Toast.error(result.error || 'Ошибка сохранения');
             }
@@ -1799,9 +1843,446 @@ const StrategiesPage = (() => {
 
     function closeModal() {
         NfqwsAutocomplete.detachAll();
+        disableModalResize();
         const modal = document.getElementById('strategy-modal');
         if (modal) modal.style.display = 'none';
         editorData = null;
+        // Сбрасываем отложенный коллбэк объединения, чтобы он не выстрелил
+        // на следующем (несвязанном) сохранении.
+        editorOnSaved = null;
+    }
+
+    // ══════════════════ Буфер обмена: копирование/вставка стратегий (§3) ══════════════════
+
+    // Копировать выбранную стратегию со всеми профилями (через --new) в буфер.
+    function copyStrategyToClipboard(sid) {
+        const s = strategies.find(x => x.id === sid);
+        if (!s) return;
+        const parts = (s.profiles || []).map(p => (p.args || '').trim()).filter(Boolean);
+        if (!parts.length) { Toast.warning('У стратегии нет аргументов для копирования'); return; }
+        const text = parts.join(' --new ');
+        _copyText(text, 'Стратегия скопирована в буфер (профилей: ' + parts.length + ')');
+    }
+
+    // Вставка по кнопке: пытаемся прочитать буфер (в secure-context). На роутере
+    // по http navigator.clipboard.readText недоступен — подсказываем Ctrl+V,
+    // который работает через событие paste (см. attachGlobalKeys).
+    async function pasteStrategyFromClipboard() {
+        let text = '';
+        try {
+            if (navigator.clipboard && navigator.clipboard.readText) {
+                text = await navigator.clipboard.readText();
+            }
+        } catch (_e) { /* доступ к буферу запрещён */ }
+        if (!text) {
+            Toast.info('Скопируйте стратегию и нажмите Ctrl+V на этой странице');
+            return;
+        }
+        if (!_looksLikeStrategy(text)) {
+            Toast.warning('В буфере нет распознаваемой стратегии nfqws2');
+            return;
+        }
+        _openPasteEditor(text);
+    }
+
+    // Эвристика: похоже ли содержимое буфера на стратегию nfqws2.
+    function _looksLikeStrategy(text) {
+        return /--(?:lua-desync|dpi-desync|filter-(?:tcp|udp|l7|l3)|new|hostlist|payload|wssize|dup)\b/.test(String(text || ''));
+    }
+
+    // Разбить строку args по разделителю профилей --new.
+    function _splitNew(s) {
+        return String(s || '').split(/\s+--new\s+/).map(x => x.trim()).filter(Boolean);
+    }
+
+    // Имя/id профиля из его args (зеркалит backend _detect_profile_info).
+    function _detectProfileInfo(argStr, idx) {
+        const toks = String(argStr || '').split(/\s+/);
+        for (const t of toks) {
+            if (t.startsWith('--filter-tcp=')) {
+                const port = t.split('=')[1] || '';
+                if (port === '80') return ['http' + (idx + 1), 'HTTP (порт 80)'];
+                return ['tcp' + (idx + 1), 'TCP (порты ' + port + ')'];
+            }
+            if (t.startsWith('--filter-udp=')) {
+                const port = t.split('=')[1] || '';
+                return ['udp' + (idx + 1), 'UDP (порты ' + port + ')'];
+            }
+            if (t.startsWith('--filter-l3=')) {
+                const ver = t.split('=')[1] || '';
+                return [ver + '_' + (idx + 1), ver.toUpperCase()];
+            }
+        }
+        return ['profile' + (idx + 1), 'Профиль ' + (idx + 1)];
+    }
+
+    // Распарсить текст из буфера в массив профилей. Поддерживает наш формат
+    // (args --new args) и блочный вывод blockcheck2 (строки «nfqws2 args»,
+    // комментарии «# …» игнорируются).
+    function _parseStrategyArgs(text) {
+        const lines = String(text || '').split('\n')
+            .map(l => l.trim())
+            .filter(l => l && !l.startsWith('#'));
+        const segs = [];
+        lines.forEach(line => {
+            const noEngine = line.replace(/^(?:nfqws2?|winws2?)\s+/i, '');
+            _splitNew(noEngine).forEach(seg => { if (seg) segs.push(seg); });
+        });
+        return segs.map((argStr, i) => {
+            const info = _detectProfileInfo(argStr, i);
+            return { id: info[0], name: info[1], enabled: true, args: argStr };
+        });
+    }
+
+    // Открыть редактор СОЗДАНИЯ, предзаполненный профилями из буфера.
+    // Автоматически НЕ сохраняем — решение за пользователем (§3).
+    function _openPasteEditor(text) {
+        const profiles = _parseStrategyArgs(text);
+        if (!profiles.length) { Toast.warning('В буфере нет распознаваемой стратегии'); return; }
+        openEditor({
+            id: '',
+            name: '',
+            description: 'Вставлено из буфера обмена',
+            type: profiles.length > 1 ? 'combined' : 'single',
+            profiles,
+        }, 'create');
+        Toast.info('Стратегия из буфера — задайте ID/имя, проверьте и сохраните');
+    }
+
+    // Копирование в буфер с fallback на execCommand (работает и по http,
+    // где navigator.clipboard недоступен).
+    function _copyText(text, okMsg) {
+        const done = () => Toast.success(okMsg || 'Скопировано');
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(() => _copyFallback(text, done));
+        } else {
+            _copyFallback(text, done);
+        }
+    }
+    function _copyFallback(text, done) {
+        try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            done();
+        } catch (_e) {
+            Toast.error('Не удалось скопировать');
+        }
+    }
+
+    // ══════════════════ Множественный выбор и объединение (§7) ══════════════════
+
+    function toggleSelect(ev, id) {
+        if (ev) ev.stopPropagation();
+        const checked = ev && ev.target ? !!ev.target.checked : !selectedIds.has(id);
+        if (checked) selectedIds.add(id); else selectedIds.delete(id);
+        const card = ev && ev.target && ev.target.closest('.strategy-card');
+        if (card) card.classList.toggle('selected', checked);
+        renderBulkBar();
+    }
+
+    function clearSelection() {
+        selectedIds.clear();
+        document.querySelectorAll('.strategy-select').forEach(c => { c.checked = false; });
+        document.querySelectorAll('.strategy-card.selected').forEach(c => c.classList.remove('selected'));
+        renderBulkBar();
+    }
+
+    function renderBulkBar() {
+        const bar = document.getElementById('strat-bulkbar');
+        if (!bar) return;
+        const n = selectedIds.size;
+        if (n === 0) { bar.style.display = 'none'; bar.innerHTML = ''; return; }
+        const canMerge = n >= 2;
+        bar.style.display = 'flex';
+        bar.innerHTML = `
+            <span class="strat-bulkbar-count">Выбрано: <b>${n}</b></span>
+            <button class="btn btn-primary btn-sm" onclick="StrategiesPage.mergeSelected()"
+                    ${canMerge ? '' : 'disabled'}
+                    title="${canMerge ? 'Объединить выбранные стратегии в одну (профили сложатся)' : 'Выберите минимум 2 стратегии'}">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="margin-right:4px;">
+                    <polyline points="8 17 12 21 16 17"/><line x1="12" y1="21" x2="12" y2="9"/>
+                    <path d="M5 9a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4"/>
+                </svg>
+                Объединить
+            </button>
+            <button class="btn btn-ghost btn-sm" onclick="StrategiesPage.clearSelection()">Снять выделение</button>
+        `;
+    }
+
+    // Объединить выбранные стратегии: открываем редактор СОЗДАНИЯ с суммой их
+    // профилей. После сохранения предложим удалить исходные (§7).
+    function mergeSelected() {
+        const ids = Array.from(selectedIds);
+        if (ids.length < 2) { Toast.warning('Выберите минимум 2 стратегии'); return; }
+        const sources = ids.map(id => strategies.find(s => s.id === id)).filter(Boolean);
+        if (sources.length < 2) { Toast.error('Не удалось найти выбранные стратегии'); return; }
+
+        const profiles = [];
+        sources.forEach(s => {
+            (s.profiles || []).forEach(p => {
+                profiles.push({
+                    id: '',  // переназначится в saveEditor
+                    name: p.name || p.id || 'Профиль',
+                    enabled: p.enabled !== false,
+                    args: p.args || '',
+                });
+            });
+        });
+
+        const name = sources.map(s => s.name).join(' + ');
+        const baseId = ('merged_' + sources.map(s => String(s.id).replace(/[^a-zA-Z0-9_-]/g, '')).join('_'))
+            .slice(0, 48);
+
+        // Источники для возможного удаления после сохранения. Захватываем в
+        // замыкание, т.к. closeModal сбрасывает editorOnSaved до вызова коллбэка.
+        const userIds = sources.filter(s => !s.is_builtin).map(s => s.id);
+        const builtinKept = sources.filter(s => s.is_builtin).map(s => s.name);
+        editorOnSaved = () => afterMergeSave(userIds, builtinKept);
+
+        openEditor({
+            id: baseId,
+            name: name.slice(0, 120),
+            description: 'Объединено из: ' + sources.map(s => s.name).join(', '),
+            type: 'combined',
+            profiles,
+        }, 'create');
+        Toast.info('Проверьте объединённую стратегию (ID/имя/профили) и сохраните');
+    }
+
+    // После успешного сохранения объединённой стратегии — предложить удалить
+    // исходные (только пользовательские; встроенные удалить нельзя).
+    function afterMergeSave(toDelete, builtinKept) {
+        toDelete = (toDelete || []).slice();
+        builtinKept = (builtinKept || []).slice();
+
+        if (!toDelete.length) {
+            if (builtinKept.length) {
+                Toast.info('Встроенные стратегии не удаляются: ' + builtinKept.join(', '));
+            }
+            clearSelection();
+            return;
+        }
+        let msg = 'Объединённая стратегия создана.\n\nУдалить исходные стратегии (' + toDelete.length + ' шт.)?';
+        if (builtinKept.length) {
+            msg += '\n\nВстроенные нельзя удалить, они останутся: ' + builtinKept.join(', ');
+        }
+        if (!confirm(msg)) { clearSelection(); return; }
+        deleteStrategiesSeq(toDelete);
+    }
+
+    async function deleteStrategiesSeq(ids) {
+        let ok = 0, fail = 0;
+        for (const id of ids) {
+            try {
+                const r = await API.delete('/api/strategies/' + encodeURIComponent(id));
+                if (r && r.ok) ok++; else fail++;
+            } catch (_e) { fail++; }
+        }
+        if (ok) Toast.success('Удалено исходных стратегий: ' + ok);
+        if (fail) Toast.error('Не удалось удалить: ' + fail);
+        clearSelection();
+        fetchStrategies();
+    }
+
+    // ══════════════════ Глобальные клавиши: ESC (§4) + Ctrl+V (§3) ══════════════════
+
+    function _modalOpen(el) {
+        return !!(el && el.style && el.style.display && el.style.display !== 'none');
+    }
+    function _anyModalOpen() {
+        return _modalOpen(document.getElementById('strategy-modal'))
+            || _modalOpen(document.getElementById('preview-modal'));
+    }
+
+    function attachGlobalKeys() {
+        detachGlobalKeys();
+        escKeyHandler = (e) => {
+            if (e.key !== 'Escape' || e.defaultPrevented) return; // autocomplete и т.п. уже обработали
+            if (_modalOpen(document.getElementById('strategy-modal'))) {
+                e.preventDefault();
+                closeModal();
+            } else if (_modalOpen(document.getElementById('preview-modal'))) {
+                e.preventDefault();
+                closePreview();
+            }
+        };
+        pasteHandler = (e) => {
+            const t = e.target;
+            // Не мешаем обычной вставке в поля ввода и при открытых окнах.
+            if (t && (t.closest && t.closest('input, textarea, select') || t.isContentEditable)) return;
+            if (_anyModalOpen()) return;
+            const cd = e.clipboardData || window.clipboardData;
+            const text = cd && cd.getData ? cd.getData('text') : '';
+            if (!text || !_looksLikeStrategy(text)) return;
+            e.preventDefault();
+            _openPasteEditor(text);
+        };
+        document.addEventListener('keydown', escKeyHandler);
+        document.addEventListener('paste', pasteHandler);
+    }
+
+    function detachGlobalKeys() {
+        if (escKeyHandler) document.removeEventListener('keydown', escKeyHandler);
+        if (pasteHandler) document.removeEventListener('paste', pasteHandler);
+        escKeyHandler = null;
+        pasteHandler = null;
+    }
+
+    // ══════════════════ Ресайз/перемещение окна редактора (§5) ══════════════════
+
+    const MODAL_GEOM_KEY = 'strategy-modal-geom';
+    const MODAL_MIN_W = 420;
+    const MODAL_MIN_H = 240;
+
+    // Начальная геометрия: сохранённая пользователем (если есть) либо дефолт —
+    // ширина 2× прежней (modal-lg=680 → 1360), высота по содержимому формы,
+    // окно по центру. Содержимое измеряем при целевой ширине (§5).
+    function _initialGeom(content) {
+        const saved = _loadModalGeom();
+        if (saved) return _clampGeom(saved);
+        const vw = window.innerWidth, vh = window.innerHeight;
+        const width = Math.min(1360, Math.max(MODAL_MIN_W, vw - 40));
+        // Меряем естественную высоту при заданной ширине.
+        content.style.left = '0px';
+        content.style.top = '0px';
+        content.style.width = width + 'px';
+        content.style.height = '';
+        const natural = content.scrollHeight;
+        const height = Math.min(Math.max(MODAL_MIN_H, natural + 2),
+            Math.round(vh * 0.92), vh - 24);
+        const left = Math.max(12, Math.round((vw - width) / 2));
+        const top = Math.max(12, Math.round((vh - height) / 2));
+        return { left, top, width, height };
+    }
+    function _loadModalGeom() {
+        try {
+            const g = JSON.parse(localStorage.getItem(MODAL_GEOM_KEY) || 'null');
+            if (g && typeof g.width === 'number' && typeof g.height === 'number') return g;
+        } catch (_e) { /* ignore */ }
+        return null;
+    }
+    function _saveModalGeom(g) {
+        try { localStorage.setItem(MODAL_GEOM_KEY, JSON.stringify(g)); } catch (_e) { /* quota */ }
+    }
+    function _curGeom(el) {
+        const r = el.getBoundingClientRect();
+        return { left: r.left, top: r.top, width: r.width, height: r.height };
+    }
+    function _clampGeom(g) {
+        const vw = window.innerWidth, vh = window.innerHeight;
+        const width = Math.max(MODAL_MIN_W, Math.min(g.width, vw - 16));
+        const height = Math.max(MODAL_MIN_H, Math.min(g.height, vh - 16));
+        const left = Math.min(Math.max(8, g.left), Math.max(8, vw - width - 8));
+        const top = Math.min(Math.max(8, g.top), Math.max(8, vh - height - 8));
+        return { left, top, width, height };
+    }
+    function _applyGeom(el, g) {
+        el.style.left = g.left + 'px';
+        el.style.top = g.top + 'px';
+        el.style.width = g.width + 'px';
+        el.style.height = g.height + 'px';
+    }
+
+    function enableModalResize() {
+        const modal = document.getElementById('strategy-modal');
+        if (!modal) return;
+        const content = modal.querySelector('.modal-content');
+        if (!content) return;
+        disableModalResize();
+        content.classList.add('modal-resizable');
+
+        _applyGeom(content, _initialGeom(content));
+
+        const dirs = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'];
+        const handles = dirs.map(dir => {
+            const h = document.createElement('div');
+            h.className = 'modal-resize-handle mrh-' + dir;
+            h.addEventListener('pointerdown', (e) => startResize(e, content, dir));
+            content.appendChild(h);
+            return h;
+        });
+
+        const header = content.querySelector('.modal-header');
+        const onHeaderDown = (e) => startMove(e, content);
+        if (header) header.addEventListener('pointerdown', onHeaderDown);
+
+        const onWinResize = () => _applyGeom(content, _clampGeom(_curGeom(content)));
+        window.addEventListener('resize', onWinResize);
+
+        modalResize = {
+            cleanup() {
+                handles.forEach(h => h.remove());
+                if (header) header.removeEventListener('pointerdown', onHeaderDown);
+                window.removeEventListener('resize', onWinResize);
+                content.classList.remove('modal-resizable');
+                content.style.left = content.style.top = content.style.width = content.style.height = '';
+            },
+        };
+    }
+
+    function disableModalResize() {
+        if (modalResize) {
+            try { modalResize.cleanup(); } catch (_e) { /* ignore */ }
+            modalResize = null;
+        }
+    }
+
+    function startResize(e, el, dir) {
+        if (e.button != null && e.button !== 0) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const sx = e.clientX, sy = e.clientY;
+        const s = _curGeom(el);
+        const move = (ev) => {
+            const dx = ev.clientX - sx, dy = ev.clientY - sy;
+            let { left, top, width, height } = s;
+            if (dir.indexOf('e') >= 0) width = s.width + dx;
+            if (dir.indexOf('s') >= 0) height = s.height + dy;
+            if (dir.indexOf('w') >= 0) { width = s.width - dx; left = s.left + dx; }
+            if (dir.indexOf('n') >= 0) { height = s.height - dy; top = s.top + dy; }
+            if (width < MODAL_MIN_W) {
+                if (dir.indexOf('w') >= 0) left = s.left + (s.width - MODAL_MIN_W);
+                width = MODAL_MIN_W;
+            }
+            if (height < MODAL_MIN_H) {
+                if (dir.indexOf('n') >= 0) top = s.top + (s.height - MODAL_MIN_H);
+                height = MODAL_MIN_H;
+            }
+            _applyGeom(el, { left, top, width, height });
+        };
+        const up = () => {
+            document.removeEventListener('pointermove', move);
+            document.removeEventListener('pointerup', up);
+            _saveModalGeom(_clampGeom(_curGeom(el)));
+        };
+        document.addEventListener('pointermove', move);
+        document.addEventListener('pointerup', up);
+    }
+
+    function startMove(e, el) {
+        // Не таскаем, если ухватились за кнопку/поле в шапке.
+        if (e.target && e.target.closest && e.target.closest('.modal-close, button, input, select, textarea, a')) return;
+        if (e.button != null && e.button !== 0) return;
+        e.preventDefault();
+        const sx = e.clientX, sy = e.clientY;
+        const s = _curGeom(el);
+        const move = (ev) => {
+            const dx = ev.clientX - sx, dy = ev.clientY - sy;
+            _applyGeom(el, _clampGeom({ left: s.left + dx, top: s.top + dy, width: s.width, height: s.height }));
+        };
+        const up = () => {
+            document.removeEventListener('pointermove', move);
+            document.removeEventListener('pointerup', up);
+            _saveModalGeom(_curGeom(el));
+        };
+        document.addEventListener('pointermove', move);
+        document.addEventListener('pointerup', up);
     }
 
     // ══════════════════ Utils ══════════════════
@@ -1814,6 +2295,9 @@ const StrategiesPage = (() => {
 
     function destroy() {
         NfqwsAutocomplete.detachAll();
+        detachGlobalKeys();
+        disableModalResize();
+        selectedIds.clear();
         if (pollTimer) {
             clearInterval(pollTimer);
             pollTimer = null;
@@ -1872,5 +2356,12 @@ const StrategiesPage = (() => {
         runHealthcheckNow,
         toggleHealthcheckSettings,
         saveHealthcheckSettings,
+        // §3 буфер обмена
+        copyStrategyToClipboard,
+        pasteStrategyFromClipboard,
+        // §7 множественный выбор / объединение
+        toggleSelect,
+        clearSelection,
+        mergeSelected,
     };
 })();


### PR DESCRIPTION
1. blockcheck2: при создании стратегии из бейджа подставляем --hostlist-domains= из доменов формы (fallback — протестированный домен).
2. blockcheck2: кнопка «Копировать все» — список всех найденных стратегий в буфер обмена (комментарий + готовые args, для ручной компоновки).
3. Стратегии: кнопка «В буфер» — копирование стратегии со всеми профилями через --new; и обратно — вставка из буфера (Ctrl+V на странице или кнопка «Вставить из буфера») открывает создание новой стратегии с профилями, без автосохранения. Парсер понимает формат --new и вывод blockcheck2.
4. Стратегии: ESC закрывает окно редактирования (и превью), не мешая автокомплиту (учитываем defaultPrevented).
5. Стратегии: окно редактора растягивается во все стороны (8 ручек) и перемещается за заголовок; ширина по умолчанию 2× (≈1360px), высота по содержимому; геометрия запоминается в localStorage.
6. Списки доменов и IP-списки: поиск файла по имени — фильтрует табы и карточки-статистику (когда файлов много).
7. Стратегии: выделение нескольких стратегий чекбоксами и объединение их в одну (профили складываются); после сохранения предлагается удалить исходные (встроенные не удаляются).
8. blockcheck2: домены и галки формы сохраняются при уходе/возврате на вкладку (раньше терялись, хотя бейджи сохранялись).