### PR TITLE
fix(routing,singbox): NDMS domain-правила на Keenetic + детект clash_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,46 @@
   подписки/пул/именованные списки/маршруты единого слоя — проверено).
 
 ### Исправлено
+- **На Keenetic нельзя было добавить domain-правило в «AWG-правила → Домены»:
+  кнопка «Добавить правило» оставалась серой.** Под зелёным баннером
+  «Активен Keenetic-native режим (NDMS)» кнопка всё равно гейтилась на
+  готовности dnsmasq (`dnReady`), а на Keenetic'е dnsmasq намеренно не
+  поднимается (53-й порт занят системным ndnsproxy) — поэтому `dnReady`
+  всегда `false` и кнопка была вечно неактивной. При этом NDMS-backend
+  (`core/routing/ndms_backend.py`: `object-group fqdn` + `dns-proxy route`)
+  давно реализован и полностью рабочий — не хватало только разблокировки в
+  UI. Теперь в `web/js/pages/awg_routing.js` введён флаг
+  `domainReady = ndmsActive || dnReady`: на нём гейтятся и кнопка, и подсказка
+  «недоступно». Дополнительно:
+  - в NDMS-режиме текст-подсказка описывает реальный путь (ndnsproxy +
+    `dns-proxy route`, без dnsmasq/ipset), а не «dnsmasq будет резолвить…»;
+  - в выпадающий список «Туннель назначения» подмешиваются **нативные
+    Keenetic-WG-интерфейсы** (`Wireguard0…`, источник `/api/routing/interfaces`,
+    `source=ndms`) — именно их понимает `dns-proxy route`, тогда как
+    userspace-`awg0` NDMS не видит; раньше на роутере с нативным WG и без
+    наших AWG-конфигов список был пуст. Сравнение с поведением
+    [hoaxisr/awg-manager](https://github.com/hoaxisr/awg-manager) (там
+    domain-routing тоже идёт через системные NDMS-WG-интерфейсы)
+    подтвердило, что цель правила — именно нативный интерфейс.
+- **Тестер серверов сыпал в лог `FATAL … clash api is not included in this
+  build` на каждый батч и каждую пересборку пула.** Бинарь sing-box у
+  пользователя собран без `with_clash_api`, поэтому фаза 2 (e2e через Clash
+  API) была обречена. Хотя `proxy_tester` и раньше деградировал на TCP-отсев,
+  он всё равно поднимал заведомо падающий sing-box и логировал сырой stderr
+  с ANSI-цветами (`\x1b[31mFATAL\x1b[0m`). Теперь:
+  - перед фазой 2 — дешёвый pre-flight `binary_has_clash_api()` по строке
+    `Tags:` из `sing-box version`; если clash_api заведомо нет, фаза 2
+    пропускается с одним внятным INFO (вместо FATAL на каждый батч);
+  - в лог-хвост stderr добавлена очистка ANSI (`_strip_ansi`);
+  - детектор (`core/singbox_detector.py`) парсит build-теги и отдаёт
+    `tags` + `has_clash_api`; инсталлятор (`check_for_updates`) выставляет
+    `needs_reinstall`, даже если upstream-версия совпадает (наша свежая
+    сборка с тем же номером уже включает `with_clash_api`) — иначе
+    обновление по версии не предлагалось и пользователь застревал без
+    e2e-теста навсегда;
+  - на странице «sing-box → Установка» показывается статус `clash_api` и
+    жёлтая плашка с предложением переустановить. Сам релизный workflow уже
+    собирает с `with_clash_api` (тэг добавлен в `SINGBOX_TAGS`).
 - **`LUA ERROR: invalid failure detector function 'z2k_mid_stream_stall'`
   после обновления GUI через веб-интерфейс** (issue #144). Самообновление
   `gui_updater._do_update` копировало только `api/core/web/config/catalogs/

--- a/core/proxy_tester.py
+++ b/core/proxy_tester.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import secrets
 import shutil
 import socket
@@ -46,6 +47,15 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from core.log_buffer import log
+
+
+# sing-box печатает stderr с ANSI-цветами (FATAL красным и т.п.). В наш
+# лог-буфер они попадают сырыми («\x1b[31mFATAL\x1b[0m»), поэтому чистим.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    return _ANSI_RE.sub("", s or "")
 
 
 # ─────── target presets ───────
@@ -400,9 +410,38 @@ def _tail_text(path: str, limit: int = 600) -> str:
             data = f.read()
     except OSError:
         return ""
-    text = data.decode("utf-8", errors="replace").strip()
+    text = _strip_ansi(data.decode("utf-8", errors="replace")).strip()
     text = " ".join(text.split())
     return text[-limit:]
+
+
+def binary_has_clash_api(binary: str):
+    """
+    Определить по build-тегам, собран ли бинарь sing-box с clash_api.
+
+    Возвращает:
+      True  — clash_api точно есть;
+      False — `Tags:` распарсились, но clash_api там нет (точно нет);
+      None  — определить не удалось (нет бинаря / нет строки Tags) —
+              трактуем как «неизвестно», движок всё равно пробуем.
+
+    Используется как дешёвый pre-flight перед фазой 2: если clash_api
+    заведомо нет, нет смысла поднимать заведомо падающий sing-box и
+    засорять лог FATAL'ом — отдаём только TCP-результат.
+    """
+    if not binary:
+        return None
+    try:
+        r = subprocess.run([binary, "version"], capture_output=True,
+                           text=True, timeout=4)
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+    out = r.stdout or ""
+    m = re.search(r"^\s*Tags:\s*(.+)$", out, re.IGNORECASE | re.MULTILINE)
+    if not m:
+        return None
+    tags = [t.strip() for t in re.split(r"[,\s]+", m.group(1)) if t.strip()]
+    return any("clash_api" in t for t in tags)
 
 
 # ─────── public API ───────
@@ -457,14 +496,25 @@ def test_outbounds(outbounds: list, *, target: str = DEFAULT_TARGET,
     e2e: dict = {}
     engine_used = False
     if bin_path and survivors:
-        try:
-            _report("e2e", 0, len(survivors))
-            e2e = _e2e_delays(survivors, target_url, timeout_ms, bin_path,
-                              on_done=lambda d, t: _report("e2e", d, t))
-            engine_used = True
-        except Exception as e:
-            log.warning("proxy_tester e2e: %s" % e, source="singbox")
-            e2e = {}
+        # Pre-flight: если бинарь заведомо собран без clash_api, фаза 2
+        # обречена (sing-box упадёт с «clash api is not included»). Не
+        # поднимаем заведомо падающий процесс на каждый батч и не сыпем
+        # FATAL'ом в лог — один внятный INFO и graceful degrade на TCP.
+        if binary_has_clash_api(bin_path) is False:
+            log.info(
+                "proxy_tester: бинарь sing-box собран без clash_api — "
+                "e2e-тест через движок пропущен, фильтрация только по TCP. "
+                "Переустановите sing-box (раздел «sing-box → Установка»), "
+                "чтобы включить полную проверку серверов.", source="singbox")
+        else:
+            try:
+                _report("e2e", 0, len(survivors))
+                e2e = _e2e_delays(survivors, target_url, timeout_ms, bin_path,
+                                  on_done=lambda d, t: _report("e2e", d, t))
+                engine_used = True
+            except Exception as e:
+                log.warning("proxy_tester e2e: %s" % e, source="singbox")
+                e2e = {}
 
     results = []
     for ob in obs:

--- a/core/singbox_detector.py
+++ b/core/singbox_detector.py
@@ -73,24 +73,57 @@ class SingboxDetector:
         if not path:
             path = _find_binary(["sing-box"])
         if not path:
-            return {"installed": False, "path": "", "version": ""}
-        version = self._probe_version(path)
-        return {"installed": True, "path": path, "version": version}
+            return {"installed": False, "path": "", "version": "",
+                    "tags": [], "has_clash_api": False}
+        info = self._probe_version_info(path)
+        return {"installed": True, "path": path,
+                "version":       info["version"],
+                "tags":          info["tags"],
+                # has_clash_api отражает УВЕРЕННОЕ наличие тега в сборке.
+                # Если `Tags:`-строку распарсить не удалось (tags пуст) —
+                # оставляем False, но потребители (proxy_tester/installer)
+                # реагируют только на «уверенно отсутствует»: tags непуст и
+                # clash_api в них нет. Это страхует от ложных срабатываний
+                # на сборках, не печатающих Tags.
+                "has_clash_api": info["has_clash_api"]}
 
     def _probe_version(self, binary: str) -> str:
-        """`sing-box version` отдаёт многострочный вывод; нас интересует
-        первая строка с номером."""
+        """Только номер версии (обёртка над `_probe_version_info`)."""
+        return self._probe_version_info(binary)["version"]
+
+    def _probe_version_info(self, binary: str) -> dict:
+        """
+        `sing-box version` отдаёт многострочный вывод вида:
+
+            sing-box version 1.12.0
+            Environment: go1.23 linux/amd64
+            Tags: with_quic,with_grpc,with_utls,with_clash_api
+            Revision: ...
+            CGO: disabled
+
+        Возвращаем {version, tags, has_clash_api}. `tags` — список build-
+        тегов из строки `Tags:` (может быть пуст, если её нет). По нему
+        определяется, собран ли бинарь с clash_api — без него тестер
+        серверов (proxy_tester) не может прогнать e2e-замеры.
+        """
         out = _cmd_out([binary, "version"], timeout=3)
         if not out:
-            return ""
+            return {"version": "", "tags": [], "has_clash_api": False}
         # sing-box version 1.x.y -- ... либо первая строка содержит
         # «sing-box version 1.x.y»
         m = re.search(r"sing-box\s+(?:version\s+)?(\S+)", out, re.IGNORECASE)
         if m:
-            return m.group(1)
-        # Fallback — взять первый токен
-        first = out.splitlines()[0].strip()
-        return first
+            version = m.group(1)
+        else:
+            version = out.splitlines()[0].strip()
+        # Строка `Tags: a,b,c` (теги через запятую и/или пробелы).
+        tags = []
+        tm = re.search(r"^\s*Tags:\s*(.+)$", out, re.IGNORECASE | re.MULTILINE)
+        if tm:
+            tags = [t.strip() for t in re.split(r"[,\s]+", tm.group(1))
+                    if t.strip()]
+        has_clash = any("clash_api" in t for t in tags)
+        return {"version": version, "tags": tags, "has_clash_api": has_clash}
 
     def detect_tun(self) -> dict:
         dev_tun = os.path.exists("/dev/net/tun") or os.path.exists("/dev/tun")

--- a/core/singbox_installer.py
+++ b/core/singbox_installer.py
@@ -227,11 +227,13 @@ class SingboxInstaller:
         bin_info = get_singbox_detector().detect_binary()
         state = _read_state()
         return {
-            "installed":    bin_info.get("installed", False),
-            "path":         bin_info.get("path", ""),
-            "version":      bin_info.get("version", ""),
-            "tag":          state.get("tag", ""),
-            "installed_at": state.get("installed_at", 0),
+            "installed":     bin_info.get("installed", False),
+            "path":          bin_info.get("path", ""),
+            "version":       bin_info.get("version", ""),
+            "tags":          bin_info.get("tags", []),
+            "has_clash_api": bin_info.get("has_clash_api", False),
+            "tag":           state.get("tag", ""),
+            "installed_at":  state.get("installed_at", 0),
         }
 
     def check_for_updates(self) -> dict:
@@ -244,11 +246,28 @@ class SingboxInstaller:
         latest_ver = (manifest.get("sing_box") or {}).get("version", "")
         latest_tag = manifest.get("tag", "")
         has_update = bool(latest_ver) and latest_ver != installed.get("version")
+        # Переустановка нужна, даже если версия совпадает: наши сборки
+        # начиная с тэга «clash_api в бинаре» включают with_clash_api, без
+        # которого не работает тестер серверов (proxy_tester). Если в
+        # установленном бинаре уверенно нет clash_api (теги распарсились и
+        # тега там нет) — подсказываем переустановиться. has_update при
+        # этом может быть False (одна и та же upstream-версия), поэтому
+        # сигнал нужен отдельный, иначе пользователь никогда не узнает.
+        needs_reinstall = bool(
+            installed.get("installed")
+            and installed.get("tags")               # теги распарсились
+            and not installed.get("has_clash_api")  # но clash_api среди них нет
+        )
         return {
-            "ok":         True,
-            "installed":  installed,
-            "latest":     {"tag": latest_tag, "version": latest_ver},
-            "has_update": has_update,
+            "ok":              True,
+            "installed":       installed,
+            "latest":          {"tag": latest_tag, "version": latest_ver},
+            "has_update":      has_update,
+            "needs_reinstall": needs_reinstall,
+            "reinstall_reason": ("Бинарь собран без clash_api — тестер серверов"
+                                 " работает только по TCP. Переустановите, чтобы"
+                                 " включить полную e2e-проверку."
+                                 if needs_reinstall else ""),
         }
 
     # ─── architecture ───

--- a/tests/test_proxy_tester.py
+++ b/tests/test_proxy_tester.py
@@ -1,7 +1,9 @@
 # tests/test_proxy_tester.py
 """Unit-тесты для core/proxy_tester.py (чистые помощники, без бинаря)."""
 
+import types
 import unittest
+from unittest import mock
 
 from core import proxy_tester as pt
 from core.proxy_tester import build_test_config, parse_delay
@@ -115,6 +117,77 @@ class TestTestOutboundsNoBinary(unittest.TestCase):
         tcp = [c for c in calls if c[0] == "tcp"]
         self.assertEqual(tcp[-1][1], 2)
         self.assertEqual(tcp[-1][2], 2)
+
+
+class TestStripAnsi(unittest.TestCase):
+
+    def test_removes_color_codes(self):
+        raw = "\x1b[31mFATAL\x1b[0m[0000] create clash-server: clash api is not included"
+        self.assertEqual(
+            pt._strip_ansi(raw),
+            "FATAL[0000] create clash-server: clash api is not included")
+
+    def test_plain_unchanged(self):
+        self.assertEqual(pt._strip_ansi("plain text"), "plain text")
+
+
+class TestBinaryHasClashApi(unittest.TestCase):
+
+    def _run(self, stdout):
+        return mock.patch.object(
+            pt.subprocess, "run",
+            return_value=types.SimpleNamespace(stdout=stdout, returncode=0))
+
+    def test_present(self):
+        with self._run("sing-box version 1.12.0\n"
+                       "Tags: with_quic,with_clash_api\nCGO: disabled"):
+            self.assertIs(pt.binary_has_clash_api("/opt/sing-box"), True)
+
+    def test_absent(self):
+        with self._run("sing-box version 1.12.0\n"
+                       "Tags: with_quic,with_utls\nCGO: disabled"):
+            self.assertIs(pt.binary_has_clash_api("/opt/sing-box"), False)
+
+    def test_unknown_when_no_tags_line(self):
+        with self._run("sing-box version 1.12.0\nCGO: disabled"):
+            self.assertIsNone(pt.binary_has_clash_api("/opt/sing-box"))
+
+    def test_empty_binary_is_unknown(self):
+        self.assertIsNone(pt.binary_has_clash_api(""))
+
+
+class TestSkipE2EWithoutClashApi(unittest.TestCase):
+    """Фаза 2 не запускается, если бинарь заведомо без clash_api."""
+
+    def test_no_clash_api_skips_engine(self):
+        obs = [{"type": "vless", "tag": "a", "server": "1.1.1.1",
+                "server_port": 443, "uuid": "u"}]
+        with mock.patch.object(pt, "tcp_prefilter",
+                               return_value={"a": (True, 12)}), \
+             mock.patch.object(pt, "binary_has_clash_api",
+                               return_value=False), \
+             mock.patch.object(pt, "_e2e_delays") as e2e:
+            res = pt.test_outbounds(obs, binary="/opt/sing-box")
+        e2e.assert_not_called()              # движок не поднимали
+        self.assertFalse(res["engine_used"])
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["results"][0]["stage"], "tcp")
+        self.assertTrue(res["results"][0]["alive"])
+
+    def test_clash_api_present_runs_engine(self):
+        obs = [{"type": "vless", "tag": "a", "server": "1.1.1.1",
+                "server_port": 443, "uuid": "u"}]
+        with mock.patch.object(pt, "tcp_prefilter",
+                               return_value={"a": (True, 12)}), \
+             mock.patch.object(pt, "binary_has_clash_api",
+                               return_value=True), \
+             mock.patch.object(pt, "_e2e_delays",
+                               return_value={"a": {"ok": True,
+                                                   "latency_ms": 99}}) as e2e:
+            res = pt.test_outbounds(obs, binary="/opt/sing-box")
+        e2e.assert_called_once()
+        self.assertTrue(res["engine_used"])
+        self.assertEqual(res["results"][0]["stage"], "e2e")
 
 
 if __name__ == "__main__":

--- a/tests/test_singbox_subsystem.py
+++ b/tests/test_singbox_subsystem.py
@@ -90,6 +90,56 @@ class TestSingboxDetectorProbeVersion(unittest.TestCase):
             self.assertEqual(v, "unexpected output here")
 
 
+class TestSingboxDetectorBuildTags(unittest.TestCase):
+    """Парсинг строки `Tags:` и определение clash_api."""
+
+    _MODERN = ("sing-box version 1.12.0\n"
+               "Environment: go1.23 linux/amd64\n"
+               "Tags: with_quic,with_grpc,with_utls,with_clash_api\n"
+               "Revision: abcdef\nCGO: disabled")
+    _NO_CLASH = ("sing-box version 1.12.0\n"
+                 "Tags: with_quic,with_grpc,with_utls\n"
+                 "CGO: disabled")
+    _NO_TAGS = "sing-box version 1.12.0\nCGO: disabled"
+
+    def setUp(self):
+        self.det = singbox_detector.SingboxDetector()
+
+    def test_clash_api_present(self):
+        with mock.patch.object(singbox_detector, "_cmd_out",
+                                return_value=self._MODERN):
+            info = self.det._probe_version_info("/opt/sing-box")
+        self.assertEqual(info["version"], "1.12.0")
+        self.assertIn("with_clash_api", info["tags"])
+        self.assertTrue(info["has_clash_api"])
+
+    def test_clash_api_absent(self):
+        with mock.patch.object(singbox_detector, "_cmd_out",
+                                return_value=self._NO_CLASH):
+            info = self.det._probe_version_info("/opt/sing-box")
+        self.assertTrue(info["tags"])              # теги распарсились
+        self.assertFalse(info["has_clash_api"])    # но clash_api нет
+
+    def test_no_tags_line(self):
+        with mock.patch.object(singbox_detector, "_cmd_out",
+                                return_value=self._NO_TAGS):
+            info = self.det._probe_version_info("/opt/sing-box")
+        self.assertEqual(info["tags"], [])         # строки Tags нет
+        self.assertFalse(info["has_clash_api"])
+
+    def test_detect_binary_surfaces_capability(self):
+        with mock.patch.object(self.det, "detect_platform") as dp, \
+             mock.patch("os.path.isfile", return_value=True), \
+             mock.patch("os.access", return_value=True), \
+             mock.patch.object(singbox_detector, "_cmd_out",
+                                return_value=self._MODERN):
+            dp.return_value.binary_path.return_value = "/opt/sing-box"
+            info = self.det.detect_binary()
+        self.assertTrue(info["installed"])
+        self.assertTrue(info["has_clash_api"])
+        self.assertIn("with_clash_api", info["tags"])
+
+
 class TestSingboxDetectTun(unittest.TestCase):
 
     def test_tun_present(self):
@@ -182,6 +232,47 @@ class TestInstallerProgress(unittest.TestCase):
         self.assertEqual(s["status"], "downloading")
         self.assertEqual(s["progress"], 42)
         self.assertEqual(s["message"], "test")
+
+
+class TestInstallerNeedsReinstall(unittest.TestCase):
+    """check_for_updates флагует переустановку, если в бинаре нет clash_api."""
+
+    def _check(self, bin_info, manifest_ver="1.12.0"):
+        i = singbox_installer.SingboxInstaller()
+        fake_det = mock.Mock()
+        fake_det.detect_binary.return_value = bin_info
+        with mock.patch.object(singbox_installer, "get_singbox_detector",
+                               return_value=fake_det), \
+             mock.patch.object(i, "get_manifest", return_value={
+                 "tag": "singbox-bin-v%s" % manifest_ver,
+                 "sing_box": {"version": manifest_ver}}):
+            return i.check_for_updates()
+
+    def test_flags_reinstall_when_clash_api_missing(self):
+        r = self._check({"installed": True, "version": "1.12.0",
+                         "tags": ["with_quic", "with_utls"],
+                         "has_clash_api": False})
+        self.assertTrue(r["needs_reinstall"])
+        self.assertFalse(r["has_update"])          # та же upstream-версия
+        self.assertIn("clash_api", r["reinstall_reason"])
+
+    def test_no_reinstall_when_clash_api_present(self):
+        r = self._check({"installed": True, "version": "1.12.0",
+                         "tags": ["with_quic", "with_clash_api"],
+                         "has_clash_api": True})
+        self.assertFalse(r["needs_reinstall"])
+        self.assertEqual(r["reinstall_reason"], "")
+
+    def test_no_reinstall_when_tags_unknown(self):
+        # Теги не распарсились — не дёргаем пользователя ложной тревогой.
+        r = self._check({"installed": True, "version": "1.12.0",
+                         "tags": [], "has_clash_api": False})
+        self.assertFalse(r["needs_reinstall"])
+
+    def test_no_reinstall_when_not_installed(self):
+        r = self._check({"installed": False, "version": "",
+                         "tags": [], "has_clash_api": False})
+        self.assertFalse(r["needs_reinstall"])
 
 
 if __name__ == "__main__":

--- a/web/js/pages/awg_routing.js
+++ b/web/js/pages/awg_routing.js
@@ -15,6 +15,7 @@ const AwgRoutingPage = (() => {
     let environment  = null;   // отчёт детектора (для подсказок)
     let dnsmasqInfo  = null;   // /api/routing/dnsmasq/status
     let ndmsInfo     = null;   // /api/routing/ndms/status (Keenetic-native)
+    let routeIfaces  = [];     // /api/routing/interfaces (вкл. нативные NDMS WG)
     let devices      = [];     // /api/devices (DHCP+ARP)
     let devicesSrc   = null;   // sources status
     let busy         = false;
@@ -108,19 +109,21 @@ const AwgRoutingPage = (() => {
 
     async function loadAll() {
         try {
-            const [rulesResp, cfgsResp, envResp, dnResp, ndmsResp] =
+            const [rulesResp, cfgsResp, envResp, dnResp, ndmsResp, ifResp] =
                 await Promise.all([
                     API.get('/api/routing/rules'),
                     API.get('/api/awg/configs'),
                     API.get('/api/awg/environment').catch(() => null),
                     API.get('/api/routing/dnsmasq/status').catch(() => null),
                     API.get('/api/routing/ndms/status').catch(() => null),
+                    API.get('/api/routing/interfaces').catch(() => null),
                 ]);
             rules       = (rulesResp && rulesResp.rules)   || [];
             configs     = (cfgsResp  && cfgsResp.configs)  || [];
             environment = envResp || null;
             dnsmasqInfo = dnResp   || null;
             ndmsInfo    = ndmsResp || null;
+            routeIfaces = (ifResp  && ifResp.interfaces)   || [];
             if (!formIface && configs.length > 0) {
                 formIface = configs[0].name;
             }
@@ -507,6 +510,14 @@ const AwgRoutingPage = (() => {
         const ndmsActive = !!(ndmsInfo && ndmsInfo.available);
 
         const dnReady = !!dn.available && !!dn.running && !!preferred;
+        // Domain-routing готов, если работает ХОТЬ ОДИН бэкенд: либо
+        // Keenetic-native (ndnsproxy через dns-proxy route — dnsmasq на
+        // этой платформе не нужен и не запускается), либо классический
+        // dnsmasq+ipset/nftset. Раньше кнопка «Добавить правило» гейтилась
+        // только на dnReady, поэтому на Keenetic'е (где dnReady=false by
+        // design) она оставалась навсегда неактивной — хотя NDMS-backend
+        // полностью реализован (см. core/routing/ndms_backend.py).
+        const domainReady = ndmsActive || dnReady;
         const setupApplied = !!(dnsmasqInfo && dnsmasqInfo.auto_setup_applied);
         // Кнопка нужна, если у нас не работает domain-routing и есть хоть
         // какая-то надежда поднять его: либо dnsmasq установлен (его надо
@@ -583,9 +594,36 @@ const AwgRoutingPage = (() => {
                </div>`;
         }
 
