### PR TITLE
feat(singbox): TUN-режим — sing-box как интерфейс для выборочной марш…

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -49,6 +49,9 @@ REST API для sing-box.
   POST   /api/singbox/transparent/apply     — поднять firewall TProxy/
                                                 Redirect/Hybrid
   POST   /api/singbox/transparent/remove    — снять firewall-правила
+  POST   /api/singbox/configs/<name>/tun-inbound — добавить TUN-inbound
+                                              (sing-box как интерфейс для
+                                              Selective routing)
   POST   /api/singbox/configs/<name>/transparent-inbounds
                                               — вставить transparent-
                                                 inbound'ы в конфиг
@@ -997,6 +1000,51 @@ def register(app):
         save = mgr.save_config(name, text=render_conf(cfg))
         if not save.get("ok"):
             response.status = 500
+        return save
+
+    @app.route("/api/singbox/configs/<name>/tun-inbound", method="POST")
+    def singbox_tun_inbound(name):
+        """
+        Добавить/заменить TUN-inbound в конфиге: sing-box создаст сетевой
+        интерфейс (`interface_name`), который затем виден в системе и на
+        странице «Selective routing» как цель правил device/domain/cidr.
+
+        body: {interface_name, address, mtu, stack, auto_route, sniff}.
+          auto_route=false (по умолчанию) — что заворачивать в интерфейс,
+            решает выборочная маршрутизация (ip rule/nftset);
+          auto_route=true — весь трафик роутера/клиентов уходит в TUN.
+        После сохранения конфиг нужно (пере)запустить.
+        """
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        from core.singbox_manager import get_singbox_manager
+        from core.singbox_config import set_tun_inbound, render_conf
+        mgr = get_singbox_manager()
+        cfg_resp = mgr.get_config(name)
+        if not cfg_resp.get("ok"):
+            response.status = 404
+            return cfg_resp
+        cfg = cfg_resp.get("parsed") or {}
+        addr = body.get("address")
+        if isinstance(addr, str):
+            addr = [a.strip() for a in addr.split(",") if a.strip()]
+        iface = (body.get("interface_name") or "singbox-tun").strip()
+        set_tun_inbound(
+            cfg,
+            interface_name=iface,
+            address=addr or None,
+            mtu=int(body.get("mtu") or 9000),
+            stack=(body.get("stack") or "system"),
+            auto_route=bool(body.get("auto_route", False)),
+            sniff=bool(body.get("sniff", True)))
+        save = mgr.save_config(name, text=render_conf(cfg))
+        if not save.get("ok"):
+            response.status = 500
+            return save
+        save["interface_name"] = iface
         return save
 
     @app.route("/api/singbox/transparent/apply", method="POST")

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -294,23 +294,96 @@ def set_transparent_inbounds(cfg: dict, *, mode: str = "tproxy",
         mode=mode, tcp_port=tcp_port, udp_port=udp_port,
         dns_port=dns_port, sniff=sniff)
     cfg["inbounds"] = new_ibs + existing
-
     # Сниффинг и перехват DNS — через route actions (а не legacy-поля
     # inbound'а / спец-outbound `dns`, удалённые в sing-box 1.13).
+    _set_managed_route_rules(cfg, sniff=sniff, hijack_dns=bool(dns_port))
+    return cfg
+
+
+def _set_managed_route_rules(cfg: dict, *, sniff: bool,
+                             hijack_dns: bool) -> None:
+    """
+    Идемпотентно выставить наши служебные route actions в начало
+    `route.rules`: сначала `{"action":"sniff"}`, затем
+    `{"protocol":"dns","action":"hijack-dns"}`. Прежние наши правила
+    (точные совпадения) снимаются, пользовательские — сохраняются.
+    hijack_dns требует определения протокола, поэтому включает sniff.
+    """
     route = cfg.setdefault("route", {})
     rules = route.get("rules")
     if not isinstance(rules, list):
         rules = []
     sniff_rule = make_sniff_rule()
     dns_rule = make_hijack_dns_rule()
-    # Снять наши прежние правила (точные совпадения) — идемпотентность.
     rules = [r for r in rules if r != sniff_rule and r != dns_rule]
     managed = []
-    if sniff or dns_port:           # hijack-dns требует sniff
+    if sniff or hijack_dns:
         managed.append(sniff_rule)
-    if dns_port:
+    if hijack_dns:
         managed.append(dns_rule)
     route["rules"] = managed + rules
