### PR TITLE
fix(singbox): детект TPROXY-цели и понятная подсказка вместо «No chai…

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -1091,7 +1091,11 @@ def register(app):
             cfg.set("singbox", "transparent", persist)
             cfg.save()
         if not res.get("ok"):
-            response.status = 500
+            # Префлайт-условие (нет цели TPROXY, issue #149) — это не
+            # серверная ошибка: отдаём 200, чтобы фронт показал понятную
+            # подсказку из тела (res.need/errors), а не безликое «HTTP 500»
+            # (API.post на не-2xx бросает исключение и теряет errors[]).
+            response.status = 200 if res.get("need") else 500
         return res
 
     @app.route("/api/singbox/transparent/remove", method="POST")

--- a/core/singbox_transparent.py
+++ b/core/singbox_transparent.py
@@ -79,6 +79,22 @@ DEFAULT_BYPASS_V6 = [
     "::1/128", "fc00::/7", "fe80::/10", "ff00::/8",
 ]
 
+# Сообщение, когда на роутере нет netfilter-цели TPROXY (issue #149):
+# у пользователя bypass-RETURN'ы проходят, но `-A ... -j TPROXY` падает с
+# «No chain/target/match by that name» — нет модуля ядра/расширения.
+_TPROXY_MISSING_MSG = (
+    "Режим '%s' требует netfilter-цель TPROXY, но её нет на этом роутере "
+    "(не установлен пакет iptables-mod-tproxy или не загружен модуль ядра "
+    "xt_TPROXY/nf_tproxy). Установите: opkg install iptables-mod-tproxy — и "
+    "при необходимости загрузите модуль: modprobe xt_TPROXY nf_tproxy_ipv4. "
+    "Либо выберите режим 'redirect' (только TCP, TPROXY не нужен) или "
+    "включите TUN-режим на вкладке sing-box — он тоже не требует TPROXY."
+)
+
+# Модули ядра, нужные для TPROXY (на Keenetic часто просто не загружены).
+_TPROXY_KMODS = ("nf_tproxy_ipv4", "nf_tproxy_ipv6", "xt_TPROXY",
+                 "xt_socket", "xt_mark")
+
 
 def _run(args, timeout=10):
     try:
@@ -374,6 +390,44 @@ def available(family: str = "v4") -> bool:
     return rc == 0
 
 
