### PR TITLE
fix(strategies): сохранять кавычки в args профиля (Lua-литералы --lua…

### DIFF
--- a/core/strategy_builder.py
+++ b/core/strategy_builder.py
@@ -431,14 +431,24 @@ class StrategyManager:
 
     def _parse_profile_args(self, args_str: str) -> list:
         """
-        Разобрать строку аргументов профиля в список.
+        Разобрать строку аргументов профиля в список argv.
 
-        Поддерживает аргументы с пробелами внутри кавычек.
+        Кавычки используются ТОЛЬКО для группировки (пробел внутри кавычек не
+        разрывает токен), но сами символы кавычек СОХРАНЯЮТСЯ в токене. Это
+        критично для inline-Lua в ``--lua-init=``: одинарные кавычки там —
+        строковый литерал Lua, напр. ``--lua-init=fake_default_tls=tls_mod(
+        fake_default_tls,'rnd')``. Если их вырезать, nfqws2 получит
+        ``tls_mod(...,rnd)`` и Lua упадёт с «bad argument #2 to 'tls_mod'
+        (string expected, got nil)» — rnd станет неопределённой переменной.
+
+        argv уходит в nfqws2 через subprocess списком (без shell), поэтому
+        кавычки доходят дословно — повторной интерпретации оболочкой нет.
         """
         if not args_str:
             return []
 
-        # Простой парсинг: разбиваем по пробелам, но учитываем кавычки
+        # Разбиваем по пробелам, не разрывая токен внутри кавычек; сами кавычки
+        # оставляем в токене (см. docstring — нужны для Lua-литералов).
         result = []
         current = ""
         in_quote = None
@@ -446,9 +456,11 @@ class StrategyManager:
         for char in args_str:
             if char in ('"', "'") and in_quote is None:
                 in_quote = char
+                current += char
                 continue
             elif char == in_quote:
                 in_quote = None
+                current += char
                 continue
             elif char == ' ' and in_quote is None:
                 if current:

--- a/tests/test_strategy_arg_quotes.py
+++ b/tests/test_strategy_arg_quotes.py
@@ -1,0 +1,62 @@
+# tests/test_strategy_arg_quotes.py
+"""Парсинг args профиля сохраняет кавычки (важно для inline-Lua в --lua-init).
+
+Регрессия: стратегии из blockcheck2 содержат lua-литералы вида
+``tls_mod(fake_default_tls,'rnd')``. Раньше _parse_profile_args вырезал
+одинарные кавычки → nfqws2 получал ``tls_mod(...,rnd)`` и Lua падал с
+«bad argument #2 to 'tls_mod' (string expected, got nil)». Кавычки должны
+доходить до nfqws2 дословно (argv передаётся subprocess списком, без shell).
+"""
+
+import unittest
+
+from core.strategy_builder import StrategyManager
+
+
+class TestParseProfileArgsQuotes(unittest.TestCase):
+
+    def setUp(self):
+        # _parse_profile_args не использует состояние экземпляра —
+        # создаём объект без тяжёлого __init__.
+        self.sm = StrategyManager.__new__(StrategyManager)
+
+    def test_lua_init_single_quotes_preserved(self):
+        # Кейс из бейджа blockcheck2: одинарные кавычки — это Lua-строка.
+        s = ("--filter-tcp=443 --filter-l7=tls --hostlist-domains=youtube.com "
+             "--lua-init=fake_default_tls=tls_mod(fake_default_tls,'rnd') "
+             "--lua-desync=wssize:wsize=1:scale=6 --payload=tls_client_hello")
+        out = self.sm._parse_profile_args(s)
+        self.assertEqual(out, [
+            "--filter-tcp=443",
+            "--filter-l7=tls",
+            "--hostlist-domains=youtube.com",
+            "--lua-init=fake_default_tls=tls_mod(fake_default_tls,'rnd')",
+            "--lua-desync=wssize:wsize=1:scale=6",
+            "--payload=tls_client_hello",
+        ])
+
+    def test_double_quotes_preserved(self):
+        out = self.sm._parse_profile_args('--lua-init=x=f("rnd")')
+        self.assertEqual(out, ['--lua-init=x=f("rnd")'])
+
+    def test_space_inside_quotes_groups_and_keeps_quotes(self):
+        # Пробел внутри кавычек не разрывает токен; кавычки сохраняются.
+        out = self.sm._parse_profile_args('--foo="a b" --bar=x')
+        self.assertEqual(out, ['--foo="a b"', '--bar=x'])
+
+    def test_plain_args_unchanged(self):
+        out = self.sm._parse_profile_args(
+            "--filter-tcp=443 --lua-desync=multisplit")
+        self.assertEqual(out, ["--filter-tcp=443", "--lua-desync=multisplit"])
+
+    def test_extra_spaces_collapsed(self):
+        out = self.sm._parse_profile_args("  --filter-tcp=443    --payload=tls_client_hello ")
+        self.assertEqual(out, ["--filter-tcp=443", "--payload=tls_client_hello"])
+
+    def test_empty(self):
+        self.assertEqual(self.sm._parse_profile_args(""), [])
+        self.assertEqual(self.sm._parse_profile_args(None), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…-init)

_parse_profile_args вырезал одинарные/двойные кавычки при токенизации строки аргументов. Для inline-Lua в --lua-init это ломает строковые литералы: стратегия из blockcheck2 с
  --lua-init=fake_default_tls=tls_mod(fake_default_tls,'rnd')
превращалась в tls_mod(...,rnd) → nfqws2 падал с
  «bad argument #2 to 'tls_mod' (string expected, got nil)»
(rnd трактуется как неопределённая переменная, а не строка).

Теперь кавычки используются только для группировки (пробел внутри них не разрывает токен), но сами символы СОХРАНЯЮТСЯ. argv уходит в nfqws2 через subprocess списком (без shell), поэтому кавычки доходят дословно. Существующие стратегии (builtin/каталог/user) кавычек в args не содержат — регрессии нет (17 прежних тестов зелёные). Добавлен tests/test_strategy_arg_quotes.py.