+
+
+_TUN_TAG = "tun-in"
+
+
+def make_tun_inbound(*, interface_name: str = "singbox-tun",
+                     address=None, mtu: int = 9000,
+                     stack: str = "system",
+                     auto_route: bool = False,
+                     strict_route: bool = False) -> dict:
+    """
+    Собрать TUN-inbound sing-box (создаёт сетевой интерфейс
+    `interface_name`). Используются ТОЛЬКО актуальные поля 1.11+/1.13:
+    `address` (а не удалённые `inet4_address`/`inet6_address`).
+
+    auto_route=False (по умолчанию) — sing-box НЕ забирает маршрут по
+    умолчанию: интерфейс просто создаётся, а какой трафик в него
+    заворачивать, решает страница «Selective routing» (ip rule/nftset).
+    Для режима «весь трафик» выставьте auto_route=True.
+
+    stack: 'system' (быстрее, нужен модуль tun ядра — на Keenetic есть),
+           'gvisor' (userspace, переносимее) или 'mixed'.
+    """
+    return {
+        "type": "tun",
+        "tag": _TUN_TAG,
+        "interface_name": interface_name or "singbox-tun",
+        "address": list(address) if address else ["172.18.0.1/30"],
+        "mtu": int(mtu) if mtu else 9000,
+        "auto_route": bool(auto_route),
+        "strict_route": bool(strict_route),
+        "stack": stack or "system",
+    }
+
+
+def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
+                    address=None, mtu: int = 9000, stack: str = "system",
+                    auto_route: bool = False, strict_route: bool = False,
+                    sniff: bool = True, route_to_proxy: bool = True) -> dict:
+    """
+    Вставить/заменить TUN-inbound в конфиге (cfg мутируется и
+    возвращается). Прежний наш `tun-in` убирается, остальные inbound'ы
+    сохраняются. Чистая функция (без I/O).
+
+    После этого конфиг можно запустить — интерфейс `interface_name`
+    появится в системе и в «Selective routing» (как цель device/domain/
+    cidr-правил). sniff=True добавляет `{"action":"sniff"}` (чтобы
+    доменные route-правила Selective routing срабатывали).
+    route_to_proxy=True направляет весь попавший в TUN трафик в основной
+    прокси-outbound конфига (route.final → selector/первый сервер).
+    """
+    existing = [ib for ib in (cfg.get("inbounds") or [])
+                if not (isinstance(ib, dict) and ib.get("tag") == _TUN_TAG)]
+    tun = make_tun_inbound(
+        interface_name=interface_name, address=address, mtu=mtu,
+        stack=stack, auto_route=auto_route, strict_route=strict_route)
+    cfg["inbounds"] = [tun] + existing
+    _set_managed_route_rules(cfg, sniff=sniff, hijack_dns=False)
+    if route_to_proxy:
+        proxy = pick_proxy_outbound(cfg)
+        if proxy:
+            cfg.setdefault("route", {})["final"] = proxy
     return cfg
 
 

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -13,7 +13,8 @@ from unittest import mock
 from core import singbox_transparent as tp
 from core.singbox_config import (
     make_transparent_inbounds, set_transparent_inbounds, make_sniff_rule,
-    make_hijack_dns_rule,
+    make_hijack_dns_rule, make_tun_inbound, set_tun_inbound,
+    find_tun_interface,
 )
 
 
@@ -266,6 +267,53 @@ class TestSetTransparentInbounds(unittest.TestCase):
         # выключение DNS-hijack снимает правило
         set_transparent_inbounds(cfg, mode="tproxy", dns_port=0)
         self.assertNotIn(make_hijack_dns_rule(), cfg["route"]["rules"])
