### PR TITLE
fix(firewall): #151 — деградация при отсутствии multiport/connbytes/N…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,29 @@
   правила в именованные цепочки `nfqws_post/nfqws_pre/nfqws_nat` без
   комментариев (снимаются через `_remove_ipt_named_chain`). На системах, где
   `comment` есть, поведение прежнее. Покрыто тестами (`tests/test_firewall_rules.py`).
+- **Firewall: продолжение #151 — на Keenetic/Entware падали и оставшиеся 9 из
+  14 правил (`No chain/target/match` после фикса `-m comment`), сайты по-
+  прежнему не работали** ([#151](https://github.com/avatarDD/zapret-gui/issues/151)).
+  Причина — порт-зависимые правила опираются на матчи/цель, которые на mips-
+  Keenetic нередко отсутствуют и **не ставятся через opkg** («Unknown package»
+  для `iptables-mod-comment`/`-nfqueue`/`-conntrack-extra`): `-m multiport`
+  (`xt_multiport`), `-m connbytes` (`xt_connbytes`) и цель `NFQUEUE`
+  (`xt_NFQUEUE`). Теперь и Python-путь (`core/firewall.py`), и shell-путь
+  автозапуска/реаплая (`core/firewall_persistence.py`) **детектируют каждую
+  фичу** одноразовой пробой в таблице `filter` и **деградируют**:
+  - нет `multiport` → список портов разбивается на отдельные правила
+    `--dport/--sport` (нативный матч tcp/udp понимает одиночный порт и диапазон
+    `X:Y`, так что `3478:3481` сохраняется как диапазон);
+  - нет `connbytes` → выкидывается ограничитель «первые N пакетов» (в очередь
+    идут все пакеты целевых портов; внутренний cutoff nfqws2 всё равно
+    отрабатывает);
+  - нет `NFQUEUE` → обход через iptables физически невозможен: громкая ошибка
+    с подсказкой (догрузить модуль ядра / перейти на nftables), правила не
+    льются впустую.
+  Диагностика предпосылок (`GET /api/diagnostics/prerequisites`) теперь
+  отдельно проверяет реальные iptables-матчи/цель и отличает «NFQUEUE нет»
+  (ошибка) от «multiport/connbytes нет» (предупреждение, обход работает).
+  Покрыто тестами (`tests/test_firewall_rules.py`, `tests/test_firewall_persistence.py`).
 - **zapret2 1.0 ломал nfqws2: `LUA ERROR … Incompatible NFQWS2_COMPAT_VER`
   ([#151](https://github.com/avatarDD/zapret-gui/issues/151)).** zapret2 1.0
   сменил `lua_compat_ver` 5→6 (несовместимое изменение: везде `WRITEABLE`→

--- a/core/diagnostics.py
+++ b/core/diagnostics.py
@@ -1339,6 +1339,61 @@ def check_strategy_prerequisites():
                     "сканирование смысла не имеет.",
         })
 
+    # 5b. iptables-матчи/цель (issue #151). На Entware/Keenetic NFQUEUE-цель и
+    #     матчи multiport / connbytes нередко вынесены в отдельные модули ядра,
+    #     которых нет и которые не ставятся через opkg ("Unknown package"). Без
+    #     NFQUEUE обход невозможен; без multiport/connbytes firewall.py
+    #     деградирует сам (порты → отдельные --dport/--sport, без ограничителя).
+    #     Проверка пробует реальные матчи/цель в одноразовой цепочке filter.
+    ipt = _find_binary(["iptables"])
+    if ipt:
+        try:
+            from core.firewall import FirewallManager
+            fw = FirewallManager()
+            caps = {
+                "nfqueue": fw._ipt_probe_rule(
+                    ipt, ["-j", "NFQUEUE", "--queue-num", "0",
+                          "--queue-bypass"]),
+                "multiport": fw._ipt_probe_rule(
+                    ipt, ["-p", "tcp", "-m", "multiport", "--dports",
+                          "80,443", "-j", "RETURN"]),
+                "connbytes": fw._ipt_probe_rule(
+                    ipt, ["-p", "tcp", "-m", "connbytes",
+                          "--connbytes-dir=original",
+                          "--connbytes-mode=packets", "--connbytes", "1:5",
+                          "-j", "RETURN"]),
+            }
+            checks["iptables_caps"] = caps
+            if not caps["nfqueue"]:
+                issues.append({
+                    "id": "ipt_nfqueue_target_missing", "severity": "error",
+                    "title": "iptables: цель NFQUEUE недоступна",
+                    "detail": "iptables не знает target NFQUEUE "
+                              "(модуль ядра xt_NFQUEUE / nfnetlink_queue).",
+                    "hint": "Без неё пакеты не попадают в nfqws2 — обход не "
+                            "работает. Догрузите модуль ядра NFQUEUE (на "
+                            "Keenetic — соответствующий компонент netfilter) "
+                            "или перейдите на nftables.",
+                })
+            else:
+                degraded = [n for n in ("multiport", "connbytes")
+                            if not caps[n]]
+                if degraded:
+                    issues.append({
+                        "id": "ipt_match_degraded", "severity": "warning",
+                        "title": "iptables: недоступны матчи %s"
+                                 % ", ".join(degraded),
+                        "detail": "Нет: %s (модули xt_%s)."
+                                  % (", ".join(degraded),
+                                     ", xt_".join(degraded)),
+                        "hint": "Не блокер: zapret-gui разобьёт списки портов "
+                                "на отдельные правила --dport/--sport и уберёт "
+                                "ограничитель connbytes (issue #151). Правила "
+                                "станут многословнее, но обход работает.",
+                    })
+        except Exception:
+            pass
+
     # 6. conntrack tcp_be_liberal (best-effort)
     be_liberal = _read_sysctl_int(
         "/proc/sys/net/netfilter/nf_conntrack_tcp_be_liberal")

--- a/core/firewall.py
+++ b/core/firewall.py
@@ -140,6 +140,22 @@ class FirewallManager:
     # При положительном детекте отсутствия — переходим на именованные цепочки.
     _comment_support_cache: dict = {}
 
+    # Кэш поддержки матчей/целей, которые на Entware/Keenetic нередко вынесены
+    # в отдельные (часто отсутствующие и неустанавливаемые через opkg) модули
+    # ядра:
+    #   multiport → iptables-mod-multiport (xt_multiport)
+    #   connbytes → iptables-mod-conntrack-extra (xt_connbytes)
+    #   NFQUEUE   → iptables-mod-nfqueue (xt_NFQUEUE / nfnetlink_queue)
+    # Без них правила с этими матчами/целью падали с «No chain/target/match by
+    # that name», и обход не поднимался даже после фикса `-m comment` — ровно
+    # 9 правил из 14 (все порт-зависимые) (issue #151). Деградируем:
+    #   нет multiport → список портов бьём на отдельные --dport/--sport;
+    #   нет connbytes → выкидываем ограничитель первых пакетов;
+    #   нет NFQUEUE   → обход через iptables невозможен (громкая ошибка).
+    _multiport_support_cache: dict = {}
+    _connbytes_support_cache: dict = {}
+    _nfqueue_support_cache: dict = {}
+
     def __init__(self):
         self._lock = threading.Lock()
         self._applied = False
@@ -440,26 +456,17 @@ class FirewallManager:
         self._rules_info = rules
         return ok
 
-    def _comment_supported(self, ipt_cmd) -> bool:
-        """Доступен ли матч `-m comment` (xt_comment) у этого iptables.
+    def _ipt_probe_rule(self, ipt_cmd, probe_args) -> bool:
+        """Можно ли добавить правило `probe_args` (есть ли матч/цель в ядре).
 
-        На Entware/Keenetic это отдельный модуль (пакет iptables-mod-comment),
-        которого часто нет. Без него каждое правило с `-m comment` падает с
-        «No chain/target/match by that name», и весь обход не поднимается
-        (issue #151) — тогда мы кладём правила в именованные цепочки nfqws_*
-        без комментариев.
-
-        Переключаемся на запасной путь ТОЛЬКО при положительном детекте
-        отсутствия матча. Если проверить не удалось (нет iptables, нет прав,
-        иная ошибка) — считаем, что comment есть, и НЕ меняем привычное
-        поведение. Результат кэшируется по бинарнику.
+        Создаёт одноразовую цепочку в таблице filter (она есть всегда и вне
+        тракта трафика), пытается добавить туда правило и смотрит на «No chain/
+        target/match by that name». Возвращает False ТОЛЬКО при таком явном
+        вердикте; при любой иной ошибке или невозможности проверить — True (не
+        ломаем рабочий путь). За собой пробную цепочку чистит.
         """
-        cache = FirewallManager._comment_support_cache
-        if ipt_cmd in cache:
-            return cache[ipt_cmd]
-
         wait = FirewallManager._iptables_wait_flag(ipt_cmd)
-        probe = "ZGUI_CMT_PROBE"
+        probe = "ZGUI_PROBE"
 
         def _raw(args):
             try:
@@ -470,26 +477,92 @@ class FirewallManager:
             except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
                 return None
 
-        supported = True  # по умолчанию — как раньше (не ломаем рабочий путь)
-        # Одноразовая цепочка в таблице filter (всегда есть), вне тракта трафика.
+        available = True
         _raw(["-t", "filter", "-N", probe])
-        add = _raw(["-t", "filter", "-A", probe,
-                    "-m", "comment", "--comment", "zgui", "-j", "RETURN"])
+        add = _raw(["-t", "filter", "-A", probe] + probe_args)
         if (add is not None and add.returncode != 0
                 and "No chain/target/match" in (add.stderr or "")):
-            supported = False
+            available = False
         _raw(["-t", "filter", "-F", probe])
         _raw(["-t", "filter", "-X", probe])
+        return available
 
-        cache[ipt_cmd] = supported
-        if not supported:
-            log.warning(
-                "%s: матч `-m comment` недоступен (нет пакета "
-                "iptables-mod-comment?). Правила пойдут в именованные цепочки "
-                "nfqws_* без комментариев (issue #151)." % ipt_cmd,
-                source="firewall",
-            )
-        return supported
+    def _feature_supported(self, ipt_cmd, cache, probe_args, warn=None) -> bool:
+        """Кэшируемый детект матча/цели (см. _ipt_probe_rule).
+
+        `warn % ipt_cmd` логируется один раз — при первом обнаружении
+        отсутствия. Результат кэшируется по бинарнику.
+        """
+        if ipt_cmd in cache:
+            return cache[ipt_cmd]
+        ok = self._ipt_probe_rule(ipt_cmd, probe_args)
+        cache[ipt_cmd] = ok
+        if not ok and warn:
+            log.warning(warn % ipt_cmd, source="firewall")
+        return ok
+
+    def _comment_supported(self, ipt_cmd) -> bool:
+        """Доступен ли матч `-m comment` (xt_comment) у этого iptables.
+
+        На Entware/Keenetic это отдельный модуль (пакет iptables-mod-comment),
+        которого часто нет. Без него каждое правило с `-m comment` падает с
+        «No chain/target/match by that name», и весь обход не поднимается
+        (issue #151) — тогда мы кладём правила в именованные цепочки nfqws_*
+        без комментариев. Переключаемся ТОЛЬКО при положительном детекте
+        отсутствия матча.
+        """
+        return self._feature_supported(
+            ipt_cmd, FirewallManager._comment_support_cache,
+            ["-m", "comment", "--comment", "zgui", "-j", "RETURN"],
+            warn="%s: матч `-m comment` недоступен (нет пакета "
+                 "iptables-mod-comment?). Правила пойдут в именованные цепочки "
+                 "nfqws_* без комментариев (issue #151).",
+        )
+
+    def _multiport_supported(self, ipt_cmd) -> bool:
+        """Доступен ли матч `-m multiport` (xt_multiport).
+
+        Если нет — список портов нельзя задать одним правилом; бьём его на
+        отдельные правила `--dport/--sport` (нативный матч tcp/udp понимает и
+        одиночный порт, и диапазон X:Y) (issue #151).
+        """
+        return self._feature_supported(
+            ipt_cmd, FirewallManager._multiport_support_cache,
+            ["-p", "tcp", "-m", "multiport", "--dports", "80,443",
+             "-j", "RETURN"],
+            warn="%s: матч `-m multiport` недоступен (нет "
+                 "iptables-mod-multiport?). Списки портов разбиваем на "
+                 "отдельные правила --dport/--sport (issue #151).",
+        )
+
+    def _connbytes_supported(self, ipt_cmd) -> bool:
+        """Доступен ли матч `-m connbytes` (xt_connbytes).
+
+        Если нет — выкидываем ограничитель «первые N пакетов»; в очередь пойдут
+        все пакеты целевых портов (дороже по CPU, но обход работает; cutoff
+        внутри nfqws2 всё равно отрабатывает) (issue #151).
+        """
+        return self._feature_supported(
+            ipt_cmd, FirewallManager._connbytes_support_cache,
+            ["-p", "tcp", "-m", "connbytes", "--connbytes-dir=original",
+             "--connbytes-mode=packets", "--connbytes", "1:5", "-j", "RETURN"],
+            warn="%s: матч `-m connbytes` недоступен (нет "
+                 "iptables-mod-conntrack-extra?). Ограничитель первых пакетов "
+                 "отключён — в очередь идут все пакеты целевых портов "
+                 "(issue #151).",
+        )
+
+    def _nfqueue_supported(self, ipt_cmd) -> bool:
+        """Доступна ли цель NFQUEUE (xt_NFQUEUE / nfnetlink_queue).
+
+        Без неё ядро физически не может отдать пакеты в nfqws2 — обход через
+        iptables невозможен (issue #151). Детект — единственный, по которому
+        мы прекращаем накат правил (см. _apply_ipt_family).
+        """
+        return self._feature_supported(
+            ipt_cmd, FirewallManager._nfqueue_support_cache,
+            ["-j", "NFQUEUE", "--queue-num", "0", "--queue-bypass"],
+        )
 
     def _ensure_named_chain(self, ipt_cmd, table, hook, name) -> None:
         """Создать/очистить нашу цепочку `name` и подцепить её к `hook`.
@@ -552,6 +625,27 @@ class FirewallManager:
         udp_pkt_in = self._extra.get("udp_pkt_in", 3)
         do_nat = (ipt_cmd == "iptables")  # MASQUERADE только для IPv4
 
+        # NFQUEUE — фундаментальная цель: без неё ядро не отдаёт пакеты в
+        # nfqws2 и обход не работает в принципе. Если её нет — громко сообщаем
+        # и не накатываем ничего (иначе все порт-правила тихо падают). Детект
+        # консервативен (False только на явное «No chain/target/match»), потому
+        # ему можно доверять (issue #151).
+        if not self._nfqueue_supported(ipt_cmd):
+            log.error(
+                "%s: цель NFQUEUE недоступна — нет модуля ядра xt_NFQUEUE / "
+                "nfnetlink_queue. Перенаправление трафика в nfqws2 невозможно, "
+                "обход работать не будет. Догрузите модуль ядра NFQUEUE (на "
+                "Keenetic — соответствующий компонент netfilter) либо перейдите "
+                "на nftables (issue #151)." % ipt_cmd,
+                source="firewall",
+            )
+            return False
+
+        # multiport / connbytes на Entware/Keenetic тоже бывают недоступны —
+        # тогда деградируем (см. _multiport_supported / _connbytes_supported).
+        use_multiport = self._multiport_supported(ipt_cmd)
+        use_connbytes = self._connbytes_supported(ipt_cmd)
+
         # На Entware/Keenetic матч `-m comment` (xt_comment) — отдельный
         # пакет iptables-mod-comment, которого может не быть. Тогда КАЖДОЕ
         # правило падало с «No chain/target/match by that name» и обход не
@@ -583,6 +677,32 @@ class FirewallManager:
         def _nfq():
             return ["-j", "NFQUEUE", "--queue-num", str(qnum), "--queue-bypass"]
 
+        def _port_bases(prefix, proto, direction, ports):
+            """Базовые правила под список портов.
+
+            С `-m multiport` — одно правило на весь список. Без него — по
+            одному правилу на каждый токен через нативный `--dport/--sport`
+            (он понимает и одиночный порт, и диапазон вида `3478:3481`).
+            `direction` — "dports" (исходящие) или "sports" (ответные).
+            """
+            if use_multiport:
+                return [prefix + ["-p", proto, "-m", "multiport",
+                                  "--%s" % direction, ports]]
+            single = "--dport" if direction == "dports" else "--sport"
+            bases = []
+            for tok in str(ports).split(","):
+                tok = tok.strip()
+                if tok:
+                    bases.append(prefix + ["-p", proto, single, tok])
+            return bases
+
+        def _connbytes_args(conn_dir, limit):
+            """Ограничитель «первые N пакетов»; пусто, если connbytes нет."""
+            if not use_connbytes:
+                return []
+            return ["-m", "connbytes", "--connbytes-dir=%s" % conn_dir,
+                    "--connbytes-mode=packets", "--connbytes", "1:%d" % limit]
+
         # Для каждого WAN или без привязки к интерфейсу
         oif_list = wan_ifaces if wan_ifaces else [None]
 
@@ -611,36 +731,35 @@ class FirewallManager:
 
             # 3) TCP → NFQUEUE (первые N пакетов + fin/rst)
             if ports_tcp:
-                base = ([ipt_cmd, "-t", "mangle", "-A", post_chain]
-                        + oif_args + ["-p", "tcp", "-m", "multiport",
-                                      "--dports", ports_tcp])
-                if self._run_cmd(
-                    base + ["-m", "connbytes", "--connbytes-dir=original",
-                            "--connbytes-mode=packets", "--connbytes",
-                            "1:%d" % tcp_pkt] + _comment() + _nfq()
-                ):
-                    rules.append("%s TCP %s → NFQUEUE %d%s" % (
-                        family_tag, ports_tcp, qnum, tag))
-                else:
-                    ok = False
-                self._run_cmd(base + ["--tcp-flags", "fin", "fin"]
-                              + _comment() + _nfq())
-                self._run_cmd(base + ["--tcp-flags", "rst", "rst"]
-                              + _comment() + _nfq())
+                prefix = [ipt_cmd, "-t", "mangle", "-A", post_chain] + oif_args
+                logged = False
+                for base in _port_bases(prefix, "tcp", "dports", ports_tcp):
+                    if self._run_cmd(base + _connbytes_args("original", tcp_pkt)
+                                     + _comment() + _nfq()):
+                        if not logged:
+                            rules.append("%s TCP %s → NFQUEUE %d%s" % (
+                                family_tag, ports_tcp, qnum, tag))
+                            logged = True
+                    else:
+                        ok = False
+                    self._run_cmd(base + ["--tcp-flags", "fin", "fin"]
+                                  + _comment() + _nfq())
+                    self._run_cmd(base + ["--tcp-flags", "rst", "rst"]
+                                  + _comment() + _nfq())
 
             # 4) UDP → NFQUEUE
             if ports_udp:
-                if self._run_cmd(
-                    [ipt_cmd, "-t", "mangle", "-A", post_chain] + oif_args
-                    + ["-p", "udp", "-m", "multiport", "--dports", ports_udp,
-                       "-m", "connbytes", "--connbytes-dir=original",
-                       "--connbytes-mode=packets", "--connbytes",
-                       "1:%d" % udp_pkt] + _comment() + _nfq()
-                ):
-                    rules.append("%s UDP %s → NFQUEUE %d%s" % (
-                        family_tag, ports_udp, qnum, tag))
-                else:
-                    ok = False
+                prefix = [ipt_cmd, "-t", "mangle", "-A", post_chain] + oif_args
+                logged = False
+                for base in _port_bases(prefix, "udp", "dports", ports_udp):
+                    if self._run_cmd(base + _connbytes_args("original", udp_pkt)
+                                     + _comment() + _nfq()):
+                        if not logged:
+                            rules.append("%s UDP %s → NFQUEUE %d%s" % (
+                                family_tag, ports_udp, qnum, tag))
+                            logged = True
+                    else:
+                        ok = False
 
             # ───────── NAT POSTROUTING (только IPv4) ─────────
             # nfqws2 переписывает адреса → повторный MASQUERADE для UDP.
@@ -665,28 +784,21 @@ class FirewallManager:
                 + ["-j", "RETURN"]
             )
             if ports_tcp:
-                base = ([ipt_cmd, "-t", "mangle", "-A", pre_chain]
-                        + iif_args + ["-p", "tcp", "-m", "multiport",
-                                      "--sports", ports_tcp])
-                self._run_cmd(
-                    base + ["-m", "connbytes", "--connbytes-dir=reply",
-                            "--connbytes-mode=packets", "--connbytes",
-                            "1:%d" % tcp_pkt_in] + _comment() + _nfq()
-                )
-                self._run_cmd(base + ["--tcp-flags", "syn,ack", "syn,ack"]
-                              + _comment() + _nfq())
-                self._run_cmd(base + ["--tcp-flags", "fin", "fin"]
-                              + _comment() + _nfq())
-                self._run_cmd(base + ["--tcp-flags", "rst", "rst"]
-                              + _comment() + _nfq())
+                prefix = [ipt_cmd, "-t", "mangle", "-A", pre_chain] + iif_args
+                for base in _port_bases(prefix, "tcp", "sports", ports_tcp):
+                    self._run_cmd(base + _connbytes_args("reply", tcp_pkt_in)
+                                  + _comment() + _nfq())
+                    self._run_cmd(base + ["--tcp-flags", "syn,ack", "syn,ack"]
+                                  + _comment() + _nfq())
+                    self._run_cmd(base + ["--tcp-flags", "fin", "fin"]
+                                  + _comment() + _nfq())
+                    self._run_cmd(base + ["--tcp-flags", "rst", "rst"]
+                                  + _comment() + _nfq())
             if ports_udp:
-                self._run_cmd(
-                    [ipt_cmd, "-t", "mangle", "-A", pre_chain] + iif_args
-                    + ["-p", "udp", "-m", "multiport", "--sports", ports_udp,
-                       "-m", "connbytes", "--connbytes-dir=reply",
-                       "--connbytes-mode=packets", "--connbytes",
-                       "1:%d" % udp_pkt_in] + _comment() + _nfq()
-                )
+                prefix = [ipt_cmd, "-t", "mangle", "-A", pre_chain] + iif_args
+                for base in _port_bases(prefix, "udp", "sports", ports_udp):
+                    self._run_cmd(base + _connbytes_args("reply", udp_pkt_in)
+                                  + _comment() + _nfq())
 
         return ok
 

--- a/core/firewall_persistence.py
+++ b/core/firewall_persistence.py
@@ -81,12 +81,66 @@ _iface_list() {
     if [ -n "$WAN_IFACES" ]; then echo "$WAN_IFACES"; else echo "__ALL__"; fi
 }
 
+# Можно ли добавить правило (есть ли матч/цель в ядре)? $1=CMD, далее — аргументы
+# правила. Возврат 1 ТОЛЬКО на явное «No chain/target/match by that name», иначе 0
+# (не ломаем рабочий путь). Проба — в одноразовой цепочке таблицы filter.
+_fw_probe() {
+    _pc="$1"; shift
+    "$_pc" -w -t filter -N ZGUI_PROBE 2>/dev/null
+    _po=$("$_pc" -w -t filter -A ZGUI_PROBE "$@" 2>&1); _pr=$?
+    "$_pc" -w -t filter -F ZGUI_PROBE 2>/dev/null
+    "$_pc" -w -t filter -X ZGUI_PROBE 2>/dev/null
+    if [ "$_pr" != "0" ] && echo "$_po" | grep -q "No chain/target/match"; then
+        return 1
+    fi
+    return 0
+}
+
+# Детект multiport/connbytes/NFQUEUE для $1=CMD (issue #151). На Entware/Keenetic
+# эти модули нередко отсутствуют и неустановимы через opkg — тогда деградируем.
+_fw_caps() {
+    _cc="$1"
+    HAVE_MULTIPORT=1; HAVE_CONNBYTES=1; HAVE_NFQUEUE=1
+    _fw_probe "$_cc" -p tcp -m multiport --dports 80,443 -j RETURN || HAVE_MULTIPORT=0
+    _fw_probe "$_cc" -p tcp -m connbytes --connbytes-dir=original --connbytes-mode=packets --connbytes 1:5 -j RETURN || HAVE_CONNBYTES=0
+    _fw_probe "$_cc" -j NFQUEUE --queue-num 0 --queue-bypass || HAVE_NFQUEUE=0
+}
+
+# Фрагмент(ы) матча портов, по одному на строку. С multiport — одна строка;
+# без него — по строке на токен (одиночный порт или диапазон X:Y, понятный
+# базовому матчу tcp/udp). $1=proto $2=dports|sports $3=ports.
+_fw_port_match() {
+    _proto="$1"; _dir="$2"; _ports="$3"
+    if [ "$HAVE_MULTIPORT" = "1" ]; then
+        echo "-p $_proto -m multiport --$_dir $_ports"
+        return 0
+    fi
+    if [ "$_dir" = "dports" ]; then _single="--dport"; else _single="--sport"; fi
+    _oifs="$IFS"; IFS=,
+    for _p in $_ports; do
+        IFS="$_oifs"
+        [ -n "$_p" ] && echo "-p $_proto $_single $_p"
+        IFS=,
+    done
+    IFS="$_oifs"
+}
+
+# Фрагмент ограничителя «первые N пакетов»; пусто, если connbytes недоступен.
+# $1=original|reply $2=limit.
+_fw_cb() {
+    [ "$HAVE_CONNBYTES" = "1" ] || return 0
+    echo "-m connbytes --connbytes-dir=$1 --connbytes-mode=packets --connbytes 1:$2"
+}
+
 _firewall_start() {
     CMD="$1"
+    _fw_caps "$CMD"
+    if [ "$HAVE_NFQUEUE" != "1" ]; then
+        echo "zapret-gui: NFQUEUE недоступна для $CMD (нет xt_NFQUEUE / nfnetlink_queue) — обход не работает (issue #151)" >&2
+        return 0
+    fi
     JNFQ="$(_jnfq)"
     CONN_CHECK="-m mark ! --mark $MARK_PROCESSED"
-    CB_ORIG="-m connbytes --connbytes-dir=original --connbytes-mode=packets"
-    CB_REPLY="-m connbytes --connbytes-dir=reply --connbytes-mode=packets"
 
     $CMD -w -t mangle -N $IPT_GROUP_POST 2>/dev/null
     $CMD -w -t mangle -F $IPT_GROUP_POST
@@ -108,12 +162,19 @@ _firewall_start() {
 
         $CMD -w -t mangle -A $IPT_GROUP_POST $OIF -m connmark --mark $MARK_EXCLUDE -j RETURN
         if [ -n "$PORTS_UDP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p udp -m multiport --dports $PORTS_UDP $CB_ORIG --connbytes 1:$MAX_PKT_OUT_UDP $JNFQ
+            CB="$(_fw_cb original $MAX_PKT_OUT_UDP)"
+            _fw_port_match udp dports "$PORTS_UDP" | while read -r PM; do
+                [ -n "$PM" ] && $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK $PM $CB $JNFQ
+            done
         fi
         if [ -n "$PORTS_TCP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP $CB_ORIG --connbytes 1:$MAX_PKT_OUT $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags fin fin $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK -p tcp -m multiport --dports $PORTS_TCP --tcp-flags rst rst $JNFQ
+            CB="$(_fw_cb original $MAX_PKT_OUT)"
+            _fw_port_match tcp dports "$PORTS_TCP" | while read -r PM; do
+                [ -n "$PM" ] || continue
+                $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK $PM $CB $JNFQ
+                $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK $PM --tcp-flags fin fin $JNFQ
+                $CMD -w -t mangle -A $IPT_GROUP_POST $OIF $CONN_CHECK $PM --tcp-flags rst rst $JNFQ
+            done
         fi
 
         if [ "$CMD" = "iptables" ]; then
@@ -123,13 +184,20 @@ _firewall_start() {
         $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m connmark --mark $MARK_EXCLUDE -j RETURN
         $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF -m mark --mark $MARK_PROCESSED -j RETURN
         if [ -n "$PORTS_UDP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p udp -m multiport --sports $PORTS_UDP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
+            CB="$(_fw_cb reply $MAX_PKT_IN)"
+            _fw_port_match udp sports "$PORTS_UDP" | while read -r PM; do
+                [ -n "$PM" ] && $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK $PM $CB $JNFQ
+            done
         fi
         if [ -n "$PORTS_TCP" ]; then
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP $CB_REPLY --connbytes 1:$MAX_PKT_IN $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags syn,ack syn,ack $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags fin fin $JNFQ
-            $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK -p tcp -m multiport --sports $PORTS_TCP --tcp-flags rst rst $JNFQ
+            CB="$(_fw_cb reply $MAX_PKT_IN)"
+            _fw_port_match tcp sports "$PORTS_TCP" | while read -r PM; do
+                [ -n "$PM" ] || continue
+                $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK $PM $CB $JNFQ
+                $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK $PM --tcp-flags syn,ack syn,ack $JNFQ
+                $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK $PM --tcp-flags fin fin $JNFQ
+                $CMD -w -t mangle -A $IPT_GROUP_PRE $IIF $CONN_CHECK $PM --tcp-flags rst rst $JNFQ
+            done
         fi
     done
 }

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.21.31"
+GUI_VERSION = "0.21.32"

--- a/tests/test_firewall_persistence.py
+++ b/tests/test_firewall_persistence.py
@@ -97,5 +97,91 @@ class TestInstallRemove(unittest.TestCase):
             self.assertEqual(res["installed"], [])
 
 
+# Фейковый iptables: пробные правила (-A ZGUI_PROBE) проваливаются с
+# «No chain/target/match» для матчей/цели, помеченных как недоступные через
+# env FAKE_NO_{MULTIPORT,CONNBYTES,NFQUEUE}; реальные правила печатаются как
+# «RULE: …». Цепочечные команды (-N/-F/-X/-C) и переходы — всегда успех.
+_FAKE_IPTABLES = r"""
+iptables() {
+    case " $* " in
+      *" -A ZGUI_PROBE "*)
+        case " $* " in
+          *" -m multiport "*) [ "$FAKE_NO_MULTIPORT" = 1 ] && { echo "iptables: No chain/target/match by that name." >&2; return 1; } ;;
+          *" -m connbytes "*) [ "$FAKE_NO_CONNBYTES" = 1 ] && { echo "iptables: No chain/target/match by that name." >&2; return 1; } ;;
+          *" NFQUEUE "*) [ "$FAKE_NO_NFQUEUE" = 1 ] && { echo "iptables: No chain/target/match by that name." >&2; return 1; } ;;
+        esac
+        return 0 ;;
+      *" -N "*|*" -F "*|*" -X "*|*" -C "*) return 0 ;;
+      *) echo "RULE: $*"; return 0 ;;
+    esac
+}
+"""
+
+_SHELL_PRELUDE = (
+    'QUEUE_NUM=300\nPORTS_TCP="80,443,8443"\nPORTS_UDP="443,3478:3481"\n'
+    'MAX_PKT_OUT=20\nMAX_PKT_OUT_UDP=5\nMAX_PKT_IN=10\n'
+    'MARK_PROCESSED="0x40000000/0x40000000"\n'
+    'MARK_EXCLUDE="0x20000000/0x20000000"\n'
+    'IPV6_ENABLED=0\nWAN_IFACES="eth3"\n'
+)
+
+
+def _run_shell_firewall(no_multiport=0, no_connbytes=0, no_nfqueue=0):
+    """Запустить shell `firewall_iptables` с фейковым iptables; вернуть строки
+    реально накатанных правил (без префикса RULE:)."""
+    sh = shutil.which("sh")
+    if not sh:
+        return None
+    env = dict(os.environ,
+               FAKE_NO_MULTIPORT=str(no_multiport),
+               FAKE_NO_CONNBYTES=str(no_connbytes),
+               FAKE_NO_NFQUEUE=str(no_nfqueue))
+    script = (_SHELL_PRELUDE + _FAKE_IPTABLES
+              + fp.FIREWALL_SH_FUNCTIONS + "\nfirewall_iptables\n")
+    r = subprocess.run([sh], input=script, text=True,
+                       capture_output=True, env=env)
+    return [ln[len("RULE: "):] for ln in r.stdout.splitlines()
+            if ln.startswith("RULE: ")]
+
+
+@unittest.skipUnless(shutil.which("sh"), "нет sh")
+class TestShellDegradation(unittest.TestCase):
+    """issue #151: shell-путь (автозапуск S99zapret + reapply-хук) должен так же
+    деградировать при отсутствии multiport / connbytes / NFQUEUE на Keenetic."""
+
+    def test_all_available_uses_multiport_and_connbytes(self):
+        rules = _run_shell_firewall()
+        self.assertTrue(any("-m multiport" in r for r in rules))
+        self.assertTrue(any("connbytes" in r for r in rules))
+        self.assertTrue(any("NFQUEUE --queue-num 300" in r for r in rules))
+
+    def test_no_multiport_splits_into_per_port_rules(self):
+        rules = _run_shell_firewall(no_multiport=1)
+        self.assertFalse(any("multiport" in r for r in rules))
+        self.assertTrue(any(r.endswith("--dport 80 -j NFQUEUE "
+                                       "--queue-num 300 --queue-bypass")
+                            or "--dport 80 " in (r + " ") for r in rules))
+        self.assertTrue(any("--sport 443 " in (r + " ") for r in rules))
+        # диапазон сохраняется как нативный X:Y
+        self.assertTrue(any("--dport 3478:3481" in r for r in rules))
+
+    def test_no_connbytes_drops_limiter(self):
+        rules = _run_shell_firewall(no_connbytes=1)
+        self.assertFalse(any("connbytes" in r for r in rules))
+        # но NFQUEUE-перехват остаётся
+        self.assertTrue(any("NFQUEUE" in r for r in rules))
+
+    def test_no_multiport_and_connbytes_together(self):
+        rules = _run_shell_firewall(no_multiport=1, no_connbytes=1)
+        self.assertFalse(any("multiport" in r for r in rules))
+        self.assertFalse(any("connbytes" in r for r in rules))
+        self.assertTrue(any("NFQUEUE" in r for r in rules))
+        self.assertTrue(any("MASQUERADE" in r for r in rules))
+
+    def test_no_nfqueue_emits_no_rules(self):
+        rules = _run_shell_firewall(no_nfqueue=1)
+        self.assertEqual(rules, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_firewall_rules.py
+++ b/tests/test_firewall_rules.py
@@ -22,6 +22,9 @@ def _capture_iptables(fw):
 
     with mock.patch.object(fw, "_run_cmd", side_effect=fake_run), \
             mock.patch.object(fw, "_comment_supported", return_value=True), \
+            mock.patch.object(fw, "_multiport_supported", return_value=True), \
+            mock.patch.object(fw, "_connbytes_supported", return_value=True), \
+            mock.patch.object(fw, "_nfqueue_supported", return_value=True), \
             mock.patch("core.firewall.shutil.which", return_value="/sbin/iptables"):
         rules = []
         fw._apply_ipt_family(
@@ -81,6 +84,12 @@ class TestIptablesNoCommentFallback(unittest.TestCase):
                 side_effect=lambda c: self.captured.append(c) or True), \
                 mock.patch.object(self.fw, "_comment_supported",
                                   return_value=False), \
+                mock.patch.object(self.fw, "_multiport_supported",
+                                  return_value=True), \
+                mock.patch.object(self.fw, "_connbytes_supported",
+                                  return_value=True), \
+                mock.patch.object(self.fw, "_nfqueue_supported",
+                                  return_value=True), \
                 mock.patch.object(self.fw, "_ensure_named_chain") as ens, \
                 mock.patch("core.firewall.shutil.which",
                            return_value="/sbin/iptables"):
@@ -156,6 +165,133 @@ class TestCommentProbe(unittest.TestCase):
     def test_supported_when_failure_is_unrelated(self):
         # иная ошибка (например, нет прав) → не ломаем рабочий путь
         self.assertTrue(self._run_with(1, "Permission denied"))
+
+
+def _apply_with_caps(multiport, connbytes, nfqueue, ports_tcp="80,443",
+                     ports_udp="443,3478:3481"):
+    """Прогнать _apply_ipt_family с заданной доступностью матчей/цели.
+
+    Возвращает (ok, плоский список строк-команд). comment-режим включён
+    (правила во встроенных цепочках), чтобы не отвлекаться на named-chains.
+    """
+    fw = FirewallManager()
+    captured = []
+    with mock.patch.object(fw, "_run_cmd",
+                           side_effect=lambda c: captured.append(c) or True), \
+            mock.patch.object(fw, "_comment_supported", return_value=True), \
+            mock.patch.object(fw, "_multiport_supported", return_value=multiport), \
+            mock.patch.object(fw, "_connbytes_supported", return_value=connbytes), \
+            mock.patch.object(fw, "_nfqueue_supported", return_value=nfqueue), \
+            mock.patch("core.firewall.shutil.which", return_value="/sbin/iptables"):
+        rules = []
+        ok = fw._apply_ipt_family(
+            "iptables", 300, ports_tcp, ports_udp,
+            "0x40000000", 20, 5, ["eth0"], rules,
+        )
+    return ok, [" ".join(c) for c in captured]
+
+
+class TestIptablesNoMultiportConnbytesFallback(unittest.TestCase):
+    """issue #151: на Keenetic/Entware матчи `-m multiport` / `-m connbytes`
+    нередко недоступны и неустановимы через opkg. Тогда после фикса `-m comment`
+    падали ровно 9 порт-зависимых правил из 14. Теперь порты бьются на отдельные
+    --dport/--sport, а ограничитель connbytes выкидывается."""
+
+    def setUp(self):
+        self.ok, self.flat = _apply_with_caps(
+            multiport=False, connbytes=False, nfqueue=True)
+
+    def test_no_multiport_match(self):
+        self.assertFalse(any("multiport" in c for c in self.flat),
+                         "без xt_multiport не должно быть `-m multiport`")
+
+    def test_no_connbytes_match(self):
+        self.assertFalse(any("connbytes" in c for c in self.flat),
+                         "без xt_connbytes не должно быть `-m connbytes`")
+
+    def test_per_port_rules_emitted(self):
+        # каждый TCP-порт получает своё правило --dport/--sport
+        self.assertTrue(any("--dport 80 " in (c + " ") for c in self.flat))
+        self.assertTrue(any("--dport 443 " in (c + " ") for c in self.flat))
+        self.assertTrue(any("--sport 80 " in (c + " ") for c in self.flat))
+        self.assertTrue(any("--sport 443 " in (c + " ") for c in self.flat))
+
+    def test_udp_range_preserved_as_native_range(self):
+        # диапазон портов остаётся диапазоном (нативный матч понимает X:Y)
+        self.assertTrue(any("--dport 3478:3481" in c for c in self.flat))
+        self.assertTrue(any("--sport 3478:3481" in c for c in self.flat))
+
+    def test_nfqueue_still_present(self):
+        self.assertTrue(any("NFQUEUE" in c for c in self.flat))
+
+    def test_tcp_flags_still_present_per_port(self):
+        self.assertTrue(any("--dport 80 --tcp-flags fin fin" in c
+                            for c in self.flat))
+        self.assertTrue(any("--sport 443 --tcp-flags syn,ack syn,ack" in c
+                            for c in self.flat))
+
+
+class TestIptablesNfqueueMissingAborts(unittest.TestCase):
+    """issue #151: если цели NFQUEUE нет — обход невозможен, правила не льём."""
+
+    def setUp(self):
+        self.ok, self.flat = _apply_with_caps(
+            multiport=True, connbytes=True, nfqueue=False)
+
+    def test_returns_false(self):
+        self.assertFalse(self.ok)
+
+    def test_no_rules_emitted(self):
+        # ни одного NFQUEUE/MASQUERADE-правила — выходим до их наката
+        self.assertFalse(any("NFQUEUE" in c for c in self.flat))
+        self.assertFalse(any("MASQUERADE" in c for c in self.flat))
+
+
+class TestIptablesMultiportOnlyMissing(unittest.TestCase):
+    """connbytes есть, multiport нет — connbytes сохраняется на каждом
+    раздробленном правиле."""
+
+    def setUp(self):
+        self.ok, self.flat = _apply_with_caps(
+            multiport=False, connbytes=True, nfqueue=True)
+
+    def test_connbytes_kept_on_split_rules(self):
+        cb = [c for c in self.flat if "connbytes" in c]
+        self.assertTrue(cb)
+        # connbytes-правила тоже без multiport
+        self.assertFalse(any("multiport" in c for c in cb))
+
+
+class TestFeatureProbe(unittest.TestCase):
+    """Обобщённый детект матча/цели: False ТОЛЬКО на «No chain/target/match»."""
+
+    def setUp(self):
+        self.fw = FirewallManager()
+
+    def _probe(self, add_rc, add_stderr):
+        class _R:
+            def __init__(self, rc, err=""):
+                self.returncode, self.stderr, self.stdout = rc, err, ""
+
+        def fake(cmd, **kw):
+            return _R(add_rc, add_stderr) if "-A" in cmd else _R(0)
+
+        with mock.patch("core.firewall.subprocess.run", side_effect=fake), \
+                mock.patch.object(FirewallManager, "_iptables_wait_flag",
+                                  return_value=["-w"]):
+            return self.fw._ipt_probe_rule(
+                "iptables", ["-j", "NFQUEUE", "--queue-num", "0",
+                             "--queue-bypass"])
+
+    def test_unavailable_on_no_chain_target_match(self):
+        self.assertFalse(self._probe(
+            1, "iptables: No chain/target/match by that name."))
+
+    def test_available_on_success(self):
+        self.assertTrue(self._probe(0, ""))
+
+    def test_available_on_unrelated_error(self):
+        self.assertTrue(self._probe(2, "Permission denied (you must be root)"))
 
 
 class TestNftablesRules(unittest.TestCase):


### PR DESCRIPTION
…FQUEUE на Keenetic

После фикса `-m comment` на mips-Keenetic падали оставшиеся 9 из 14 правил (`iptables: No chain/target/match by that name`), обход не работал. Порт- зависимые правила опираются на матчи/цель, которые там нередко вынесены в отдельные модули ядра и НЕ ставятся через opkg («Unknown package» для iptables-mod-comment/-nfqueue/-conntrack-extra): `-m multiport`, `-m connbytes`, цель `NFQUEUE`.

Теперь и Python-путь (core/firewall.py), и shell-путь автозапуска/реаплая (core/firewall_persistence.py) детектируют каждую фичу одноразовой пробой в таблице filter и деградируют:
- нет multiport → список портов разбивается на отдельные --dport/--sport (нативный матч tcp/udp понимает одиночный порт и диапазон X:Y);
- нет connbytes → выкидывается ограничитель «первые N пакетов»;
- нет NFQUEUE → обход невозможен: громкая ошибка с подсказкой, правила не льются.

Диагностика предпосылок отдельно проверяет реальные iptables-матчи/цель и отличает «нет NFQUEUE» (ошибка) от «нет multiport/connbytes» (предупреждение, обход работает).

Покрыто тестами (tests/test_firewall_rules.py, tests/test_firewall_persistence.py), проверено на реальном iptables: полностью деградированный набор правил принимается без ошибок.

https://claude.ai/code/session_01QZa9UccSfCKQyK5EPezwhK