### PR TITLE
fix(singbox): статус прозрачного проксирования учитывает nftables-бэкенд

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -962,12 +962,21 @@ def register(app):
     def singbox_transparent_status():
         response.content_type = "application/json; charset=utf-8"
         from core import singbox_transparent as tp
+        from core import singbox_transparent_nft as nft
         from core.config_manager import get_config_manager
         saved = get_config_manager().get("singbox", "transparent",
                                          default={}) or {}
+        # Доступность по обоим бэкендам: на «чистом» nftables-роутере
+        # (без команды iptables) применение всё равно работает через nft,
+        # поэтому UI не должен пугать «iptables недоступен».
+        ipt_v4 = tp.available("v4")
+        nft_ok = nft.available()
+        backend = "iptables" if ipt_v4 else ("nftables" if nft_ok else "none")
         return {"ok": True,
-                "available_v4": tp.available("v4"),
+                "available_v4": ipt_v4,
                 "available_v6": tp.available("v6"),
+                "available_nft": nft_ok,
+                "backend": backend,
                 "settings": saved}
 
     @app.route("/api/singbox/configs/<name>/transparent-inbounds",

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -287,7 +287,8 @@ const SingboxDashboardPage = (() => {
     function renderTransparent() {
         const box = document.getElementById('sb-transparent-body');
         if (!box) return;
-        const avail = transparent ? !!transparent.available_v4 : false;
+        const backend = transparent ? (transparent.backend || 'none') : 'none';
+        const avail = backend !== 'none';
         const applied = transparent && transparent.settings
                         && transparent.settings.mode;
         const cfgOpts = ['<option value="">— выбрать конфиг —</option>'].concat(
@@ -301,8 +302,10 @@ const SingboxDashboardPage = (() => {
             <p class="text-muted" style="font-size:13px; margin-top:0;">
                 Заворачивает трафик LAN-клиентов (и опц. самого роутера) в
                 sing-box без настройки клиентов. Нужен соответствующий inbound
-                в конфиге (кнопка «Добавить inbound'ы»). iptables-режим.
-                ${avail ? '' : '<br><span style="color:#e58;">iptables недоступен — применение работать не будет.</span>'}
+                в конфиге (кнопка «Добавить inbound'ы»).
+                ${backend === 'iptables' ? ' Бэкенд: <strong>iptables</strong>.' : ''}
+                ${backend === 'nftables' ? '<br><span style="color:#6aa;">iptables не найден — будет использован бэкенд <strong>nftables</strong>.</span>' : ''}
+                ${avail ? '' : '<br><span style="color:#e58;">Ни iptables, ни nftables не найдены — применение работать не будет.</span>'}
             </p>
             ${tpNote ? `<div style="margin:0 0 10px; padding:9px 11px; border-radius:6px;
                 background:rgba(229,80,136,0.12); border:1px solid rgba(229,80,136,0.35);


### PR DESCRIPTION
apply(backend="auto") давно умеет падать на nft-путь, если команды iptables нет (OpenWrt 22.03+, «чистый» nftables). Но статус-эндпоинт и UI смотрели только на iptables (available_v4) — поэтому на nft-роутере страница пугала «iptables недоступен — применение работать не будет», хотя через nft всё применилось бы.

- api: /transparent/status теперь отдаёт available_nft и backend ('iptables'|'nftables'|'none') по той же логике, что choose_backend.
- web: предупреждение показываем только если НЕ доступен ни один бэкенд; иначе подсказываем, какой используется (на nft-роутере — nftables).

https://claude.ai/code/session_01FN5Ur2inCz4qyJaMFzGbov