+
+
+class TestTunInbound(unittest.TestCase):
+
+    def _cfg(self):
+        return {"inbounds": [{"type": "mixed", "tag": "user"}], "outbounds": [
+            {"type": "selector", "tag": "PROXY",
+             "outbounds": ["s1"], "default": "s1"},
+            {"type": "vless", "tag": "s1", "server": "x",
+             "server_port": 443, "uuid": "u"}]}
+
+    def test_make_tun_uses_modern_fields_only(self):
+        ib = make_tun_inbound(interface_name="singbox-tun")
+        self.assertEqual(ib["type"], "tun")
+        self.assertEqual(ib["interface_name"], "singbox-tun")
+        self.assertIsInstance(ib["address"], list)        # не inet4_address
+        for legacy in ("inet4_address", "inet6_address",
+                       "inet4_route_address", "gso"):
+            self.assertNotIn(legacy, ib)
+
+    def test_make_tun_auto_route_off_by_default(self):
+        # для выборочной маршрутизации sing-box не должен забирать
+        # маршрут по умолчанию.
+        self.assertFalse(make_tun_inbound()["auto_route"])
+        self.assertTrue(make_tun_inbound(auto_route=True)["auto_route"])
+
+    def test_set_tun_inbound_creates_interface(self):
+        cfg = self._cfg()
+        set_tun_inbound(cfg, interface_name="singbox-tun")
+        self.assertEqual(find_tun_interface(cfg), "singbox-tun")
+        tags = [ib["tag"] for ib in cfg["inbounds"]]
+        self.assertIn("tun-in", tags)
+        self.assertIn("user", tags)                       # чужой inbound цел
+
+    def test_set_tun_routes_to_proxy_and_sniffs(self):
+        cfg = self._cfg()
+        set_tun_inbound(cfg, route_to_proxy=True, sniff=True)
+        self.assertEqual(cfg["route"]["final"], "PROXY")  # первый selector
+        self.assertIn(make_sniff_rule(), cfg["route"]["rules"])
+
+    def test_set_tun_idempotent(self):
+        cfg = self._cfg()
+        set_tun_inbound(cfg, interface_name="t0")
+        set_tun_inbound(cfg, interface_name="t1")
+        tun = [ib for ib in cfg["inbounds"] if ib["tag"] == "tun-in"]
+        self.assertEqual(len(tun), 1)                     # заменён, не дубль
+        self.assertEqual(tun[0]["interface_name"], "t1")
 
 
 class TestReapplySaved(unittest.TestCase):

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -19,6 +19,11 @@ const SingboxDashboardPage = (() => {
         proxy_self: false, dns_hijack_port: 0, ipv6_policy: 'allow',
         inject_config: '',
     };
+    let tunForm = {                  // форма TUN-интерфейса (для Selective routing)
+        config: '', interface_name: 'singbox-tun',
+        address: '172.18.0.1/30', stack: 'system', mtu: 9000,
+        auto_route: false,
+    };
 
     // ══════════════ render ══════════════
 
@@ -57,6 +62,13 @@ const SingboxDashboardPage = (() => {
             <div class="card" id="sb-transparent" style="margin-top:16px;">
                 <div class="card-title">Прозрачное проксирование (TProxy / Redirect / Hybrid)${typeof Help !== 'undefined' ? Help.button('transparent') : ''}</div>
                 <div id="sb-transparent-body" style="margin-top:8px;">
+                    <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
+                </div>
+            </div>
+
+            <div class="card" id="sb-tun" style="margin-top:16px;">
+                <div class="card-title">TUN-интерфейс (для выборочной маршрутизации)</div>
+                <div id="sb-tun-body" style="margin-top:8px;">
                     <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
                 </div>
             </div>
@@ -105,6 +117,7 @@ const SingboxDashboardPage = (() => {
         renderSummary();
         renderInstances();
         renderTransparent();
+        renderTun();
     }
 
     function startPolling() {
@@ -403,6 +416,92 @@ const SingboxDashboardPage = (() => {
         } catch (e) { Toast.error(e.message); }
     }
 
+    // ══════════════ TUN interface (for selective routing) ══════════════
+
+    function renderTun() {
+        const box = document.getElementById('sb-tun-body');
+        if (!box) return;
+        if (!tunForm.config && configs.length) tunForm.config = configs[0].name;
+        const cfgOpts = ['<option value="">— выбрать конфиг —</option>'].concat(
+            configs.map(c => `<option value="${escapeAttr(c.name)}"
+                ${c.name === tunForm.config ? 'selected' : ''}>${escapeHtml(c.name)}${c.running ? ' ●' : ''}</option>`)
+        ).join('');
+        const opt = (v, cur, label) =>
+            `<option value="${v}" ${v === cur ? 'selected' : ''}>${label}</option>`;
+        box.innerHTML = `
+            <p class="text-muted" style="font-size:13px; margin-top:0;">
+                Создаёт сетевой интерфейс sing-box. После (пере)запуска конфига он
+                появится в системе и на странице
+                <a href="#routing" style="text-decoration:underline;">Selective routing</a>,
+                где можно завернуть в него выбранные устройства / домены / подсети.
+                Маршрут по умолчанию не забирается (auto_route выкл.) — что
+                заворачивать, решают правила маршрутизации.
+            </p>
+            <div style="display:grid; grid-template-columns:170px 1fr; gap:8px 12px; align-items:center; max-width:660px;">
+                <label class="text-muted">Конфиг</label>
+                <select class="form-control" style="max-width:240px;"
+                        onchange="SingboxDashboardPage.setTun('config', this.value)">${cfgOpts}</select>
+
+                <label class="text-muted">Имя интерфейса</label>
+                <input type="text" class="form-control" style="max-width:200px;"
+                       value="${escapeAttr(tunForm.interface_name)}"
+                       onchange="SingboxDashboardPage.setTun('interface_name', this.value)">
+
+                <label class="text-muted">Адрес (CIDR)</label>
+                <input type="text" class="form-control" style="max-width:200px;"
+                       value="${escapeAttr(tunForm.address)}"
+                       title="напр. 172.18.0.1/30"
+                       onchange="SingboxDashboardPage.setTun('address', this.value)">
+
+                <label class="text-muted">Сетевой стек</label>
+                <select class="form-control" style="max-width:280px;"
+                        onchange="SingboxDashboardPage.setTun('stack', this.value)">
+                    ${opt('system', tunForm.stack, 'system (быстрее, нужен tun ядра)')}
+                    ${opt('gvisor', tunForm.stack, 'gvisor (userspace, переносимее)')}
+                    ${opt('mixed', tunForm.stack, 'mixed')}
+                </select>
+
+                <label class="text-muted">MTU</label>
+                <input type="number" class="form-control" style="max-width:120px;"
+                       value="${escapeAttr(tunForm.mtu)}"
+                       onchange="SingboxDashboardPage.setTun('mtu', this.value)">
+
+                <label class="text-muted">Весь трафик</label>
+                <label class="text-muted" style="display:flex; align-items:center; gap:6px;">
+                    <input type="checkbox" ${tunForm.auto_route ? 'checked' : ''}
+                           onchange="SingboxDashboardPage.setTun('auto_route', this.checked)">
+                    auto_route — завернуть ВЕСЬ трафик (вместо выборочной маршрутизации)
+                </label>
+            </div>
+            <div style="margin-top:12px;">
+                <button class="btn btn-primary btn-sm"
+                        onclick="SingboxDashboardPage.createTunInbound()">Создать TUN-инбаунд</button>
+            </div>
+        `;
+    }
+
+    function setTun(key, value) {
+        if (key === 'auto_route') tunForm.auto_route = !!value;
+        else if (key === 'mtu') tunForm.mtu = parseInt(value, 10) || 9000;
+        else tunForm[key] = value;
+    }
+
+    async function createTunInbound() {
+        if (!tunForm.config) { Toast.error('Выберите конфиг'); return; }
+        try {
+            const r = await API.post(
+                `/api/singbox/configs/${encodeURIComponent(tunForm.config)}/tun-inbound`,
+                { interface_name: tunForm.interface_name, address: tunForm.address,
+                  stack: tunForm.stack, mtu: tunForm.mtu,
+                  auto_route: tunForm.auto_route });
+            if (r && r.ok) {
+                Toast.success('TUN-инбаунд добавлен в ' + tunForm.config +
+                    '. (Пере)запустите конфиг, затем настройте Selective routing.');
+                await refresh();
+            } else Toast.error((r && r.error) || 'ошибка');
+        } catch (e) { Toast.error(e.message); }
+    }
+
     // ══════════════ helpers ══════════════
 
     function escapeHtml(s) {
@@ -417,5 +516,6 @@ const SingboxDashboardPage = (() => {
         render, destroy, refresh,
         up, down, restart,
         setTp, applyTransparent, removeTransparent, injectInbounds,
+        setTun, createTunInbound,
     };
 })();


### PR DESCRIPTION
…рутизации

Добавляет sing-box TUN-inbound: конфиг создаёт сетевой интерфейс (`singbox-tun`), который виден в системе и на странице «Selective routing» как цель правил device/domain/cidr. Это закрывает оба вопроса: sing-box теперь появляется в списке интерфейсов, и трафик можно заворачивать ВЫБОРОЧНО (определённые клиенты/домены), а не только «всё» через прозрачное проксирование.

- core/singbox_config: make_tun_inbound() — только актуальные поля 1.13 (`address`, без удалённых inet4_address/gso); auto_route=False по умолчанию (маршрут по умолчанию не забирается — что заворачивать, решает Selective routing). set_tun_inbound() вставляет tun-инбаунд, добавляет sniff и направляет route.final в прокси-outbound. Общий хелпер _set_managed_route_rules для sniff/hijack-dns.
- api/singbox: POST /configs/<name>/tun-inbound.
- web: на странице sing-box карточка «TUN-интерфейс» (конфиг, имя, адрес, стек, MTU, auto_route) + ссылка на Selective routing.

Тесты: модерн-поля без legacy, auto_route по умолчанию off, создание интерфейса (find_tun_interface), final→proxy + sniff, идемпотентность.

https://claude.ai/code/session_01FN5Ur2inCz4qyJaMFzGbov