### PR TITLE
feat(singbox/nft): DNS-hijack и IPv6 anti-leak в nft-бэкенде (паритет…

### DIFF
--- a/core/singbox_transparent_nft.py
+++ b/core/singbox_transparent_nft.py
@@ -132,6 +132,45 @@ def build_tproxy_fragments(*, family: str, port: int,
     return {"prerouting": pre, "output": out}
 
 
+def build_dns_hijack_fragments(*, family: str, dns_port: int,
+                               lan_ifaces: list = None,
+                               via: str = "tproxy",
+                               mark: int = DEFAULT_TPROXY_MARK) -> list:
+    """
+    Фрагменты перехвата DNS форвард-трафика (udp/tcp dport 53) на DNS-порт
+    движка — защита от DNS-leak мимо туннеля. Парно к build_dns_hijack_rules
+    из iptables-ветки.
+
+      via='redirect' → `redirect to :dns_port` (ставится в nat-цепочку predr);
+      via='tproxy'   → `tproxy … meta mark set` (в mangle-цепочку pretp).
+
+    `th dport 53` (transport-header dport) ловит и tcp, и udp. Возвращает
+    список фрагментов-строк (по одному на интерфейс).
+    """
+    tp_ip = "ip6" if family == "v6" else "ip"
+    ifaces = lan_ifaces or [None]
+    frags = []
+    for ifn in ifaces:
+        prefix = ('iifname "%s" ' % ifn) if ifn else ""
+        if via == "redirect":
+            frags.append("%smeta l4proto { tcp, udp } th dport 53 "
+                         "redirect to :%d" % (prefix, dns_port))
+        else:
+            frags.append("%smeta l4proto { tcp, udp } th dport 53 "
+                         "tproxy %s to :%d meta mark set %d"
+                         % (prefix, tp_ip, dns_port, mark))
+    return frags
+
+
+def build_ipv6_block_fragment() -> str:
+    """
+    Anti-leak: дроп всего форвард-IPv6, когда проксируем только v4 (иначе
+    IPv6-клиенты ходят мимо туннеля). В inet-таблице семейство различаем
+    через `meta nfproto ipv6` — аналог `ip6tables -A FORWARD -j DROP`.
+    """
+    return "meta nfproto ipv6 drop"
+
+
 # ─────────────────────── ip rule/route (shared с iptables) ───────────
 
 def _add_tproxy_route(family: str, mark: int, table: int) -> list:
@@ -231,6 +270,28 @@ def apply(*, mode: str,
                 if rc != 0:
                     errors.append("outtp: %s" % e.strip())
             errors.extend(_add_tproxy_route(family, mark, table))
+
+        # Перехват DNS (как в iptables-ветке): redirect-режим → в nat-
+        # цепочку, иначе → tproxy в mangle-цепочку.
+        if dns_hijack_port:
+            via = "redirect" if mode == "redirect" else "tproxy"
+            dns_chain = "predr" if via == "redirect" else "pretp"
+            for fr in build_dns_hijack_fragments(
+                    family=family, dns_port=dns_hijack_port,
+                    lan_ifaces=lan_ifaces, via=via, mark=mark):
+                rc, _o, e = _run(_nft_add_rule(dns_chain, fr))
+                rule_count += 1
+                if rc != 0:
+                    errors.append("%s(dns): %s" % (dns_chain, e.strip()))
+
+    # IPv6 anti-leak: дропнуть весь форвард-IPv6, если v6 не проксируем и
+    # политика drop (parity с iptables build_ipv6_block_rules).
+    if "v6" not in families and ipv6_policy == "drop":
+        _chain("fwd6", "{ type filter hook forward priority 0; policy accept; }")
+        rc, _o, e = _run(_nft_add_rule("fwd6", build_ipv6_block_fragment()))
+        rule_count += 1
+        if rc != 0:
+            errors.append("fwd6: %s" % e.strip())
 
     ok = not errors
     if ok:

--- a/tests/test_singbox_transparent_nft.py
+++ b/tests/test_singbox_transparent_nft.py
@@ -2,6 +2,7 @@
 """Unit-тесты для nft-builder'ов прозрачного проксирования."""
 
 import unittest
+from unittest import mock
 
 from core import singbox_transparent_nft as nft
 
@@ -73,6 +74,89 @@ class TestNftAddRule(unittest.TestCase):
         argv = nft._nft_add_rule("pretp", "meta mark set 1")
         self.assertEqual(argv[:6],
                          ["nft", "add", "rule", "inet", "sbtproxy", "pretp"])
+
+
+class TestDnsHijackFragments(unittest.TestCase):
+
+    def test_via_tproxy(self):
+        frags = nft.build_dns_hijack_fragments(
+            family="v4", dns_port=1053, via="tproxy")
+        self.assertTrue(any("th dport 53" in f for f in frags))
+        self.assertTrue(any("tproxy ip to :1053" in f for f in frags))
+        self.assertTrue(any("{ tcp, udp }" in f for f in frags))
+
+    def test_via_redirect(self):
+        frags = nft.build_dns_hijack_fragments(
+            family="v4", dns_port=1053, via="redirect")
+        self.assertTrue(any("redirect to :1053" in f for f in frags))
+        self.assertTrue(all("tproxy" not in f for f in frags))
+
+    def test_lan_ifaces_per_iface(self):
+        frags = nft.build_dns_hijack_fragments(
+            family="v4", dns_port=1053, lan_ifaces=["br0", "br1"])
+        self.assertEqual(len(frags), 2)
+        self.assertTrue(all(f.startswith('iifname "br') for f in frags))
+
+    def test_v6_uses_ip6(self):
+        frags = nft.build_dns_hijack_fragments(
+            family="v6", dns_port=1053, via="tproxy")
+        self.assertTrue(any("tproxy ip6 to :1053" in f for f in frags))
+
+
+class TestIpv6BlockFragment(unittest.TestCase):
+
+    def test_fragment(self):
+        self.assertEqual(nft.build_ipv6_block_fragment(),
+                         "meta nfproto ipv6 drop")
+
+
+class TestNftApplyWiring(unittest.TestCase):
+    """apply() через мок _run (без рута): DNS-hijack и IPv6-drop должны
+    доезжать до нужных цепочек."""
+
+    def _run_apply(self, **kw):
+        cmds = []
+
+        def fake(args, timeout=10):
+            cmds.append(" ".join(args))
+            return (0, "", "")
+
+        with mock.patch.object(nft, "_run", fake), \
+             mock.patch.object(nft, "available", lambda: True):
+            res = nft.apply(**kw)
+        return res, cmds
+
+    def test_dns_redirect_goes_to_nat_chain(self):
+        res, cmds = self._run_apply(mode="redirect", tcp_port=1100,
+                                    dns_hijack_port=1053, families=("v4",))
+        self.assertTrue(res["ok"])
+        self.assertTrue(any("rule inet sbtproxy predr" in c
+                            and "th dport 53" in c
+                            and "redirect to :1053" in c for c in cmds))
+
+    def test_dns_tproxy_goes_to_mangle_chain(self):
+        res, cmds = self._run_apply(mode="tproxy", tcp_port=1100,
+                                    dns_hijack_port=1053, families=("v4",))
+        self.assertTrue(any("rule inet sbtproxy pretp" in c
+                            and "th dport 53" in c and "tproxy" in c
+                            for c in cmds))
+
+    def test_ipv6_drop_created_when_policy_drop(self):
+        res, cmds = self._run_apply(mode="tproxy", tcp_port=1100,
+                                    families=("v4",), ipv6_policy="drop")
+        self.assertTrue(any("chain inet sbtproxy fwd6" in c for c in cmds))
+        self.assertTrue(any("rule inet sbtproxy fwd6" in c
+                            and "meta nfproto ipv6 drop" in c for c in cmds))
+
+    def test_no_ipv6_drop_when_allow(self):
+        _res, cmds = self._run_apply(mode="tproxy", tcp_port=1100,
+                                     families=("v4",), ipv6_policy="allow")
+        self.assertFalse(any("fwd6" in c for c in cmds))
+
+    def test_no_ipv6_drop_when_v6_proxied(self):
+        _res, cmds = self._run_apply(mode="tproxy", tcp_port=1100,
+                                     families=("v4", "v6"), ipv6_policy="drop")
+        self.assertFalse(any("fwd6" in c for c in cmds))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
… с iptables)

Раньше nft-вариант прозрачного проксирования принимал dns_hijack_port и ipv6_policy, но не разворачивал их (в отличие от iptables-ветки). Допилено по аналогии:

- build_dns_hijack_fragments(): перехват udp/tcp dport 53 на DNS-порт движка. via='redirect' → `redirect` в nat-цепочку predr; via='tproxy' → `tproxy … meta mark set` в mangle-цепочку pretp. `th dport 53` ловит оба протокола. apply() выбирает via как iptables: redirect-режим → redirect, иначе tproxy.
- build_ipv6_block_fragment(): `meta nfproto ipv6 drop` в отдельной forward-цепочке fwd6 (inet-таблица различает семейство по nfproto) — аналог `ip6tables -A FORWARD -j DROP`. Создаётся только при v6 вне families и ipv6_policy=drop. remove() снимает его вместе с таблицей.

Синтаксис проверен `nft --check` на nft 1.0.9. Тесты: builder'ы (redirect/ tproxy/v6/интерфейсы), wiring apply() через мок _run (правильные цепочки, fwd6 только при drop и v4-only).

https://claude.ai/code/session_01FN5Ur2inCz4qyJaMFzGbov