### PR TITLE
fix: self-update копирует import/ и синхронизирует ассеты в /opt/zapret2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,29 @@
   подписки/пул/именованные списки/маршруты единого слоя — проверено).
 
 ### Исправлено
+- **`LUA ERROR: invalid failure detector function 'z2k_mid_stream_stall'`
+  после обновления GUI через веб-интерфейс** (issue #144). Самообновление
+  `gui_updater._do_update` копировало только `api/core/web/config/catalogs/
+  data/app.py` — каталог `import/` с bundled lua/blob/lists в список не
+  входил, а `asset_importer` после обновления не вызывался. В результате
+  обновлённый `core/nfqws_manager.py` приходил с триггерами на `z2k-*.lua`
+  (`z2k_mid_stream_stall`, `z2k_http_success_positive_only`, `z2k_nohost_key`,
+  `z2k_dynamic_ttl`), но сами файлы оставались от предыдущей версии или
+  отсутствовали в `/opt/zapret2/lua/`. `_build_lua_init_args` молча
+  пропускал их (`os.path.isfile=False`), и стратегия «z2k TLS/HTTP авто»
+  падала на вызове необъявленной функции. Теперь `import/` копируется
+  вместе с остальными директориями, а сразу после распаковки запускается
+  `asset_importer.import_runtime_assets()` — bundled-ассеты разъезжаются
+  в `/opt/zapret2/{lua,files/fake,lists,ipset}/`, как при первой установке
+  (`core/gui_updater.py`).
+- **BlockCheck2: «Копировать все» не подставлял домены из поля формы.**
+  Клик по конкретному бейджу (`useStrategy`) корректно собирал
+  `--hostlist-domains=` из поля «Домены» (или брал сам протестированный
+  домен как фолбэк), а кнопка «Копировать все» (`copyAllFound`) вызывала
+  `_buildArgs(f, null)` — список доменов отбрасывался, и в буфер уходили
+  стратегии без `--hostlist-domains=`. Теперь обе ветки используют один
+  источник: домены из формы, при пустом поле — `f.domain`
+  (`web/js/pages/blockcheck2.js`).
 - **Перезапуск nfqws2 применял старую стратегию после её правки.** Кнопки
   «Старт»/«Перезапуск» (`/api/start`, `/api/restart`) переиспользовали
   закэшированные в `nfqws_manager._last_args` аргументы прошлого запуска,

--- a/core/gui_updater.py
+++ b/core/gui_updater.py
@@ -265,9 +265,16 @@ class GuiUpdater:
 
             self._set_progress("Обновление файлов...", 55)
 
-            # 4. Копировать новые файлы поверх старых
+            # 4. Копировать новые файлы поверх старых.
+            #
+            # import/ обязателен: там лежат bundled lua/blob/lists, которые
+            # после копирования синхронизируются в /opt/zapret2/ через
+            # asset_importer (шаг 5). Без него self-update приносит новый
+            # core/ с триггерами на z2k-*.lua, но сами файлы остаются от
+            # предыдущей версии (или отсутствуют), и nfqws2 падает с
+            # «LUA ERROR: invalid failure detector function ...» (issue #144).
             dirs_to_update = [
-                "api", "core", "web", "config", "catalogs", "data",
+                "api", "core", "web", "config", "catalogs", "data", "import",
             ]
             files_to_update = ["app.py"]
 
@@ -291,6 +298,31 @@ class GuiUpdater:
                 dst = os.path.join(app_dir, f)
                 if os.path.isfile(src):
                     shutil.copy2(src, dst)
+
+            # 5. Импорт обновлённых bundled-ассетов в runtime zapret2:
+            #    import/lua/*.lua    → /opt/zapret2/lua/
+            #    import/bin/*.bin    → /opt/zapret2/files/fake/
+            #    import/lists/*.txt  → /opt/zapret2/{lists,ipset}/
+            # Без этого новые lua-скрипты (например, z2k-*.lua), на которые
+            # ссылается обновлённый core/nfqws_manager.py, остаются только в
+            # import/ и не попадают в lua_path → _build_lua_init_args их
+            # молча пропускает (os.path.isfile=False), и nfqws2 пытается
+            # вызвать функцию из необъявленного файла.
+            self._set_progress("Импорт ассетов в zapret2...", 75)
+            try:
+                from core.asset_importer import import_runtime_assets
+                import_runtime_assets()
+            except Exception as e:
+                # Best-effort: ошибка импорта не должна срывать обновление,
+                # но её нужно громко залогировать — иначе следующий запуск
+                # nfqws2 загадочно упадёт на отсутствующей lua-функции.
+                log.warning(
+                    "Не удалось импортировать bundled-ассеты после "
+                    "обновления: %s. Проверьте права на %s/lua и при "
+                    "необходимости запустите `python3 -m core.asset_importer "
+                    "--only runtime` вручную." % (e, "/opt/zapret2"),
+                    source="gui-updater",
+                )
 
             # Гарантируем CLI-обёртку `zapret-gui` в PATH. Старые ipk
             # (до появления CLI) её не клали, а self-update раньше не

--- a/tests/test_gui_updater.py
+++ b/tests/test_gui_updater.py
@@ -77,5 +77,36 @@ class TestFetchLatestGuiRelease(unittest.TestCase):
                 GuiUpdater()._fetch_github_latest_release()
 
 
+class TestSelfUpdateAssetSync(unittest.TestCase):
+    """
+    Regression для issue #144: self-update должен копировать import/ и
+    запускать asset_importer.import_runtime_assets() — иначе обновлённый
+    core/ ссылается на lua-скрипты, которых нет в /opt/zapret2/lua/, и
+    nfqws2 падает с «LUA ERROR: invalid failure detector function ...».
+    """
+
+    def test_import_dir_is_copied_on_update(self):
+        """import/ обязан быть в dirs_to_update — иначе bundled lua/blob/
+        lists не доедут до /opt/zapret2/, а триггеры в новом core/ их
+        ожидают."""
+        import inspect
+        src = inspect.getsource(GuiUpdater._do_update)
+        # ищем литерал списка dirs_to_update — там обязан быть "import"
+        self.assertIn('"import"', src,
+                      "self-update должен копировать import/ "
+                      "(см. issue #144)")
+
+    def test_asset_importer_called_after_copy(self):
+        """После копирования файлов self-update должен вызвать
+        asset_importer.import_runtime_assets() — без этого новые bundled
+        lua/blob/lists не попадут в /opt/zapret2/."""
+        import inspect
+        src = inspect.getsource(GuiUpdater._do_update)
+        self.assertIn("import_runtime_assets", src,
+                      "self-update должен синхронизировать import/ "
+                      "с /opt/zapret2/ через asset_importer "
+                      "(см. issue #144)")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/js/pages/blockcheck2.js
+++ b/web/js/pages/blockcheck2.js
@@ -598,14 +598,19 @@ const Blockcheck2Page = (() => {
     // Копировать список всех найденных стратегий в буфер обмена (task §2).
     // Каждый приём — комментарий с доменом/успехом + готовая строка args,
     // чтобы пользователь сам скомпоновал нужные профили через --new.
+    // Домены для --hostlist-domains подставляем из поля формы; если пусто —
+    // используем сам протестированный домен (как в useStrategy, чтобы
+    // «Копировать все» и клик по бейджу давали одинаковую сборку).
     function copyAllFound() {
         if (!foundStrategies.length) { Toast && Toast.info && Toast.info('Пока нет найденных стратегий'); return; }
+        const formDomains = _domainsFromForm();
         const lines = [`# Рабочие стратегии blockcheck2 (${foundStrategies.length})`, ''];
         _foundOrder().forEach(({ f }) => {
             const rate = (f.ok != null && f.total != null) ? `${f.ok}/${f.total}` : '';
+            const domList = formDomains.length ? formDomains : (f.domain ? [f.domain] : []);
             lines.push(`# ${f.label || ''} · ${f.domain || ''}`
                 + (rate ? ` · успех ${rate}` : '') + (f.full ? '' : ' (не все попытки)'));
-            lines.push(`${f.engine || 'nfqws2'} ${_buildArgs(f, null)}`);
+            lines.push(`${f.engine || 'nfqws2'} ${_buildArgs(f, domList)}`);
             lines.push('');
         });
         _copyText(lines.join('\n').trim() + '\n', `Скопировано стратегий: ${foundStrategies.length}`);


### PR DESCRIPTION
issue #144: после обновления GUI через веб-интерфейс nfqws2 падал с
`LUA ERROR: invalid failure detector function 'z2k_mid_stream_stall'`.

`gui_updater._do_update` копировал только `api/core/web/config/catalogs/ data/app.py` — каталог `import/` с bundled lua/blob/lists в списке отсутствовал, а `asset_importer` после обновления не вызывался. В итоге обновлённый `core/nfqws_manager.py` приходил с триггерами на `z2k-*.lua`, но сами файлы оставались от прошлой версии (или отсутствовали в `/opt/zapret2/lua/`). `_build_lua_init_args` молча пропускал их через `os.path.isfile=False`, и стратегия «z2k TLS/HTTP авто» падала на вызове необъявленной функции при первом же пакете.

Теперь `import/` копируется вместе с остальными директориями, а сразу после распаковки запускается `asset_importer.import_runtime_assets()` — bundled-ассеты разъезжаются в `/opt/zapret2/{lua,files/fake,lists,ipset}/`, как при первой установке. Регрессия закрыта inspect-тестом на список dirs_to_update и наличие вызова import_runtime_assets.

Заодно фикс BlockCheck2: кнопка «Копировать все» не подставляла домены из поля формы (вызов `_buildArgs(f, null)` отбрасывал список). Клик по конкретному бейджу (`useStrategy`) делал это корректно — теперь обе ветки используют один источник: домены из формы, при пустом поле — сам протестированный домен.