### PR TITLE
fix(lua): обновить bundled lua до zapret2 1.0.1 (compat 6) — issue #151

### DIFF
--- a/.claude/skills/nfqws2-strategies/SKILL.md
+++ b/.claude/skills/nfqws2-strategies/SKILL.md
@@ -74,7 +74,7 @@ nfqws2 **не имеет хардкод-стратегий**. Параметро
 | `zapret-antidpi.lua` | Готовые desync-аналоги nfqws1: `fake`, `multisplit`, `multidisorder`, `fakedsplit`, `fakeddisorder`, `hostfakesplit`, `tcpseg`, `oob`, `wsize`, `wssize`, `syndata`, `rst`, `synack`, `synack_split`, `udplen`, `dht_dn`, `http_*`, `pktmod`, `pass`, `luaexec`. **Без неё `--lua-desync=fake:...` — вызов несуществующей функции: тихий 0%**. |
 | `zapret-auto.lua` | Оркестраторы (`circular`, `repeater`, `condition`, `per_instance_condition`, `stopif`) и iff-функции (`cond_random`, `cond_payload_str`, `cond_lua`, …). |
 | `zapret-obfs.lua` | Обфускаторы: `wgobfs`, `ippxor`, `udp2icmp`, `synhide`. **Надмножество** `zapret-wgobfs.lua` — если грузим `obfs`, то `wgobfs.lua` грузить НЕ надо (двойное определение). |
-| `zapret-pcap.lua` | Запись pcap. Требует `--writeable`. |
+| `zapret-pcap.lua` | Запись pcap. Требует `--writable` (до 1.0 — `--writeable`). |
 | `zapret-tests.lua` | Тесты C-функций. |
 
 ### Наши расширения (`import/lua/`, разворачиваются на `lua_path` через `core/asset_importer.py`)
@@ -171,6 +171,16 @@ hostname (макс. 2 «перескока»). Если все инстансы 
 `github version v0.9.5.2 (<git-hash>) lua_compat_ver 5`. Опции с `[0|1]`/
 `[=val]` имеют необязательный аргумент (без него — дефолт, обычно `=1`).
 
+⚠️ **Совместимость lua↔бинарник (`NFQWS2_COMPAT_VER`).** zapret2 **1.0**
+сменил `lua_compat_ver` 5→6 (несовместимое изменение: везде `WRITEABLE`→
+`WRITABLE`, т.е. флаг `--writeable`→`--writable` и env `WRITABLE`; плюс
+`delay` в `send` и фикс oob при `urp=b`). `zapret-lib.lua:1` проверяет
+`NFQWS2_COMPAT_VER_REQUIRED` и падает с *«Incompatible NFQWS2_COMPAT_VER»*,
+если lua и бинарник из разных релизов. Наши bundled-lua (`import/lua/`)
+должны совпадать по compat с устанавливаемым бинарником; `core/asset_importer`
+не понижает core-lua, если на диске уже лежит более новый релиз
+(см. `_protected_core_lua`, issue #151).
+
 ### 3.1 Общие / служебные
 
 | Опция | Назначение |
@@ -201,7 +211,7 @@ hostname (макс. 2 «перескока»). Если все инстансы 
 
 | Опция | Назначение |
 |---|---|
-| `--writeable[=dir]` | Создать каталог для Lua (env `WRITEABLE`). |
+| `--writable[=dir]` | Создать каталог для Lua (env `WRITABLE`). До zapret2 1.0 — `--writeable`/`WRITEABLE`. |
 | `--blob=<name>:[+ofs]@<file>\|0xHEX` | Глобальная декларация именованного блоба. Поддержан offset `+ofs`. **До первого `--new`**. |
 | `--lua-init=@<file>\|<lua_text>` | Загрузить Lua. Порядок сохраняется. Поддержаны gzip-файлы. |
 | `--lua-gc=<sec>` | Интервал GC Lua (дефолт 60). |
@@ -1068,7 +1078,8 @@ end
   `timer_info(name)`, `timer_enum()`.
 - Пейлоады: `resolve_pos(blob, payload_type, marker)`, `resolve_multi_pos`,
   `resolve_range`, `tls_mod(blob, modlist, payload)`.
-- Файлы: `--writeable` создаст каталог, путь в `os.getenv("WRITEABLE")`.
+- Файлы: `--writable` создаст каталог, путь в `os.getenv("WRITABLE")`
+  (до zapret2 1.0 — `--writeable` / `WRITEABLE`).
 
 **Песочница:** `os.execute`, `io.popen`, `package.loadlib`, модуль `debug` —
 удалены.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,26 @@
   подписки/пул/именованные списки/маршруты единого слоя — проверено).
 
 ### Исправлено
