### PR TITLE
fix(editor): распознавать глобальные флаги nfqws2 (--ipcache-hostname…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,10 +223,20 @@
     lua из более нового релиза (сравнение `NFQWS2_COMPAT_VER_REQUIRED`,
     `_protected_core_lua`). Наши расширения (`zapret-multishake`,
     `custom_funcs`, `z2k-*`, …) выкладываются как раньше.
-  - Покрыто тестами (`tests/test_asset_importer_lua_compat.py`). Редактор
-    стратегий правок не потребовал: `delay` у `send` и `urp` у `oob` уже
-    были в `nfqws2_spec.js`, а переименованный `WRITEABLE` линтер не
-    проверял.
+  - Покрыто тестами (`tests/test_asset_importer_lua_compat.py`). Сам по себе
+    `delay` у `send` и `urp` у `oob` уже были в `nfqws2_spec.js`, а
+    переименованный `WRITEABLE` линтер не проверял.
+- **Редактор стратегий: ложная ошибка «неизвестный флаг» на глобальных
+  флагах nfqws2** (`--ipcache-hostname=1`, `--ipcache-lifetime`,
+  `--ctrack-*`, `--server`, `--lua-init` и т.д.). Линтер знал только
+  профильные флаги (filter/list/range/desync/blob) и ругался на легитимные
+  глобальные/служебные флаги как на «legacy nfqws1» — хотя они встречаются
+  в наших же builtin-пресетах. Добавили в `web/js/utils/nfqws2_spec.js`
+  весь набор глобальных/служебных флагов (`ipcache-*`, `ctrack-*`,
+  `server`, `payload-disable`, `reasm-disable`, `fwmark`, `bind-fix4/6`,
+  `lua-init/lua-gc`, `writable`, `comment`) и недостающие `--hostlist-auto-*`,
+  сверив с `bol-van/zapret2` v1.0.1 (`docs/manual.md`, `nfqws2 -?`).
+  Регресс-тесты — `tests/test_nfqws2_lint.js`.
 - **На Keenetic нельзя было добавить domain-правило в «AWG-правила → Домены»:
   кнопка «Добавить правило» оставалась серой.** Под зелёным баннером
   «Активен Keenetic-native режим (NDMS)» кнопка всё равно гейтилась на

--- a/tests/test_nfqws2_lint.js
+++ b/tests/test_nfqws2_lint.js
@@ -118,6 +118,46 @@ test('lint: неверный payload в csv = предупреждение', () 
     assert.ok(warns(r).some(d => /неизвестно/.test(d.message)));
 });
 