+def _modprobe_tproxy():
+    """Best-effort подгрузка модулей ядра для TPROXY (молча)."""
+    for mod in _TPROXY_KMODS:
+        _run(["modprobe", mod], timeout=5)
+
+
+def tproxy_available(family: str = "v4") -> bool:
+    """
+    Доступна ли netfilter-цель TPROXY (`-j TPROXY`) на этом роутере.
+
+    Сначала пытаемся подгрузить модули ядра (на Keenetic они нередко
+    просто не загружены — после modprobe цель появляется), затем
+    проверяем РЕАЛЬНОЙ вставкой правила во временную цепочку mangle
+    (TPROXY допустим только в mangle). Это надёжнее, чем парсить lsmod
+    или искать libxt_TPROXY.so.
+
+    Возвращаем False ТОЛЬКО при положительном детекте отсутствия цели
+    («No chain/target/match by that name»); если проверить нельзя (нет
+    iptables) — считаем доступной, чтобы не блокировать рабочие
+    конфигурации (основной путь сам сообщит об ошибке). Ср. firewall.py
+    `_comment_supported` (issue #151) — тот же приём.
+    """
+    cmd = _ipt(family)
+    if not available(family):
+        return True
+    _modprobe_tproxy()
+    probe = "SBT_PROBE"
+    _run([cmd, "-t", "mangle", "-N", probe])
+    _run([cmd, "-t", "mangle", "-F", probe])
+    rc, _o, err = _run([cmd, "-t", "mangle", "-A", probe, "-p", "tcp",
+                        "-j", "TPROXY", "--on-port", "1", "--tproxy-mark", "1"])
+    _run([cmd, "-t", "mangle", "-F", probe])
+    _run([cmd, "-t", "mangle", "-X", probe])
+    if rc != 0 and "no chain/target/match" in (err or "").lower():
+        return False
+    return True
+
+
 def choose_backend(prefer: str = "auto") -> str:
     """
     Выбрать firewall-бэкенд: 'iptables' | 'nftables' | 'none'.
@@ -436,6 +490,16 @@ def apply(*, mode: str,
             table=table, families=tuple(families), lan_ifaces=lan_ifaces,
             server_ips=server_ips, bypass=bypass, proxy_self=proxy_self,
             dns_hijack_port=dns_hijack_port, ipv6_policy=ipv6_policy)
+
+    # Префлайт TPROXY (issue #149): если режим требует TPROXY, а цели нет
+    # ни на одном семействе — не пытаемся ставить правила (иначе сыплем
+    # сырыми «No chain/target/match»), а отдаём ОДНУ понятную подсказку.
+    if mode in ("tproxy", "hybrid"):
+        if not any(available(f) and tproxy_available(f) for f in families):
+            msg = _TPROXY_MISSING_MSG % mode
+            log.warning("singbox transparent: %s" % msg, source="singbox")
+            return {"ok": False, "mode": mode, "errors": [msg],
+                    "need": "tproxy", "rule_count": 0}
 
     cmds = []   # (family, table, [argv...]) — для лога/отладки
     errors = []

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -346,5 +346,79 @@ class TestReapplySaved(unittest.TestCase):
         self.assertNotIn("bogus_key", kwargs)
 
 
+class TestTproxyCapability(unittest.TestCase):
+    """Префлайт TPROXY (issue #149): когда цели TPROXY нет на роутере,
+    apply() для tproxy/hybrid должен отдать ОДНУ понятную подсказку и не
+    ставить правила; redirect — не трогать проверку вовсе."""
+
+    def setUp(self):
+        # Подменяем I/O: iptables «есть», все команды «успешны».
+        self._patchers = [
+            mock.patch.object(tp, "_run", lambda *a, **k: (0, "", "")),
+            mock.patch.object(tp, "available", lambda family="v4": True),
+        ]
+        for p in self._patchers:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patchers:
+            p.stop()
+
+    def test_tproxy_missing_blocks_with_actionable_error(self):
+        with mock.patch.object(tp, "tproxy_available",
+                               lambda family="v4": False):
+            r = tp.apply(mode="tproxy", tcp_port=1100,
+                         families=("v4",), backend="iptables")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r.get("need"), "tproxy")
+        self.assertEqual(r.get("rule_count"), 0)
+        joined = " ".join(r["errors"]).lower()
+        for hint in ("tproxy", "iptables-mod-tproxy", "redirect", "tun"):
+            self.assertIn(hint, joined)        # подсказка самодостаточна
+
+    def test_hybrid_missing_tproxy_also_blocks(self):
+        with mock.patch.object(tp, "tproxy_available",
+                               lambda family="v4": False):
+            r = tp.apply(mode="hybrid", tcp_port=1100, udp_port=1102,
+                         families=("v4",), backend="iptables")
+        self.assertFalse(r["ok"])
+        self.assertEqual(r.get("need"), "tproxy")
+
+    def test_tproxy_present_proceeds(self):
+        with mock.patch.object(tp, "tproxy_available",
+                               lambda family="v4": True):
+            r = tp.apply(mode="tproxy", tcp_port=1100,
+                         families=("v4",), backend="iptables")
+        self.assertTrue(r["ok"])               # _run всё «успешно»
+        self.assertNotIn("need", r)
+
+    def test_redirect_skips_tproxy_probe(self):
+        # redirect не требует TPROXY — проверку даже не запускаем.
+        calls = {"n": 0}
+
+        def _probe(family="v4"):
+            calls["n"] += 1
+            return False
+
+        with mock.patch.object(tp, "tproxy_available", _probe):
+            r = tp.apply(mode="redirect", tcp_port=1100,
+                         families=("v4",), backend="iptables")
+        self.assertTrue(r["ok"])
+        self.assertEqual(calls["n"], 0)
+
+    def test_probe_detects_missing_target(self):
+        # tproxy_available → False, когда вставка падает с «No chain/...».
+        def _fake_run(args, timeout=10):
+            if "-A" in args and "TPROXY" in args:
+                return (1, "", "iptables: No chain/target/match by that name.")
+            return (0, "", "")
+        with mock.patch.object(tp, "_run", _fake_run):
+            self.assertFalse(tp.tproxy_available("v4"))
+
+    def test_probe_ok_when_insert_succeeds(self):
+        with mock.patch.object(tp, "_run", lambda *a, **k: (0, "", "")):
+            self.assertTrue(tp.tproxy_available("v4"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -24,6 +24,7 @@ const SingboxDashboardPage = (() => {
         address: '172.18.0.1/30', stack: 'system', mtu: 9000,
         auto_route: false,
     };
+    let tpNote = '';                 // последняя ошибка применения firewall (persist)
 
     // ══════════════ render ══════════════
 
@@ -303,6 +304,9 @@ const SingboxDashboardPage = (() => {
                 в конфиге (кнопка «Добавить inbound'ы»). iptables-режим.
                 ${avail ? '' : '<br><span style="color:#e58;">iptables недоступен — применение работать не будет.</span>'}
             </p>
+            ${tpNote ? `<div style="margin:0 0 10px; padding:9px 11px; border-radius:6px;
+                background:rgba(229,80,136,0.12); border:1px solid rgba(229,80,136,0.35);
+                color:#e58; font-size:12px; line-height:1.45; white-space:pre-wrap;">${escapeHtml(tpNote)}</div>` : ''}
             ${applied ? `<div style="margin-bottom:8px; font-size:12px;">
                 Сейчас активно: <strong>${escapeHtml(transparent.settings.mode)}</strong>,
                 порты ${escapeHtml(transparent.settings.tcp_port)}${transparent.settings.mode==='hybrid' ? '/'+escapeHtml(transparent.settings.udp_port) : ''}
@@ -388,16 +392,22 @@ const SingboxDashboardPage = (() => {
                 dns_hijack_port: tpForm.dns_hijack_port,
                 ipv6_policy: tpForm.ipv6_policy,
             });
-            if (r && r.ok) Toast.success('Прозрачное проксирование применено (' + tpForm.mode + ')');
-            else Toast.error((r && (r.error || (r.errors||[]).join('; '))) || 'ошибка');
-        } catch (e) { Toast.error(e.message); }
+            if (r && r.ok) {
+                tpNote = '';
+                Toast.success('Прозрачное проксирование применено (' + tpForm.mode + ')');
+            } else {
+                tpNote = (r && (r.error || (r.errors || []).join('; '))) || 'ошибка';
+                // Подсказку про TPROXY держим дольше — её надо прочитать.
+                Toast.error(tpNote, r && r.need === 'tproxy' ? 15000 : undefined);
+            }
+        } catch (e) { tpNote = e.message; Toast.error(e.message); }
         finally { await refresh(); }
     }
 
     async function removeTransparent() {
         try {
             const r = await API.post('/api/singbox/transparent/remove', {});
-            if (r && r.ok) Toast.success('Правила сняты');
+            if (r && r.ok) { tpNote = ''; Toast.success('Правила сняты'); }
             else Toast.error((r && r.error) || 'ошибка');
         } catch (e) { Toast.error(e.message); }
         finally { await refresh(); }


### PR DESCRIPTION
…n/target/match» (#149)

Остаточная проблема issue #149: после фикса с явным `-t mangle` bypass- RETURN'ы проходят, но `-A SBT_TP_PRE -j TPROXY` всё равно падает с «iptables: No chain/target/match by that name» — на роутере пользователя нет netfilter-цели TPROXY (модуль ядра xt_TPROXY/nf_tproxy или пакет iptables-mod-tproxy не установлен/не загружен). Раньше мы сыпали сырыми iptables-ошибками в лог, а в UI показывали безликое «HTTP 500».

- core/singbox_transparent: tproxy_available() — best-effort modprobe модулей ядра (nf_tproxy_ipv4/xt_TPROXY/xt_socket/…; часто просто не загружены — после modprobe цель появляется), затем РЕАЛЬНАЯ проверка вставкой правила во временную цепочку mangle. Префлайт в apply(): для tproxy/hybrid при отсутствии цели — ничего не ставим, отдаём ОДНУ понятную подсказку (поставить iptables-mod-tproxy / modprobe / выбрать redirect / включить TUN-режим). Приём как в firewall.py _comment_supported (#151).
- api/singbox: при префлайт-условии (res.need) отдаём 200, а не 500 — иначе API.post на не-2xx бросает исключение и подсказка из errors[] теряется (пользователь видел только «HTTP 500»).
- web: подсказка показывается стойкой плашкой в карточке + тост на 15с.

Тесты: детект отсутствия/наличия цели; tproxy/hybrid блокируются с need=tproxy и самодостаточной подсказкой; redirect проверку не запускает.

https://claude.ai/code/session_01FN5Ur2inCz4qyJaMFzGbov