+- **zapret2 1.0 ломал nfqws2: `LUA ERROR … Incompatible NFQWS2_COMPAT_VER`
+  ([#151](https://github.com/avatarDD/zapret-gui/issues/151)).** zapret2 1.0
+  сменил `lua_compat_ver` 5→6 (несовместимое изменение: везде `WRITEABLE`→
+  `WRITABLE`, плюс `delay` в `send` и фикс oob при `urp=b`). Наши bundled-lua
+  (`import/lua/`) были на compat 5, а `asset_importer` принудительно
+  раскладывает их в `/opt/zapret2/lua/`, затирая свежую lua из релиза 1.0 —
+  и nfqws2 падал сразу после старта.
+  - Обновили вендоренные upstream-core lua до v1.0.1 (compat 6):
+    `zapret-lib`, `zapret-antidpi`, `zapret-pcap`, `zapret-tests`
+    (`zapret-auto`/`zapret-obfs` уже совпадали; `--writeable`→`--writable`,
+    env `WRITEABLE`→`WRITABLE`).
+  - **Защита от повторения в обе стороны** (`core/asset_importer.py`):
+    bundled core-lua больше не «понижает» версию, если на диске уже лежит
+    lua из более нового релиза (сравнение `NFQWS2_COMPAT_VER_REQUIRED`,
+    `_protected_core_lua`). Наши расширения (`zapret-multishake`,
+    `custom_funcs`, `z2k-*`, …) выкладываются как раньше.
+  - Покрыто тестами (`tests/test_asset_importer_lua_compat.py`). Редактор
+    стратегий правок не потребовал: `delay` у `send` и `urp` у `oob` уже
+    были в `nfqws2_spec.js`, а переименованный `WRITEABLE` линтер не
+    проверял.
 - **На Keenetic нельзя было добавить domain-правило в «AWG-правила → Домены»:
   кнопка «Добавить правило» оставалась серой.** Под зелёным баннером
   «Активен Keenetic-native режим (NDMS)» кнопка всё равно гейтилась на

--- a/core/asset_importer.py
+++ b/core/asset_importer.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import shutil
 from typing import Optional
 
@@ -86,6 +87,29 @@ CATALOG_BUILTIN_FILE = os.path.join(
 
 # Пропускаемые имена (техническая служебка репозитория-источника)
 _SKIP_PREFIXES = ("_",)
+
+# Lua-скрипты, которые являются дословными копиями upstream-релиза
+# bol-van/zapret2. Их версия ЖЁСТКО привязана к бинарнику nfqws2 через
+# NFQWS2_COMPAT_VER (см. первые строки zapret-lib.lua). Эти файлы кладутся в
+# /opt/zapret2/lua/ ещё и самим релизом (вместе с бинарником), поэтому их
+# нельзя «понижать» нашей bundled-копией, если на диске уже лежит lua из
+# более НОВОГО релиза — иначе получаем ровно тот LUA ERROR про несовместимый
+# NFQWS2_COMPAT_VER (issue #151), только в обратную сторону.
+#
+# Наши собственные расширения (zapret-multishake, custom_funcs, z2k-*,
+# fakemultisplit, … и устаревший zapret-wgobfs, которого в релизе уже нет)
+# сюда НЕ входят — в релизе их нет, их всегда выкладываем из bundle.
+_UPSTREAM_CORE_LUA = frozenset({
+    "zapret-lib.lua",
+    "zapret-antidpi.lua",
+    "zapret-auto.lua",
+    "zapret-obfs.lua",
+    "zapret-pcap.lua",
+    "zapret-tests.lua",
+})
+
+# Маркер версии lua↔бинарник из zapret-lib.lua (в самом начале файла).
+_COMPAT_VER_RE = re.compile(r"NFQWS2_COMPAT_VER_REQUIRED\s*=\s*(\d+)")
 
 
 # ─── Публичный API ───────────────────────────────────────────
@@ -145,9 +169,21 @@ def import_runtime_assets(base_path: Optional[str] = None) -> dict:
         IMPORT_BIN_DIR,
         os.path.join(base_path, "files", "fake"),
     )
+    # Upstream-core lua не понижаем, если на диске уже лежит более новый
+    # релиз (его lua совпадает с его же бинарником) — см. _protected_core_lua
+    # и issue #151.
+    lua_skip = _protected_core_lua(base_path)
+    if lua_skip:
+        log.info(
+            "asset-importer: lua на диске новее bundled по NFQWS2_COMPAT_VER "
+            "— сохраняем upstream-core из релиза, не затираем: %s"
+            % ", ".join(sorted(lua_skip)),
+            source="asset-importer",
+        )
     lua_stats = _sync_dir(
         IMPORT_LUA_DIR,
         os.path.join(base_path, "lua"),
+        skip_names=lua_skip,
     )
     # lists/ → split: ipset-файлы в ipset/, остальные в lists/
     lists_stats, ipset_stats = _sync_lists_split(
@@ -305,12 +341,14 @@ def import_bundled_strategies() -> dict:
 # ─── Внутренние хелперы: runtime assets ──────────────────────
 
 def _sync_dir(src_dir: str, dst_dir: str,
-              ext_whitelist: Optional[set] = None) -> dict:
+              ext_whitelist: Optional[set] = None,
+              skip_names: Optional[set] = None) -> dict:
     """
     Синхронизировать `src_dir` → `dst_dir` (однонаправленно).
 
     Поведение:
       * Файлы в src_dir с `_`-префиксом пропускаются.
+      * Файлы из `skip_names` пропускаются (считаются в skipped).
       * Если dst-файл не существует или отличается по содержимому —
         копируется (с сохранением mtime).
       * Если существует и идентичен — не трогается (идемпотентно).
@@ -322,6 +360,8 @@ def _sync_dir(src_dir: str, dst_dir: str,
         dst_dir:       Куда копируем.
         ext_whitelist: Множество разрешённых расширений (с точкой),
                        или None для всех файлов.
+        skip_names:    Имена файлов, которые НЕ перезаписывать (например,
+                       upstream-core lua из более нового релиза).
 
     Returns: {"copied": N, "skipped": M, "errors": [...]}
     """
@@ -340,6 +380,9 @@ def _sync_dir(src_dir: str, dst_dir: str,
 
     for name in sorted(os.listdir(src_dir)):
         if name.startswith(_SKIP_PREFIXES):
+            continue
+        if skip_names and name in skip_names:
+            stats["skipped"] += 1
             continue
         src = os.path.join(src_dir, name)
         if not os.path.isfile(src):
@@ -385,6 +428,44 @@ def _sha1(path: str) -> str:
         for chunk in iter(lambda: f.read(65536), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def _lua_compat_ver(path: str) -> Optional[int]:
+    """Прочитать NFQWS2_COMPAT_VER_REQUIRED из zapret-lib.lua (None если нет).
+
+    Маркер стоит в самом начале файла, читаем только голову.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            head = f.read(1024)
+    except OSError:
+        return None
+    m = _COMPAT_VER_RE.search(head)
+    try:
+        return int(m.group(1)) if m else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _protected_core_lua(base_path: str) -> set:
+    """Набор upstream-core lua, которые НЕ нужно перезаписывать bundle-копией.
+
+    Непустой набор возвращается только если на диске (<base>/lua) лежит
+    zapret-lib.lua с NFQWS2_COMPAT_VER_REQUIRED строго БОЛЬШЕ нашего bundled
+    — значит пользователь уже на более новом релизе zapret2 и его lua
+    совпадает с его бинарником. Затирать её нашей (более старой) копией
+    нельзя: это вызвало бы несовместимость lua↔nfqws2 (issue #151).
+
+    Если версию не удалось определить (нет файла / нет маркера) — ведём себя
+    как раньше: ничего не защищаем, выкладываем bundle (он же и чинит
+    отсутствующую/устаревшую lua).
+    """
+    bundled = _lua_compat_ver(os.path.join(IMPORT_LUA_DIR, "zapret-lib.lua"))
+    deployed = _lua_compat_ver(
+        os.path.join(base_path, "lua", "zapret-lib.lua"))
+    if bundled is not None and deployed is not None and deployed > bundled:
+        return set(_UPSTREAM_CORE_LUA)
+    return set()
 
 
 def _resolve_zapret_base_path() -> str:

--- a/core/nfqws_manager.py
+++ b/core/nfqws_manager.py
@@ -91,7 +91,7 @@ _EXTENSION_LUA_FILES = {
     },
     # Флуд RST с подобранным TTL до DPI. Зависит от lib+antidpi (core).
     "zapret-rst-flood.lua": {"rst_flood"},
-    # Запись pcap из lua (требует --writeable). Триггер — pcap; вспомогательные
+    # Запись pcap из lua (требует --writable). Триггер — pcap; вспомогательные
     # pcap_write* включены, чтобы набор зеркалил экспорт скрипта (см. тест).
     "zapret-pcap.lua": {
         "pcap", "pcap_write", "pcap_write_packet", "pcap_write_header",

--- a/import/lua/zapret-antidpi.lua
+++ b/import/lua/zapret-antidpi.lua
@@ -86,6 +86,7 @@ end
 
 -- nfqws1 : "--dup"
 -- standard args : direction, fooling, ip_id, ipfrag, rawsend, reconstruct
+-- arg : delay=<msec> - drop and send delayed
 function send(ctx, desync)
 	direction_cutoff_opposite(ctx, desync, "any")
 	if direction_check(desync, "any") then
@@ -93,9 +94,18 @@ function send(ctx, desync)
 		local dis = deepcopy(desync.dis)
 		apply_fooling(desync, dis)
 		apply_ip_id(desync, dis, nil, "none")
-		-- it uses rawsend, reconstruct and ipfrag options
-		rawsend_dissect_ipfrag(dis, desync_opts(desync))
+		if desync.arg.delay then
+			local tname = "send_"..desync_timer_name(desync)
+			timer_set(tname, "send_timer_delayed", tonumber(desync.arg.delay), true, {dis = dis, opts = desync_opts(desync)})
+		else
+			-- it uses rawsend, reconstruct and ipfrag options
+			rawsend_dissect_ipfrag(dis, desync_opts(desync))
+		end
 	end
+end
+function send_timer_delayed(name, data)
+	-- oneshot timer, auto deletes
+	rawsend_dissect_ipfrag(data.dis, data.opts)
 end
 
 -- nfqws1 : "--orig"

--- a/import/lua/zapret-lib.lua
+++ b/import/lua/zapret-lib.lua
@@ -1,4 +1,4 @@
-NFQWS2_COMPAT_VER_REQUIRED=5
+NFQWS2_COMPAT_VER_REQUIRED=6
 
 if NFQWS2_COMPAT_VER~=NFQWS2_COMPAT_VER_REQUIRED then
 	error("Incompatible NFQWS2_COMPAT_VER. Use pktws and lua scripts from the same release !")
@@ -761,6 +761,63 @@ function fix_ip6_next(ip6, last_proto)
 	end
 end
 
+function dis_ipsrc(dis)
+	if dis.ip then
+		return dis.ip.ip_src
+	elseif dis.ip6 then
+		return dis.ip6.ip6_src
+	end
+end
+function dis_ipdst(dis)
+	if dis.ip then
+		return dis.ip.ip_dst
+	elseif dis.ip6 then
+		return dis.ip6.ip6_dst
+	end
+end
+
+function dis_l4_name(dis)
+	local l4
+	if dis.tcp then
+		l4="tcp"
+	elseif dis.udp then
+		l4="udp"
+	elseif dis.icmp then
+		l4="icmp"
+	else
+		l4="raw"..ip_proto_l3(dis)
+	end
+	return l4
+end
+function dis_l4_ports(dis)
+	local p1,p2
+	if dis.tcp then
+		p1=dis.tcp.th_sport
+		p2=dis.tcp.th_dport
+	elseif dis.udp then
+		p1=dis.udp.uh_sport
+		p2=dis.udp.uh_dport
+	elseif dis.icmp then
+		p1=dis.icmp.icmp_type
+		p2=dis.icmp.icmp_code
+	end
+	return p1 and (p1..":"..p2) or "?"
+end
+
+function dis_timer_name(dis)
+	return table.concat({ntop(dis_ipsrc(dis)),"->",ntop(dis_ipdst(dis)),"_",dis_l4_name(dis),"_",dis_l4_ports(dis)})
+end
+function desync_timer_name(desync)
+	local name = dis_timer_name(desync.dis)
+	if desync.track then
+		name = name.."_n"..desync.track.pos.direct.pcounter
+	else
+		name = name.."_"..brandom_az09(10)
+	end
+	return name
+end
+
+
 -- reverses ip addresses, ports and seq/ack
 function dis_reverse(dis)
 	if dis.ip then
@@ -1193,7 +1250,9 @@ function rawsend_dissect_segmented(desync, dis, mss, options)
 				len = #payload - pos + 1
 				if len > max_data then len = max_data end
 				if oob then
-					if urp>=pos and urp<(pos+len)then
+					if urp==0 and pos==1 then
+						discopy.tcp.th_flags = bitor(discopy.tcp.th_flags, TH_URG)
+					elseif urp>=pos and urp<(pos+len) then
 						discopy.tcp.th_flags = bitor(discopy.tcp.th_flags, TH_URG)
 						discopy.tcp.th_urp = urp-pos+1
 					else
@@ -1376,9 +1435,9 @@ end
 function append_path(path,file)
 	return string.sub(path,#path,#path)=='/' and path..file or path.."/"..file
 end
-function writeable_file_name(filename)
+function writable_file_name(filename)
 	if is_absolute_path(filename) then return filename end
-	local writedir = os.getenv("WRITEABLE")
+	local writedir = os.getenv("WRITABLE")
 	if not writedir then return filename end
 	return append_path(writedir, filename)
 end
@@ -1689,6 +1748,7 @@ function writefile(filename, data)
 		error("writefile: "..err)
 	end
 end
+
 
 -- DISSECTORS
 

--- a/import/lua/zapret-pcap.lua
+++ b/import/lua/zapret-pcap.lua
@@ -15,8 +15,8 @@ function pcap_write(file, raw)
 	pcap_write_packet(file, raw)
 end
 
--- test case : --writeable=zdir --in-range=a --lua-desync=pcap:file=test.pcap
--- arg : file=<filename> - file for storing pcap data. if --writeable is specified and filename is relative - append filename to writeable path
+-- test case : --writable=zdir --in-range=a --lua-desync=pcap:file=test.pcap
+-- arg : file=<filename> - file for storing pcap data. if --writable is specified and filename is relative - append filename to writable path
 -- arg : keep - do not overwrite file, append packets to existing
 function pcap(ctx, desync)
 	if not desync.arg.file or #desync.arg.file==0 then
@@ -24,7 +24,7 @@ function pcap(ctx, desync)
 	end
 	local fn_cache_name = desync.func_instance.."_fn"
 	if not _G[fn_cache_name] then
-		_G[fn_cache_name] = writeable_file_name(desync.arg.file)
+		_G[fn_cache_name] = writable_file_name(desync.arg.file)
 		if not desync.arg.keep then
 			-- overwrite file
 			os.remove(_G[fn_cache_name])

--- a/import/lua/zapret-tests.lua
+++ b/import/lua/zapret-tests.lua
@@ -15,7 +15,7 @@ end
 function test_all(...)
 	test_run({
 		test_crypto, test_bin, test_time, test_gzip, test_ipstr, test_dissect, test_csum, test_resolve,
-		test_get_source_ip, test_ifaddrs, test_rawsend},...)
+		test_get_source_ip, test_ifaddrs, test_rawsend, test_timer},...)
 end
 
 
@@ -906,6 +906,53 @@ function test_ifaddrs(opts)
 		end
 	end
 end
+
+function print_current_time()
+	local sec,nsec = clock_gettime()
+	local t = sec + nsec/1000000000;
+	print("time: "..t)
+end
+function timer_info_print(tinfo)
+	print(" timer_info.name="..tinfo.name)
+	print(" timer_info.func="..tinfo.func)
+	print(" timer_info.period="..tinfo.period)
+	print(" timer_info.oneshot="..tostring(tinfo.oneshot))
+	print(" timer_info.fires="..tinfo.fires)
+end
+function timer_info_print_by_name(name)
+	local tinfo = timer_info(name)
+	timer_info_print(tinfo)
+end
+
+function timer1(name, data)
+	print("timer "..name.." fired. data="..tostring(data))
+	print_current_time()
+	timer_info_print_by_name(name)
+end
+function timer2(name, data)
+	data.n = data.n+1
+	print("timer "..name.." fired. data.n="..tostring(data.n))
+	print_current_time()
+	timer_info_print_by_name(name)
+	if data.n>=4 then
+		timer_del(name)
+	end
+end
+function test_timer(opts)
+	timer_set("t1","timer1",500,true,"sample_data");
+	local tbl = {n=0}
+	timer_set("t2","timer2",700,false,tbl);
+
+	print("* timers\n")
+	local timers=timer_enum()
+	for i,name in ipairs(timers) do
+		print("TIMER "..i.." :")
+		timer_info_print_by_name(name)
+	end
+	print_current_time()
+	print()
+end
+
 
 function test_rawsend(opts)
 	print("* rawsend")

--- a/tests/test_asset_importer_lua_compat.py
+++ b/tests/test_asset_importer_lua_compat.py
@@ -1,0 +1,163 @@
+# tests/test_asset_importer_lua_compat.py
+"""asset_importer: bundled lua не понижает версию релиза (issue #151).
+
+Бандл GUI кладёт lua-скрипты в /opt/zapret2/lua/. Upstream-core скрипты
+(zapret-lib/antidpi/auto/obfs/pcap/tests) — дословные копии релиза
+bol-van/zapret2 и жёстко привязаны к бинарнику nfqws2 через
+NFQWS2_COMPAT_VER (первая строка zapret-lib.lua). zapret2 1.0 сменил
+COMPAT_VER 5→6; если бандл (со старой lua) затирал свежую lua из релиза —
+nfqws2 падал с «Incompatible NFQWS2_COMPAT_VER» (issue #151).
+
+Здесь проверяем: (1) сам бандл уже не старый, (2) более новая lua на диске
+не затирается нашей копией.
+"""
+
+import os
+import re
+import tempfile
+import unittest
+
+from core import asset_importer as ai
+
+LUA_DIR = ai.IMPORT_LUA_DIR
+
+
+def _write(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+@unittest.skipUnless(os.path.isdir(LUA_DIR), "vendored import/lua not present")
+class TestBundledLuaIsCurrent(unittest.TestCase):
+    """Прямая регрессия issue #151 — bundled lua не должна быть compat 5."""
+
+    def test_bundled_zapret_lib_compat_ver_at_least_6(self):
+        ver = ai._lua_compat_ver(os.path.join(LUA_DIR, "zapret-lib.lua"))
+        self.assertIsNotNone(
+            ver, "не нашли NFQWS2_COMPAT_VER_REQUIRED в bundled zapret-lib.lua")
+        self.assertGreaterEqual(
+            ver, 6,
+            "bundled zapret-lib.lua compat_ver=%s < 6 — устаревшая lua "
+            "ломает nfqws2 >= 1.0 (issue #151)" % ver)
+
+    def test_no_stale_writeable_or_compat5_markers(self):
+        """В bundled lua не осталось старых маркеров (WRITEABLE, compat=5)."""
+        offenders = []
+        for name in sorted(os.listdir(LUA_DIR)):
+            if not name.endswith(".lua"):
+                continue
+            with open(os.path.join(LUA_DIR, name), encoding="utf-8",
+                      errors="replace") as f:
+                txt = f.read()
+            if "WRITEABLE" in txt or "writeable_file_name" in txt:
+                offenders.append(name + " (WRITEABLE→WRITABLE не выполнен)")
+            if re.search(r"NFQWS2_COMPAT_VER_REQUIRED\s*=\s*5\b", txt):
+                offenders.append(name + " (compat=5)")
+        self.assertEqual(offenders, [],
+                         "stale-маркеры в bundled lua: %s" % offenders)
+
+    def test_all_protected_core_files_vendored(self):
+        for name in ai._UPSTREAM_CORE_LUA:
+            self.assertTrue(
+                os.path.isfile(os.path.join(LUA_DIR, name)),
+                "upstream-core lua %s отсутствует в bundle" % name)
+
+
+class TestLuaCompatVerParser(unittest.TestCase):
+
+    def test_parse_value(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "zapret-lib.lua")
+            _write(p, "NFQWS2_COMPAT_VER_REQUIRED=6\n-- rest\n")
+            self.assertEqual(ai._lua_compat_ver(p), 6)
+            _write(p, "NFQWS2_COMPAT_VER_REQUIRED = 12\n")
+            self.assertEqual(ai._lua_compat_ver(p), 12)
+
+    def test_no_marker_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "x.lua")
+            _write(p, "function foo() end\n")
+            self.assertIsNone(ai._lua_compat_ver(p))
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(ai._lua_compat_ver("/no/such/zapret-lib.lua"))
+
+
+@unittest.skipUnless(os.path.isdir(LUA_DIR), "vendored import/lua not present")
+class TestProtectedCoreLua(unittest.TestCase):
+
+    def setUp(self):
+        self.bundled = ai._lua_compat_ver(
+            os.path.join(LUA_DIR, "zapret-lib.lua"))
+        self.assertIsNotNone(self.bundled)
+
+    @staticmethod
+    def _seed(base, ver):
+        if ver is not None:
+            _write(os.path.join(base, "lua", "zapret-lib.lua"),
+                   "NFQWS2_COMPAT_VER_REQUIRED=%d\n" % ver)
+
+    def test_newer_on_disk_is_protected(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._seed(d, self.bundled + 1)
+            self.assertEqual(ai._protected_core_lua(d),
+                             set(ai._UPSTREAM_CORE_LUA))
+
+    def test_same_version_not_protected(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._seed(d, self.bundled)
+            self.assertEqual(ai._protected_core_lua(d), set())
+
+    def test_older_on_disk_not_protected(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._seed(d, self.bundled - 1)
+            self.assertEqual(ai._protected_core_lua(d), set())
+
+    def test_missing_on_disk_not_protected(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(ai._protected_core_lua(d), set())
+
+
+class TestSyncDirSkipNames(unittest.TestCase):
+
+    def test_skip_names_not_overwritten(self):
+        with tempfile.TemporaryDirectory() as d:
+            src, dst = os.path.join(d, "src"), os.path.join(d, "dst")
+            _write(os.path.join(src, "a.lua"), "NEW-A\n")
+            _write(os.path.join(src, "b.lua"), "NEW-B\n")
+            _write(os.path.join(dst, "a.lua"), "OLD-A\n")
+            _write(os.path.join(dst, "b.lua"), "OLD-B\n")
+            stats = ai._sync_dir(src, dst, skip_names={"a.lua"})
+            with open(os.path.join(dst, "a.lua")) as f:
+                self.assertEqual(f.read(), "OLD-A\n")   # защищён
+            with open(os.path.join(dst, "b.lua")) as f:
+                self.assertEqual(f.read(), "NEW-B\n")   # обновлён
+            self.assertEqual(stats["copied"], 1)
+
+
+@unittest.skipUnless(os.path.isdir(LUA_DIR), "vendored import/lua not present")
+class TestImportRuntimePreservesNewerCoreLua(unittest.TestCase):
+    """Сквозной сценарий issue #151 (обратная сторона): на диске лежит lua
+    из БОЛЕЕ нового релиза — import_runtime_assets её не затирает, но наши
+    расширения раскладывает как обычно."""
+
+    def test_newer_core_lua_preserved_extensions_deployed(self):
+        bundled = ai._lua_compat_ver(os.path.join(LUA_DIR, "zapret-lib.lua"))
+        sentinel = "NFQWS2_COMPAT_VER_REQUIRED=%d\n-- FUTURE RELEASE\n" % (
+            bundled + 1)
+        with tempfile.TemporaryDirectory() as base:
+            _write(os.path.join(base, "lua", "zapret-lib.lua"), sentinel)
+
+            res = ai.import_runtime_assets(base_path=base)
+            self.assertTrue(res.get("ok"))
+
+            # core lua из «нового релиза» НЕ затёрта нашей копией
+            with open(os.path.join(base, "lua", "zapret-lib.lua"),
+                      encoding="utf-8") as f:
+                self.assertEqual(f.read(), sentinel)
+
+            # а наши расширения (их в релизе нет) — выложены
+            self.assertTrue(
+                os.path.isfile(os.path.join(base, "lua", "custom_funcs.lua")),
+                "custom_funcs.lua должен раскладываться даже при защите core")


### PR DESCRIPTION
zapret2 1.0 сменил lua_compat_ver 5→6 (WRITEABLE→WRITABLE, delay в send, фикс oob при urp=b). Наши вендоренные core-lua были на compat 5, а asset_importer принудительно раскладывал их в /opt/zapret2/lua/, затирая свежую lua из релиза 1.0 → nfqws2 падал с "Incompatible NFQWS2_COMPAT_VER".

- import/lua: обновлены до v1.0.1 (compat 6) zapret-lib, zapret-antidpi, zapret-pcap, zapret-tests (zapret-auto/obfs уже совпадали байт-в-байт).
- asset_importer: bundled core-lua больше не понижает версию, если на диске лежит более новый релиз (_protected_core_lua по NFQWS2_COMPAT_VER); _sync_dir получил skip_names. Защищает от регрессии в обе стороны.
- tests/test_asset_importer_lua_compat.py: парсер compat-ver, защита core-lua, skip_names, сквозной сценарий, регрессия-гард на bundle.
- nfqws_manager: комментарий --writeable→--writable.
- SKILL.md, CHANGELOG: отражают переход на compat 6.

Редактор стратегий правок не потребовал: delay у send и urp у oob уже были в nfqws2_spec.js, переименованный WRITEABLE линтер не проверял.

https://claude.ai/code/session_01RfivGcYn2NCwuUHz3rYiTp