### PR TITLE
fix(firewall): работать без iptables-mod-comment (issue #151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,16 @@
   подписки/пул/именованные списки/маршруты единого слоя — проверено).
 
 ### Исправлено
+- **Firewall: на Entware/Keenetic без `iptables-mod-comment` правила не
+  применялись — `iptables: No chain/target/match by that name` ×14, сайты
+  не работали** ([#151](https://github.com/avatarDD/zapret-gui/issues/151)).
+  Каждое NFQUEUE-правило содержало `-m comment --comment`, а матч `xt_comment`
+  на Entware — отдельный пакет, которого часто нет; без него падали ВСЕ
+  правила и обход не поднимался. Теперь `core/firewall.py` определяет
+  доступность `-m comment` (`_comment_supported`) и при его отсутствии кладёт
+  правила в именованные цепочки `nfqws_post/nfqws_pre/nfqws_nat` без
+  комментариев (снимаются через `_remove_ipt_named_chain`). На системах, где
+  `comment` есть, поведение прежнее. Покрыто тестами (`tests/test_firewall_rules.py`).
 - **zapret2 1.0 ломал nfqws2: `LUA ERROR … Incompatible NFQWS2_COMPAT_VER`
   ([#151](https://github.com/avatarDD/zapret-gui/issues/151)).** zapret2 1.0
   сменил `lua_compat_ver` 5→6 (несовместимое изменение: везде `WRITEABLE`→

--- a/core/firewall.py
+++ b/core/firewall.py
@@ -133,6 +133,13 @@ class FirewallManager:
     # iptables ≤1.4.x (Entware/Keenetic) — только «-w» без значения.
     _wait_flag_cache: dict = {}
 
+    # Кэш поддержки матча `-m comment` (xt_comment) по бинарнику. На
+    # Entware/Keenetic это отдельный пакет iptables-mod-comment, которого
+    # часто нет — тогда КАЖДОЕ правило с `-m comment` падает с
+    # «No chain/target/match by that name» и обход не поднимается (issue #151).
+    # При положительном детекте отсутствия — переходим на именованные цепочки.
+    _comment_support_cache: dict = {}
+
     def __init__(self):
         self._lock = threading.Lock()
         self._applied = False
@@ -433,6 +440,85 @@ class FirewallManager:
         self._rules_info = rules
         return ok
 
+    def _comment_supported(self, ipt_cmd) -> bool:
+        """Доступен ли матч `-m comment` (xt_comment) у этого iptables.
+
+        На Entware/Keenetic это отдельный модуль (пакет iptables-mod-comment),
+        которого часто нет. Без него каждое правило с `-m comment` падает с
+        «No chain/target/match by that name», и весь обход не поднимается
+        (issue #151) — тогда мы кладём правила в именованные цепочки nfqws_*
+        без комментариев.
+
+        Переключаемся на запасной путь ТОЛЬКО при положительном детекте
+        отсутствия матча. Если проверить не удалось (нет iptables, нет прав,
+        иная ошибка) — считаем, что comment есть, и НЕ меняем привычное
+        поведение. Результат кэшируется по бинарнику.
+        """
+        cache = FirewallManager._comment_support_cache
+        if ipt_cmd in cache:
+            return cache[ipt_cmd]
+
+        wait = FirewallManager._iptables_wait_flag(ipt_cmd)
+        probe = "ZGUI_CMT_PROBE"
+
+        def _raw(args):
+            try:
+                return subprocess.run(
+                    [ipt_cmd] + wait + args,
+                    capture_output=True, text=True, timeout=5,
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                return None
+
+        supported = True  # по умолчанию — как раньше (не ломаем рабочий путь)
+        # Одноразовая цепочка в таблице filter (всегда есть), вне тракта трафика.
+        _raw(["-t", "filter", "-N", probe])
+        add = _raw(["-t", "filter", "-A", probe,
+                    "-m", "comment", "--comment", "zgui", "-j", "RETURN"])
+        if (add is not None and add.returncode != 0
+                and "No chain/target/match" in (add.stderr or "")):
+            supported = False
+        _raw(["-t", "filter", "-F", probe])
+        _raw(["-t", "filter", "-X", probe])
+
+        cache[ipt_cmd] = supported
+        if not supported:
+            log.warning(
+                "%s: матч `-m comment` недоступен (нет пакета "
+                "iptables-mod-comment?). Правила пойдут в именованные цепочки "
+                "nfqws_* без комментариев (issue #151)." % ipt_cmd,
+                source="firewall",
+            )
+        return supported
+
+    def _ensure_named_chain(self, ipt_cmd, table, hook, name) -> None:
+        """Создать/очистить нашу цепочку `name` и подцепить её к `hook`.
+
+        Идемпотентно: цепочка создаётся (если нет) и флашится; лишние
+        дублирующие переходы из hook снимаются, затем ставится один переход
+        в начало hook. Снимается всё это потом в _remove_ipt_named_chain.
+        Используется, когда `-m comment` недоступен (issue #151).
+        """
+        wait = FirewallManager._iptables_wait_flag(ipt_cmd)
+
+        def _raw(args):
+            try:
+                return subprocess.run(
+                    [ipt_cmd] + wait + args,
+                    capture_output=True, text=True, timeout=5,
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                return None
+
+        _raw(["-t", table, "-N", name])   # создать (может уже существовать — ок)
+        _raw(["-t", table, "-F", name])   # очистить от прошлых правил
+        for _ in range(10):               # снять старые переходы (анти-дубли)
+            chk = _raw(["-t", table, "-C", hook, "-j", name])
+            if not chk or chk.returncode != 0:
+                break
+            _raw(["-t", table, "-D", hook, "-j", name])
+        _raw(["-t", table, "-I", hook, "-j", name])  # один переход в начало hook
+
     def _apply_ipt_family(self, ipt_cmd, qnum, ports_tcp, ports_udp,
                           fwmark, tcp_pkt, udp_pkt, wan_ifaces, rules):
         """
@@ -466,8 +552,33 @@ class FirewallManager:
         udp_pkt_in = self._extra.get("udp_pkt_in", 3)
         do_nat = (ipt_cmd == "iptables")  # MASQUERADE только для IPv4
 
-        def _comment():
-            return ["-m", "comment", "--comment", IPT_COMMENT]
+        # На Entware/Keenetic матч `-m comment` (xt_comment) — отдельный
+        # пакет iptables-mod-comment, которого может не быть. Тогда КАЖДОЕ
+        # правило падало с «No chain/target/match by that name» и обход не
+        # поднимался (issue #151). Если матч недоступен — кладём правила в
+        # именованные цепочки nfqws_* (их снимает _remove_ipt_named_chain),
+        # без `-m comment`. Если доступен — поведение прежнее (правила прямо
+        # во встроенных цепочках, помечены комментарием).
+        use_comment = self._comment_supported(ipt_cmd)
+        if use_comment:
+            post_chain, pre_chain, nat_chain = (
+                "POSTROUTING", "PREROUTING", "POSTROUTING")
+            post_first = "-I"   # ACCEPT-processed — первым во встроенной цепочке
+
+            def _comment():
+                return ["-m", "comment", "--comment", IPT_COMMENT]
+        else:
+            post_chain, pre_chain, nat_chain = (
+                "nfqws_post", "nfqws_pre", "nfqws_nat")
+            post_first = "-A"   # свежая цепочка: порядок = порядок добавления
+
+            def _comment():
+                return []
+
+            self._ensure_named_chain(ipt_cmd, "mangle", "POSTROUTING", post_chain)
+            self._ensure_named_chain(ipt_cmd, "mangle", "PREROUTING", pre_chain)
+            if do_nat:
+                self._ensure_named_chain(ipt_cmd, "nat", "POSTROUTING", nat_chain)
 
         def _nfq():
             return ["-j", "NFQUEUE", "--queue-num", str(qnum), "--queue-bypass"]
@@ -483,7 +594,7 @@ class FirewallManager:
             # ───────── POSTROUTING (исходящий) ─────────
             # 1) ACCEPT для уже обработанных (не зацикливаем)
             if self._run_cmd(
-                [ipt_cmd, "-t", "mangle", "-I", "POSTROUTING"] + oif_args
+                [ipt_cmd, "-t", "mangle", post_first, post_chain] + oif_args
                 + ["-m", "mark", "--mark", mark_proc] + _comment()
                 + ["-j", "ACCEPT"]
             ):
@@ -493,14 +604,14 @@ class FirewallManager:
 
             # 2) RETURN для исключённых соединений
             self._run_cmd(
-                [ipt_cmd, "-t", "mangle", "-A", "POSTROUTING"] + oif_args
+                [ipt_cmd, "-t", "mangle", "-A", post_chain] + oif_args
                 + ["-m", "connmark", "--mark", mark_excl] + _comment()
                 + ["-j", "RETURN"]
             )
 
             # 3) TCP → NFQUEUE (первые N пакетов + fin/rst)
             if ports_tcp:
-                base = ([ipt_cmd, "-t", "mangle", "-A", "POSTROUTING"]
+                base = ([ipt_cmd, "-t", "mangle", "-A", post_chain]
                         + oif_args + ["-p", "tcp", "-m", "multiport",
                                       "--dports", ports_tcp])
                 if self._run_cmd(
@@ -520,7 +631,7 @@ class FirewallManager:
             # 4) UDP → NFQUEUE
             if ports_udp:
                 if self._run_cmd(
-                    [ipt_cmd, "-t", "mangle", "-A", "POSTROUTING"] + oif_args
+                    [ipt_cmd, "-t", "mangle", "-A", post_chain] + oif_args
                     + ["-p", "udp", "-m", "multiport", "--dports", ports_udp,
                        "-m", "connbytes", "--connbytes-dir=original",
                        "--connbytes-mode=packets", "--connbytes",
@@ -535,7 +646,7 @@ class FirewallManager:
             # nfqws2 переписывает адреса → повторный MASQUERADE для UDP.
             if do_nat:
                 if self._run_cmd(
-                    [ipt_cmd, "-t", "nat", "-A", "POSTROUTING"] + oif_args
+                    [ipt_cmd, "-t", "nat", "-A", nat_chain] + oif_args
                     + ["-m", "mark", "--mark", mark_proc, "-p", "udp"]
                     + _comment() + ["-j", "MASQUERADE"]
                 ):
@@ -544,17 +655,17 @@ class FirewallManager:
             # ───────── PREROUTING (входящий / ответы) ─────────
             # RETURN для исключённых и уже обработанных
             self._run_cmd(
-                [ipt_cmd, "-t", "mangle", "-A", "PREROUTING"] + iif_args
+                [ipt_cmd, "-t", "mangle", "-A", pre_chain] + iif_args
                 + ["-m", "connmark", "--mark", mark_excl] + _comment()
                 + ["-j", "RETURN"]
             )
             self._run_cmd(
-                [ipt_cmd, "-t", "mangle", "-A", "PREROUTING"] + iif_args
+                [ipt_cmd, "-t", "mangle", "-A", pre_chain] + iif_args
                 + ["-m", "mark", "--mark", mark_proc] + _comment()
                 + ["-j", "RETURN"]
             )
             if ports_tcp:
-                base = ([ipt_cmd, "-t", "mangle", "-A", "PREROUTING"]
+                base = ([ipt_cmd, "-t", "mangle", "-A", pre_chain]
                         + iif_args + ["-p", "tcp", "-m", "multiport",
                                       "--sports", ports_tcp])
                 self._run_cmd(
@@ -570,7 +681,7 @@ class FirewallManager:
                               + _comment() + _nfq())
             if ports_udp:
                 self._run_cmd(
-                    [ipt_cmd, "-t", "mangle", "-A", "PREROUTING"] + iif_args
+                    [ipt_cmd, "-t", "mangle", "-A", pre_chain] + iif_args
                     + ["-p", "udp", "-m", "multiport", "--sports", ports_udp,
                        "-m", "connbytes", "--connbytes-dir=reply",
                        "--connbytes-mode=packets", "--connbytes",

--- a/tests/test_firewall_rules.py
+++ b/tests/test_firewall_rules.py
@@ -21,6 +21,7 @@ def _capture_iptables(fw):
         return True
 
     with mock.patch.object(fw, "_run_cmd", side_effect=fake_run), \
+            mock.patch.object(fw, "_comment_supported", return_value=True), \
             mock.patch("core.firewall.shutil.which", return_value="/sbin/iptables"):
         rules = []
         fw._apply_ipt_family(
@@ -64,6 +65,97 @@ class TestIptablesRules(unittest.TestCase):
         pre = [c for c in self.flat if "PREROUTING" in c and "multiport" in c]
         self.assertTrue(all("--dports" in c for c in post))
         self.assertTrue(all("--sports" in c for c in pre))
+
+
+class TestIptablesNoCommentFallback(unittest.TestCase):
+    """issue #151: если матч `-m comment` недоступен (нет iptables-mod-comment
+    на Entware/Keenetic), правила КАЖДОЕ падали с «No chain/target/match» и
+    обход не поднимался. Теперь правила идут в именованные цепочки nfqws_*
+    без `-m comment`."""
+
+    def setUp(self):
+        self.fw = FirewallManager()
+        self.captured = []
+        with mock.patch.object(
+                self.fw, "_run_cmd",
+                side_effect=lambda c: self.captured.append(c) or True), \
+                mock.patch.object(self.fw, "_comment_supported",
+                                  return_value=False), \
+                mock.patch.object(self.fw, "_ensure_named_chain") as ens, \
+                mock.patch("core.firewall.shutil.which",
+                           return_value="/sbin/iptables"):
+            fw_rules = []
+            self.fw._apply_ipt_family(
+                "iptables", 300, "80,443", "443",
+                "0x40000000", 20, 5, ["eth0"], fw_rules,
+            )
+            self.ensure_calls = ens.call_args_list
+        self.flat = [" ".join(c) for c in self.captured]
+
+    def test_rules_go_to_named_chains(self):
+        self.assertTrue(any("nfqws_post" in c for c in self.flat))
+        self.assertTrue(any("nfqws_pre" in c for c in self.flat))
+        self.assertTrue(any("nfqws_nat" in c for c in self.flat))
+
+    def test_no_comment_match_used(self):
+        self.assertFalse(
+            any("comment" in c for c in self.flat),
+            "в no-comment режиме не должно быть `-m comment`")
+
+    def test_no_builtin_chains_touched(self):
+        # Правила (через _run_cmd) идут только в наши цепочки; во встроенные
+        # POSTROUTING/PREROUTING ходит лишь jump из _ensure_named_chain (замокан).
+        self.assertFalse(any(" POSTROUTING " in (" " + c + " ")
+                             for c in self.flat))
+        self.assertFalse(any(" PREROUTING " in (" " + c + " ")
+                             for c in self.flat))
+
+    def test_still_has_nfqueue_and_masquerade(self):
+        self.assertTrue(any("NFQUEUE" in c for c in self.flat))
+        self.assertTrue(any("MASQUERADE" in c for c in self.flat))
+
+    def test_named_chains_were_ensured(self):
+        names = {call.args[3] for call in self.ensure_calls}
+        self.assertEqual(names, {"nfqws_post", "nfqws_pre", "nfqws_nat"})
+
+
+class TestCommentProbe(unittest.TestCase):
+    """Детект `-m comment`: запасной путь включаем ТОЛЬКО при положительном
+    обнаружении отсутствия матча; иначе — как раньше (comment-режим)."""
+
+    def setUp(self):
+        FirewallManager._comment_support_cache.clear()
+        self.fw = FirewallManager()
+
+    def tearDown(self):
+        FirewallManager._comment_support_cache.clear()
+
+    def _run_with(self, add_rc, add_stderr):
+        class _R:
+            def __init__(self, rc, err=""):
+                self.returncode, self.stderr, self.stdout = rc, err, ""
+
+        def fake(cmd, **kw):
+            # cmd = [ipt, -w?, -t, filter, ACTION, ...]
+            if "-A" in cmd:
+                return _R(add_rc, add_stderr)
+            return _R(0)
+
+        with mock.patch("core.firewall.subprocess.run", side_effect=fake), \
+                mock.patch.object(FirewallManager, "_iptables_wait_flag",
+                                  return_value=["-w"]):
+            return self.fw._comment_supported("iptables")
+
+    def test_unsupported_when_no_chain_target_match(self):
+        self.assertFalse(self._run_with(
+            1, "iptables: No chain/target/match by that name."))
+
+    def test_supported_when_probe_rule_accepted(self):
+        self.assertTrue(self._run_with(0, ""))
+
+    def test_supported_when_failure_is_unrelated(self):
+        # иная ошибка (например, нет прав) → не ломаем рабочий путь
+        self.assertTrue(self._run_with(1, "Permission denied"))
 
 
 class TestNftablesRules(unittest.TestCase):


### PR DESCRIPTION
Репортер #151: lua-ошибка ушла, но сайты не работают — iptables: No chain/target/match by that name ×14, "Ошибка при применении правил". Причина: каждое из 14 NFQUEUE-правил содержит `-m comment --comment`, а матч xt_comment на Entware/Keenetic — отдельный пакет (iptables-mod-comment), которого часто нет. Без него падали ВСЕ правила (comment — единственный общий для всех 14 элемент), и обход не поднимался.

- _comment_supported(): одноразовый зонд `-m comment` в throwaway-цепочке таблицы filter. Запасной путь включаем ТОЛЬКО при положительном детекте отсутствия матча («No chain/target/match»); при любой иной/неясной ошибке считаем, что comment есть — не ломаем рабочий путь.
- При отсутствии comment правила идут в именованные цепочки nfqws_post/nfqws_pre/nfqws_nat (через _ensure_named_chain), без `-m comment`; снимаются уже существующим _remove_ipt_named_chain. На системах с comment поведение не меняется.
- tests/test_firewall_rules.py: режим без comment (именованные цепочки, нет `-m comment`, NFQUEUE/MASQUERADE на месте) + детект зонда.

https://claude.ai/code/session_01RfivGcYn2NCwuUHz3rYiTp