+// ──────────────── Глобальные/служебные флаги (--ipcache-hostname и пр.) ────────────────
+
+test('spec: знает глобальные/служебные флаги nfqws2 1.0.1', () => {
+    ['--ipcache-hostname', '--ipcache-lifetime', '--ctrack-timeouts',
+     '--ctrack-disable', '--server', '--payload-disable', '--reasm-disable',
+     '--fwmark', '--bind-fix4', '--bind-fix6', '--lua-init', '--lua-gc',
+     '--writable', '--comment',
+     '--hostlist-auto-incoming-maxseq', '--hostlist-auto-retrans-maxseq',
+     '--hostlist-auto-retrans-reset', '--hostlist-auto-udp-out',
+     '--hostlist-auto-udp-in',
+    ].forEach((f) => {
+        assert.ok(Spec.isKnownFlag(f), f + ' должен быть известен редактору');
+    });
+});
+
+test('lint: --ipcache-hostname=1 НЕ ошибка (раньше «неизвестный флаг»)', () => {
+    const r = Lint.analyze('--ipcache-hostname=1');
+    assert.strictEqual(errs(r).length, 0,
+        'не должно быть ошибок: ' + JSON.stringify(errs(r)));
+});
+
+test('lint: --ipcache-hostname без значения НЕ ошибка (arg optional)', () => {
+    const r = Lint.analyze('--ipcache-hostname');
+    assert.strictEqual(errs(r).length, 0);
+});
+
+test('lint: --ipcache-hostname=2 = предупреждение (enum 0|1)', () => {
+    const r = Lint.analyze('--ipcache-hostname=2');
+    assert.ok(warns(r).some(d => /недопустимое значение/.test(d.message)));
+});
+
+test('lint: строка builtin-пресета с ipcache без ложных ошибок', () => {
+    const r = Lint.analyze(
+        '--filter-tcp=80,443 --filter-l7=tls,http --ipcache-hostname=1 '
+        + '--ipcache-lifetime=8400 --out-range=-s34228 --in-range=-s5556 '
+        + '--lua-desync=circular');
+    assert.strictEqual(errs(r).length, 0,
+        'ложные ошибки на валидном пресете: ' + JSON.stringify(errs(r)));
+});
+
 test('lint: корректная стратегия — без ошибок', () => {
     const r = Lint.analyze(
         '--filter-tcp=443 --filter-l7=tls --payload=tls_client_hello '

--- a/web/js/utils/nfqws2_spec.js
+++ b/web/js/utils/nfqws2_spec.js
@@ -562,12 +562,41 @@ const Nfqws2Spec = (() => {
         '--template':    { slot: 'filter', cat: 'special', desc: 'Сделать профиль шаблоном', arg: { type: 'name', optional: true } },
         '--import':      { slot: 'filter', cat: 'special', desc: 'Импорт настроек из шаблона', arg: { type: 'name' } },
         '--cookie':      { slot: 'filter', cat: 'special', desc: 'desync.cookie для инстансов профиля', arg: { type: 'string', optional: true } },
+
+        // ─── Глобальные / служебные (до первого --new) ───
+        // Часть из них GUI ставит сам (--qnum/--debug/--user/--fwmark/
+        // --lua-init), но ipcache-*/ctrack-*/server и т.п. легитимно
+        // встречаются в стратегиях и наших пресетах. Редактор обязан их
+        // знать — иначе ложная ошибка «неизвестный флаг» (напр. на
+        // --ipcache-hostname=1, который есть в builtin-пресетах).
+        // Список сверен с bol-van/zapret2 v1.0.1 (docs/manual.md, `-?`).
+        '--ipcache-hostname':  { slot: 'global', cat: 'service', desc: 'Кэшировать ip→hostname (нужно стратегиям нулевой фазы: wssize/syndata с хостлистами)', arg: { type: 'enum', values: ['0', '1'], optional: true } },
+        '--ipcache-lifetime':  { slot: 'global', cat: 'service', desc: 'TTL кэша ip→hostname, сек (дефолт 7200, 0 = без ограничений)', arg: { type: 'int', ex: ['7200', '8400'] } },
+        '--ctrack-timeouts':   { slot: 'global', cat: 'service', desc: 'Таймауты внутр. conntrack: TCP SYN:ESTABLISHED:FIN[:UDP] (дефолт 60:300:60:60)', arg: { type: 'string', ex: ['60:300:60:60'] } },
+        '--ctrack-disable':    { slot: 'global', cat: 'service', desc: 'Отключить внутренний conntrack', arg: { type: 'enum', values: ['0', '1'], optional: true } },
+        '--server':            { slot: 'global', cat: 'service', desc: 'Серверный режим (инверсия направлений и фильтрации)', arg: { type: 'enum', values: ['0', '1'], optional: true } },
+        '--payload-disable':   { slot: 'global', cat: 'service', desc: 'Не детектировать указанные payload-типы (без аргумента — все)', arg: { type: 'csv-enum', values: PAYLOAD_TYPES, optional: true } },
+        '--reasm-disable':     { slot: 'global', cat: 'service', desc: 'Отключить reasm для типов (tls_client_hello, quic_initial)', arg: { type: 'csv-enum', values: ['tls_client_hello', 'quic_initial'], optional: true } },
+        '--fwmark':            { slot: 'global', cat: 'service', desc: 'fwmark anti-loop (дефолт 0x40000000). Обычно ставит GUI', arg: { type: 'string', ex: ['0x40000000'] } },
+        '--bind-fix4':         { slot: 'global', cat: 'service', desc: 'Фикс выбора исходящего интерфейса IPv4 (PBR/multi-WAN). Обычно ставит GUI', arg: null },
+        '--bind-fix6':         { slot: 'global', cat: 'service', desc: 'Фикс выбора исходящего интерфейса IPv6. Обычно ставит GUI', arg: null },
+        '--lua-init':          { slot: 'global', cat: 'service', desc: 'Загрузить Lua (@файл|текст). Обычно ставит GUI (core + extension)', arg: { type: 'string', ex: ['@/opt/zapret2/lua/zapret-lib.lua'] } },
+        '--lua-gc':            { slot: 'global', cat: 'service', desc: 'Интервал GC Lua, сек (дефолт 60)', arg: { type: 'int' } },
+        '--writable':          { slot: 'global', cat: 'service', desc: 'Каталог с правом записи для Lua (env WRITABLE). До zapret2 1.0 — --writeable', arg: { type: 'string', optional: true } },
+        '--comment':           { slot: 'global', cat: 'service', desc: 'No-op, для читабельности конфига', arg: { type: 'string', optional: true } },
+
+        // доп. параметры автохостлиста (slot list, как остальные --hostlist-auto-*)
+        '--hostlist-auto-incoming-maxseq': { slot: 'list', cat: 'list', desc: 'Успех если входящий rel-seq > N (дефолт 4096)', arg: { type: 'int' } },
+        '--hostlist-auto-retrans-maxseq':  { slot: 'list', cat: 'list', desc: 'Макс. rel-seq ретрансмиссии (дефолт 32768)', arg: { type: 'int' } },
+        '--hostlist-auto-retrans-reset':   { slot: 'list', cat: 'list', desc: 'Слать RST ретрансмиттеру (дефолт 1)', arg: { type: 'enum', values: ['0', '1'], optional: true } },
+        '--hostlist-auto-udp-out':         { slot: 'list', cat: 'list', desc: 'UDP-провал по исходящим (дефолт 4)', arg: { type: 'int' } },
+        '--hostlist-auto-udp-in':          { slot: 'list', cat: 'list', desc: 'UDP-провал по входящим (дефолт 1)', arg: { type: 'int' } },
     };
 
     // Порядок слотов (для скелета и предупреждений о порядке)
     const SLOT_ORDER = ['global', 'sep', 'filter', 'list', 'range', 'desync'];
     const SLOT_LABELS = {
-        global: 'Блобы', sep: '--new', filter: 'Фильтр профиля',
+        global: 'Блобы/глоб.', sep: '--new', filter: 'Фильтр профиля',
         list: 'Домены/IP', range: 'Диапазон/payload', desync: 'Действие (desync)',
     };
 


### PR DESCRIPTION
… и пр.)

Линтер редактора стратегий знал только профильные флаги (filter/list/range/desync/blob) и помечал легитимные глобальные/служебные флаги nfqws2 как «неизвестный флаг … legacy nfqws1». Под раздачу попадал --ipcache-hostname=1 — хотя он есть в наших же builtin-пресетах.

Добавил в web/js/utils/nfqws2_spec.js глобальные/служебные флаги, сверив с bol-van/zapret2 v1.0.1 (docs/manual.md, nfqws2 -?): ipcache-hostname, ipcache-lifetime, ctrack-timeouts, ctrack-disable, server, payload-disable, reasm-disable, fwmark, bind-fix4/6, lua-init, lua-gc, writable, comment, и недостающие --hostlist-auto-* (incoming-maxseq/retrans-maxseq/retrans-reset/ udp-in/udp-out). Slot 'global', cat 'service'; ярлык скелета global → «Блобы/глоб.».

Регресс-тесты: tests/test_nfqws2_lint.js (--ipcache-hostname=1 больше не ошибка; enum 0|1 валидируется; строка builtin-пресета чистая).

https://claude.ai/code/session_01RfivGcYn2NCwuUHz3rYiTp