-        const cfgOptions = configs.map(c =>
-            `<option value="${escapeAttr(c.name)}" ${c.name === formDomIface ? 'selected' : ''}>
-                ${escapeHtml(c.name)}${c.active ? ' (активен)' : ''}
+        // Цели для domain-правил: наши AWG-конфиги + (в NDMS-режиме)
+        // нативные Keenetic-WG-интерфейсы (Wireguard0…). Именно последние
+        // понимает `dns-proxy route` — userspace-awg0 NDMS не видит. Без
+        // этого на «голом» Keenetic'е (нативный WG, но без наших AWG-
+        // конфигов) список был бы пуст и кнопку некуда было бы нацелить.
+        const nativeNdms = (routeIfaces || []).filter(i => i && i.source === 'ndms');
+        const cfgNames = new Set(configs.map(c => c.name));
+        const domTargets = configs.map(c => ({
+            name:  c.name,
+            label: escapeHtml(c.name) + (c.active ? ' (активен)' : ''),
+        })).concat(
+            nativeNdms
+                .filter(i => i.name && !cfgNames.has(i.name))
+                .map(i => ({
+                    name:  i.name,
+                    label: escapeHtml(i.name) + ' · Keenetic'
+                         + (i.description ? ' (' + escapeHtml(i.description) + ')' : '')
+                         + (i.active ? ' — активен' : ''),
+                }))
+        );
+        // formDomIface мог проинициализироваться из configs[0] в loadAll;
+        // если конфигов нет, а нативные интерфейсы есть — берём первый из них.
+        const domTargetNames = domTargets.map(t => t.name);
+        if ((!formDomIface || !domTargetNames.includes(formDomIface)) && domTargets.length) {
+            formDomIface = domTargets[0].name;
+        }
+
+        const cfgOptions = domTargets.map(t =>
+            `<option value="${escapeAttr(t.name)}" ${t.name === formDomIface ? 'selected' : ''}>
+                ${t.label}
              </option>`
         ).join('');
 
@@ -602,21 +640,30 @@ const AwgRoutingPage = (() => {
 
             <div class="card" style="margin-bottom: 12px;">
                 <div class="card-title">Добавить правило по доменам</div>
-                ${configs.length === 0 ? `
+                ${domTargets.length === 0 ? `
                     <p class="text-muted" style="margin-top: 8px;">
-                        Нет ни одного AWG-конфига. Сначала создайте туннель в разделе
-                        <a href="#awg-configs">Конфиги</a>.
+                        Нет ни одного интерфейса для маршрутизации. Создайте AWG-туннель
+                        в разделе <a href="#awg-configs">Конфиги</a>${ndmsActive
+                            ? ' или поднимите нативный WireGuard в веб-админке Keenetic'
+                            : ''}.
                     </p>
                 ` : `
                     <p class="text-muted" style="margin-top: 6px; font-size: 13px;">
+                        ${ndmsActive ? `
+                        Встроенный ndnsproxy Keenetic'а разрезолвит эти домены и направит
+                        трафик к ним через выбранный интерфейс (<code>dns-proxy route</code>) —
+                        ни dnsmasq, ни ipset/nftset не нужны.
+                        ` : `
                         dnsmasq будет резолвить эти домены и добавлять полученные IP
                         в ${escapeHtml(preferred || 'set')}. Маркированные пакеты уйдут
-                        через выбранный интерфейс. Поддерживаются поддомены: например,
+                        через выбранный интерфейс.
+                        `}
+                        Поддерживаются поддомены: например,
                         <code>example.com</code> покрывает <code>www.example.com</code>.
                     </p>
                     <div style="display: grid; grid-template-columns: 200px 1fr; gap: 8px 12px; margin-top: 8px; align-items: start;">
                         <label class="text-muted" style="padding-top: 6px;"
-                               title="AWG-туннель, в который пойдёт выбранный трафик. В списке — ваши конфиги; пометка «(активен)» означает, что туннель сейчас поднят.">
+                               title="Интерфейс, в который пойдёт выбранный трафик. В списке — ваши AWG-конфиги${ndmsActive ? ' и нативные WireGuard-интерфейсы Keenetic' : ''}; пометка «(активен)» означает, что туннель сейчас поднят.">
                             Туннель назначения
                         </label>
                         <select id="rt-dom-iface" onchange="AwgRoutingPage.setFormDomIface(this.value)"
@@ -639,11 +686,11 @@ const AwgRoutingPage = (() => {
                                class="form-control" style="max-width: 480px;">
                     </div>
                     <div style="margin-top: 12px;">
-                        <button class="btn btn-primary btn-sm" ${(busy || !dnReady) ? 'disabled' : ''}
+                        <button class="btn btn-primary btn-sm" ${(busy || !domainReady) ? 'disabled' : ''}
                                 onclick="AwgRoutingPage.submitDomain()">
                             Добавить правило
                         </button>
-                        ${dnReady ? '' : '<span class="text-muted" style="margin-left:10px; font-size:12px;">недоступно: см. сообщение выше</span>'}
+                        ${domainReady ? '' : '<span class="text-muted" style="margin-left:10px; font-size:12px;">недоступно: см. сообщение выше</span>'}
                     </div>
                 `}
             </div>

--- a/web/js/pages/singbox_setup.js
+++ b/web/js/pages/singbox_setup.js
@@ -128,6 +128,10 @@ const SingboxSetupPage = (() => {
         const availableArchs = Object.keys(sb.binaries || {}).sort();
         const latestVersion  = sb.version || (version && version.latest && version.latest.version) || '';
         const hasUpdate = !!(version && version.has_update);
+        // Бинарь собран без clash_api → тестер серверов умеет только TCP.
+        // Версия при этом может совпадать с релизом, поэтому отдельный сигнал.
+        const needsReinstall = !!(version && version.needs_reinstall);
+        const reinstallReason = (version && version.reinstall_reason) || '';
 
         const installInProgress = ['starting', 'manifest', 'downloading',
                                    'verifying', 'extracting', 'installing']
@@ -198,11 +202,26 @@ const SingboxSetupPage = (() => {
                             В нашем релизе: <strong>${escapeHtml(latestVersion)}</strong>
                             ${hasUpdate ? '<span style="color:#fb8;">— доступно обновление</span>' : ''}
                         </div>` : ''}
+                    ${installed ? `
+                        <div style="margin-top:4px;">
+                            clash_api: ${bin.has_clash_api
+                                ? '<span style="color:#39c45e;">включён</span>'
+                                : '<span style="color:#fb8;">нет</span> — тестер серверов работает только по TCP'}
+                        </div>` : ''}
                     ${manifestError ? `
                         <div class="text-muted" style="color:#e58; font-size:11px; margin-top:4px;">
                             ${escapeHtml(manifestError)}
                         </div>` : ''}
                 </div>
+
+                ${needsReinstall ? `
+                    <div class="alert alert-warning" style="margin-top:10px;">
+                        <div class="alert-title">Бинарь sing-box собран без clash_api</div>
+                        <p style="font-size:12px; margin:6px 0 0;">
+                            ${escapeHtml(reinstallReason || 'Тестер серверов сейчас отсеивает только по TCP (фаза e2e через движок недоступна).')}
+                            Нажмите «${hasUpdate ? 'Обновить' : 'Переустановить'}» ниже — свежая сборка из нашего релиза включает clash_api.
+                        </p>
+                    </div>` : ''}
 
                 ${archSelect}
 


### PR DESCRIPTION
…api в sing-box

Keenetic / AWG → Домены:
- кнопка «Добавить правило» больше не серая в Keenetic-native (NDMS) режиме. Раньше она гейтилась на готовности dnsmasq (dnReady), а на Keenetic'е dnsmasq намеренно не поднимается (53 порт занят ndnsproxy) — кнопка была вечно неактивной, хотя NDMS-backend (object-group fqdn + dns-proxy route) полностью реализован. Введён domainReady = ndmsActive || dnReady.
- в NDMS-режиме текст-подсказка описывает реальный путь (ndnsproxy + dns-proxy route), а в выпадающий список целей подмешиваются нативные Keenetic-WG-интерфейсы (Wireguard0…) — именно их понимает dns-proxy route.

sing-box / тестер серверов:
- proxy_tester перед e2e-фазой проверяет build-теги бинаря; если clash_api заведомо нет — фаза 2 пропускается одним INFO вместо FATAL на каждый батч, stderr в логах очищается от ANSI-цветов.
- детектор парсит Tags из `sing-box version` → tags + has_clash_api; инсталлятор выставляет needs_reinstall даже при совпадающей версии (свежая сборка того же номера уже включает with_clash_api).
- на странице sing-box → Установка показывается статус clash_api и плашка с предложением переустановить.

Тесты: парсинг тегов детектора, binary_has_clash_api + skip-e2e, ANSI-strip, needs_reinstall.