### PR TITLE
fix(singbox): дополнять PATH /sbin при детекте iptables (ложное «ipta…

### DIFF
--- a/core/singbox_transparent.py
+++ b/core/singbox_transparent.py
@@ -49,9 +49,27 @@ firewall, мы умеем сами:
 `remove`) — тонкий слой, прогоняющий argv через идемпотентный `_run`.
 """
 
+import os
 import subprocess
 
 from core.log_buffer import log
+
+
+# При запуске от обычного пользователя / из systemd на Debian/Ubuntu в
+# PATH часто нет /sbin и /usr/sbin, где живут iptables/ip6tables/ip. Тогда
+# subprocess их не находит, available() ложно сообщает «iptables
+# недоступен» (хотя пакет установлен), и применение блокируется. Дополняем
+# PATH sbin-каталогами один раз при импорте — как в core/firewall.py.
+def _ensure_sbin_in_path():
+    extra = ["/usr/local/sbin", "/usr/sbin", "/sbin"]
+    cur = os.environ.get("PATH", "")
+    parts = cur.split(os.pathsep) if cur else []
+    added = [d for d in extra if d not in parts and os.path.isdir(d)]
+    if added:
+        os.environ["PATH"] = os.pathsep.join(parts + added)
+
+
+_ensure_sbin_in_path()
 
 
 # ─────────────────────── константы ───────────────────────────────────

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -420,5 +420,34 @@ class TestTproxyCapability(unittest.TestCase):
             self.assertTrue(tp.tproxy_available("v4"))
 
 
+class TestSbinPath(unittest.TestCase):
+    """PATH без /sbin (systemd/обычный юзер) не должен прятать iptables —
+    available() ложно показывал «iptables недоступен» на Debian."""
+
+    def test_sbin_dirs_added_when_present(self):
+        import os
+        orig = os.environ.get("PATH", "")
+        try:
+            os.environ["PATH"] = os.pathsep.join(["/usr/bin", "/bin"])
+            tp._ensure_sbin_in_path()
+            parts = os.environ["PATH"].split(os.pathsep)
+            for d in ("/usr/local/sbin", "/usr/sbin", "/sbin"):
+                if os.path.isdir(d):              # только реально существующие
+                    self.assertIn(d, parts)
+        finally:
+            os.environ["PATH"] = orig
+
+    def test_existing_path_preserved(self):
+        import os
+        orig = os.environ.get("PATH", "")
+        try:
+            os.environ["PATH"] = "/opt/custom/bin"
+            tp._ensure_sbin_in_path()
+            self.assertIn("/opt/custom/bin",
+                          os.environ["PATH"].split(os.pathsep))
+        finally:
+            os.environ["PATH"] = orig
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…bles недоступен» на Debian)

На Debian/Ubuntu при запуске GUI из systemd или от обычного пользователя PATH процесса часто без /sbin и /usr/sbin, где лежит iptables. Из-за этого singbox_transparent.available() не находил бинарь и страница «Прозрачное проксирование» показывала «iptables недоступен — применение работать не будет», хотя пакет установлен.

core/firewall.py эту проблему уже решает (_ensure_sbin_in_path при импорте) — переносим тот же приём в core/singbox_transparent.py. nft- бэкенд получает фикс автоматически: он импортирует singbox_transparent.

Проверено: с PATH=/usr/bin:/bin available('v4') теперь True, /usr/sbin добавляется в PATH. Истинный случай (iptables реально не установлен) по-прежнему корректно показывает предупреждение.

https://claude.ai/code/session_01FN5Ur2inCz4qyJaMFzGbov