### PR TITLE
fix(singbox): #149 — TPROXY-недоступность видна заранее, подсказка ве…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,24 @@
   отдельно проверяет реальные iptables-матчи/цель и отличает «NFQUEUE нет»
   (ошибка) от «multiport/connbytes нет» (предупреждение, обход работает).
   Покрыто тестами (`tests/test_firewall_rules.py`, `tests/test_firewall_persistence.py`).
+- **sing-box «Прозрачное проксирование»: на роутерах без TPROXY (напр.
+  Keenetic без `modprobe` и без пакета `iptables-mod-tproxy`) режимы
+  tproxy/hybrid молча упирались в `No chain/target/match`**
+  ([#149](https://github.com/avatarDD/zapret-gui/issues/149)). Бэкенд уже
+  отдавал понятную подсказку вместо HTTP 500, но узнать о проблеме можно было
+  только методом «применил → упало», а текст вёл к `opkg`/`modprobe`, которых
+  на такой прошивке нет. Теперь:
+  - `GET /api/singbox/transparent/status` отдаёт `tproxy_supported` (реальный
+    iptables-зонд цели TPROXY, **кэшированный** — статус поллится каждые 5с,
+    живой зонд на каждый poll недопустим; `?refresh=1` перепроверяет);
+    `apply()`-префлайт держит кэш свежим;
+  - UI заранее подсвечивает режимы `tproxy`/`hybrid` как недоступные, рисует
+    предупреждение и рекомендует `redirect`/TUN — пользователь не упирается в
+    ошибку вслепую;
+  - подсказка при отсутствии TPROXY переписана: ведёт с рабочих альтернатив
+    (redirect/TUN), а установку модуля подаёт как опцию «если прошивка
+    поддерживает» (на Keenetic — нет).
+  Покрыто тестами (`tests/test_singbox_transparent.py`).
 - **zapret2 1.0 ломал nfqws2: `LUA ERROR … Incompatible NFQWS2_COMPAT_VER`
   ([#151](https://github.com/avatarDD/zapret-gui/issues/151)).** zapret2 1.0
   сменил `lua_compat_ver` 5→6 (несовместимое изменение: везде `WRITEABLE`→

--- a/api/singbox.py
+++ b/api/singbox.py
@@ -972,11 +972,22 @@ def register(app):
         ipt_v4 = tp.available("v4")
         nft_ok = nft.available()
         backend = "iptables" if ipt_v4 else ("nftables" if nft_ok else "none")
+        # Доступна ли цель TPROXY (issue #149) — чтобы UI заранее предупредил,
+        # что режимы tproxy/hybrid на этом роутере не поднимутся, и предложил
+        # redirect/TUN. Для iptables — кэшированный реальный зонд (status
+        # поллится каждые 5с); для nft пока не блокируем (юзеры с проблемой —
+        # на iptables-роутерах). force=refresh позволяет перепроверить вручную.
+        force = request.query.get("refresh") in ("1", "true", "yes")
+        if backend == "iptables":
+            tproxy_supported = tp.tproxy_supported_cached("v4", force=force)
+        else:
+            tproxy_supported = backend != "none"
         return {"ok": True,
                 "available_v4": ipt_v4,
                 "available_v6": tp.available("v6"),
                 "available_nft": nft_ok,
                 "backend": backend,
+                "tproxy_supported": tproxy_supported,
                 "settings": saved}
 
     @app.route("/api/singbox/configs/<name>/transparent-inbounds",

--- a/core/singbox_transparent.py
+++ b/core/singbox_transparent.py
@@ -99,19 +99,31 @@ DEFAULT_BYPASS_V6 = [
 
 # Сообщение, когда на роутере нет netfilter-цели TPROXY (issue #149):
 # у пользователя bypass-RETURN'ы проходят, но `-A ... -j TPROXY` падает с
-# «No chain/target/match by that name» — нет модуля ядра/расширения.
+# «No chain/target/match by that name» — нет модуля ядра/расширения. Ведём
+# с рабочих альтернатив (redirect/TUN): на части прошивок (Keenetic) ни
+# modprobe, ни пакета iptables-mod-tproxy нет и поставить их нельзя.
 _TPROXY_MISSING_MSG = (
-    "Режим '%s' требует netfilter-цель TPROXY, но её нет на этом роутере "
-    "(не установлен пакет iptables-mod-tproxy или не загружен модуль ядра "
-    "xt_TPROXY/nf_tproxy). Установите: opkg install iptables-mod-tproxy — и "
-    "при необходимости загрузите модуль: modprobe xt_TPROXY nf_tproxy_ipv4. "
-    "Либо выберите режим 'redirect' (только TCP, TPROXY не нужен) или "
-    "включите TUN-режим на вкладке sing-box — он тоже не требует TPROXY."
+    "Режим '%s' требует netfilter-цель TPROXY, но на этом роутере её нет "
+    "(не загружен модуль ядра xt_TPROXY/nf_tproxy и нет пакета "
+    "iptables-mod-tproxy). Рабочие альтернативы без TPROXY: режим "
+    "'redirect' (заворачивает TCP, работает почти везде; минус — UDP/QUIC "
+    "идёт напрямую) либо TUN-режим на вкладке sing-box. Если прошивка "
+    "поддерживает модуль — можно установить его (opkg install "
+    "iptables-mod-tproxy и, при наличии, modprobe xt_TPROXY nf_tproxy_ipv4); "
+    "на части прошивок (напр. Keenetic) модуля и modprobe нет — тогда "
+    "используйте redirect/TUN."
 )
 
 # Модули ядра, нужные для TPROXY (на Keenetic часто просто не загружены).
 _TPROXY_KMODS = ("nf_tproxy_ipv4", "nf_tproxy_ipv6", "xt_TPROXY",
                  "xt_socket", "xt_mark")
+
+# Кэш результата tproxy_available() по семейству. Нужен, потому что
+# /api/singbox/transparent/status поллится UI каждые 5с, а сам зонд делает
+# реальные iptables-вставки (+ modprobe) — на каждый poll это недопустимо.
+# apply()-префлайт пишет сюда свежий результат, чтобы статус не «залипал»
+# после установки/выгрузки модуля (issue #149).
+_tproxy_cache: dict = {}
 
 
 def _run(args, timeout=10):
@@ -446,6 +458,24 @@ def tproxy_available(family: str = "v4") -> bool:
     return True
 
 
+def tproxy_supported_cached(family: str = "v4", force: bool = False) -> bool:
+    """Кэшированный `tproxy_available` для частого поллинга статуса.
+
+    UI тянет /transparent/status каждые 5с — живой iptables-зонд на каждый
+    poll недопустим (вставка/удаление правила + modprobe). Поэтому статус
+    использует кэш; apply()-префлайт обновляет его свежим значением, а
+    `force=True` принудительно перепроверяет (issue #149).
+    """
+    if force or family not in _tproxy_cache:
+        _tproxy_cache[family] = tproxy_available(family)
+    return _tproxy_cache[family]
+
+
+def reset_tproxy_cache() -> None:
+    """Сбросить кэш доступности TPROXY (напр. после смены окружения)."""
+    _tproxy_cache.clear()
+
+
 def choose_backend(prefer: str = "auto") -> str:
     """
     Выбрать firewall-бэкенд: 'iptables' | 'nftables' | 'none'.
@@ -512,8 +542,16 @@ def apply(*, mode: str,
     # Префлайт TPROXY (issue #149): если режим требует TPROXY, а цели нет
     # ни на одном семействе — не пытаемся ставить правила (иначе сыплем
     # сырыми «No chain/target/match»), а отдаём ОДНУ понятную подсказку.
+    # Заодно обновляем кэш доступности, чтобы /transparent/status (UI рисует
+    # предупреждение по нему) сразу отразил реальный результат зонда.
     if mode in ("tproxy", "hybrid"):
-        if not any(available(f) and tproxy_available(f) for f in families):
+        supported = False
+        for f in families:
+            tp_ok = tproxy_available(f)
+            _tproxy_cache[f] = tp_ok
+            if available(f) and tp_ok:
+                supported = True
+        if not supported:
             msg = _TPROXY_MISSING_MSG % mode
             log.warning("singbox transparent: %s" % msg, source="singbox")
             return {"ok": False, "mode": mode, "errors": [msg],

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.21.32"
+GUI_VERSION = "0.21.33"

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -420,6 +420,51 @@ class TestTproxyCapability(unittest.TestCase):
             self.assertTrue(tp.tproxy_available("v4"))
 
 
+class TestTproxyCache(unittest.TestCase):
+    """issue #149: /transparent/status поллится каждые 5с, поэтому доступность
+    TPROXY кэшируется (живой iptables-зонд на каждый poll недопустим), а
+    apply()-префлайт держит кэш свежим, чтобы UI сразу убрал/показал
+    предупреждение."""
+
+    def setUp(self):
+        tp.reset_tproxy_cache()
+
+    def tearDown(self):
+        tp.reset_tproxy_cache()
+
+    def test_cached_probes_once_until_force(self):
+        calls = {"n": 0}
+
+        def _probe(family="v4"):
+            calls["n"] += 1
+            return True
+
+        with mock.patch.object(tp, "tproxy_available", _probe):
+            self.assertTrue(tp.tproxy_supported_cached("v4"))
+            self.assertTrue(tp.tproxy_supported_cached("v4"))
+            self.assertEqual(calls["n"], 1)          # второй раз — из кэша
+            self.assertTrue(tp.tproxy_supported_cached("v4", force=True))
+            self.assertEqual(calls["n"], 2)          # force → перепроверка
+
+    def test_apply_preflight_populates_cache(self):
+        # TPROXY недоступна → apply пишет False в кэш; status потом отдаёт его
+        # БЕЗ повторного зонда.
+        with mock.patch.object(tp, "_run", lambda *a, **k: (0, "", "")), \
+                mock.patch.object(tp, "available", lambda family="v4": True), \
+                mock.patch.object(tp, "tproxy_available",
+                                  lambda family="v4": False):
+            r = tp.apply(mode="tproxy", tcp_port=1100,
+                         families=("v4",), backend="iptables")
+        self.assertEqual(r.get("need"), "tproxy")
+
+        # Теперь кэш уже False — зонд дёргаться не должен.
+        def _boom(family="v4"):
+            raise AssertionError("tproxy_available не должен вызываться — кэш")
+
+        with mock.patch.object(tp, "tproxy_available", _boom):
+            self.assertFalse(tp.tproxy_supported_cached("v4"))
+
+
 class TestSbinPath(unittest.TestCase):
     """PATH без /sbin (systemd/обычный юзер) не должен прятать iptables —
     available() ложно показывал «iptables недоступен» на Debian."""

--- a/web/js/components/help.js
+++ b/web/js/components/help.js
@@ -221,18 +221,21 @@ const Help = (() => {
               '4. (Пере)запустите конфиг. «Снять» убирает firewall-правила.' +
               '<br><br>' +
               '<b>Если пишет «No chain/target/match by that name» (TPROXY).</b> ' +
-              'На роутере нет цели TPROXY. GUI сам пытается подгрузить модуль; ' +
-              'если не вышло — поставьте пакет <code>opkg install ' +
-              'iptables-mod-tproxy</code> и загрузите <code>modprobe ' +
-              'xt_TPROXY nf_tproxy_ipv4</code>, либо используйте <b>Redirect</b> ' +
-              'или <b>TUN-режим</b> (TPROXY не требуется).',
+              'На роутере нет цели TPROXY (модуля ядра <code>xt_TPROXY</code>). ' +
+              'GUI определяет это заранее и подсветит режимы tproxy/hybrid как ' +
+              'недоступные. Самый простой выход — <b>Redirect</b> (TCP без ' +
+              'TPROXY) или <b>TUN-режим</b>. Если прошивка поддерживает модуль, ' +
+              'можно поставить <code>opkg install iptables-mod-tproxy</code> и ' +
+              'загрузить <code>modprobe xt_TPROXY nf_tproxy_ipv4</code> — но на ' +
+              'части прошивок (напр. Keenetic) ни пакета, ни <code>modprobe</code> ' +
+              'нет, и поставить TPROXY нельзя; тогда только redirect/TUN.',
         examples: [
             { label: 'Типичный роутер: весь трафик, TCP+UDP',
               code: 'Режим: tproxy\nTCP-порт: 1100\nDNS-hijack: 1100 (или 0)\nIPv6: глушить (если прокси только v4)\nТрафик роутера: выкл' },
             { label: 'Максимальная совместимость (без модуля ядра)',
               code: 'Режим: redirect\nTCP-порт: 1100\n(UDP/QUIC пойдёт напрямую)' },
-            { label: 'Нет TPROXY — починка',
-              code: 'opkg install iptables-mod-tproxy\nmodprobe xt_TPROXY nf_tproxy_ipv4\n# либо переключиться на redirect' },
+            { label: 'Нет TPROXY (напр. Keenetic без модуля) — что делать',
+              code: '# вариант 1: режим redirect (TCP) или TUN — без TPROXY\n# вариант 2 (если прошивка поддерживает):\nopkg install iptables-mod-tproxy\nmodprobe xt_TPROXY nf_tproxy_ipv4' },
         ],
     });
 

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -289,6 +289,13 @@ const SingboxDashboardPage = (() => {
         if (!box) return;
         const backend = transparent ? (transparent.backend || 'none') : 'none';
         const avail = backend !== 'none';
+        // issue #149: на роутере может не быть netfilter-цели TPROXY (нет
+        // модуля ядра / пакета, на Keenetic — и modprobe нет). Тогда режимы
+        // tproxy/hybrid не поднимутся; предупреждаем заранее и ведём на
+        // redirect/TUN. Поле может отсутствовать на старых бэкендах → дефолт true.
+        const tproxySupported = !transparent
+            || transparent.tproxy_supported !== false;
+        const tpUnavail = avail && !tproxySupported;
         const applied = transparent && transparent.settings
                         && transparent.settings.mode;
         const cfgOpts = ['<option value="">— выбрать конфиг —</option>'].concat(
@@ -307,6 +314,14 @@ const SingboxDashboardPage = (() => {
                 ${backend === 'nftables' ? '<br><span style="color:#6aa;">iptables не найден — будет использован бэкенд <strong>nftables</strong>.</span>' : ''}
                 ${avail ? '' : '<br><span style="color:#e58;">Ни iptables, ни nftables не найдены — применение работать не будет.</span>'}
             </p>
+            ${tpUnavail ? `<div style="margin:0 0 10px; padding:9px 11px; border-radius:6px;
+                background:rgba(230,170,40,0.12); border:1px solid rgba(230,170,40,0.4);
+                color:#d9a521; font-size:12px; line-height:1.45;">
+                ⚠ Цель <b>TPROXY</b> на этом роутере недоступна (нет модуля ядра
+                <code>xt_TPROXY</code>/<code>nf_tproxy</code>). Режимы
+                <b>tproxy</b> и <b>hybrid</b> не поднимутся. Используйте
+                <b>redirect</b> (TCP, без TPROXY) или <b>TUN</b>-режим.
+                </div>` : ''}
             ${tpNote ? `<div style="margin:0 0 10px; padding:9px 11px; border-radius:6px;
                 background:rgba(229,80,136,0.12); border:1px solid rgba(229,80,136,0.35);
                 color:#e58; font-size:12px; line-height:1.45; white-space:pre-wrap;">${escapeHtml(tpNote)}</div>` : ''}
@@ -319,9 +334,9 @@ const SingboxDashboardPage = (() => {
                 <label class="text-muted">Режим</label>
                 <select class="form-control" style="max-width:220px;"
                         onchange="SingboxDashboardPage.setTp('mode', this.value)">
-                    ${opt('tproxy', tpForm.mode, 'TProxy (TCP+UDP)')}
-                    ${opt('redirect', tpForm.mode, 'Redirect (только TCP)')}
-                    ${opt('hybrid', tpForm.mode, 'Hybrid (TCP redirect + UDP tproxy)')}
+                    ${opt('tproxy', tpForm.mode, 'TProxy (TCP+UDP)' + (tpUnavail ? ' — нет на этом роутере' : ''))}
+                    ${opt('redirect', tpForm.mode, 'Redirect (только TCP)' + (tpUnavail ? ' — рекомендуется' : ''))}
+                    ${opt('hybrid', tpForm.mode, 'Hybrid (TCP redirect + UDP tproxy)' + (tpUnavail ? ' — нет на этом роутере' : ''))}
                 </select>
 
                 <label class="text-muted">TCP-порт</label>


### PR DESCRIPTION
…дёт на redirect/TUN

На роутерах без netfilter-цели TPROXY (напр. Keenetic: нет modprobe и нет пакета iptables-mod-tproxy) режимы tproxy/hybrid не поднимаются. Бэкенд уже отдавал понятную подсказку вместо HTTP 500, но:
- узнать о проблеме можно было только «применил → упало»;
- текст подсказки вёл к opkg/modprobe, которых на такой прошивке нет.

Теперь:
- /api/singbox/transparent/status отдаёт tproxy_supported (реальный зонд цели TPROXY, кэшированный — статус поллится каждые 5с; ?refresh=1 перепроверяет); apply()-префлайт держит кэш свежим;
- UI заранее подсвечивает tproxy/hybrid как недоступные, рисует предупреждение и рекомендует redirect/TUN;
- подсказка при отсутствии TPROXY переписана: ведёт с рабочих альтернатив (redirect/TUN), установку модуля подаёт как опцию «если прошивка поддерживает».

Покрыто тестами (tests/test_singbox_transparent.py); проверено на реальном iptables: зонд/кэш и graceful-префлайт работают.

https://claude.ai/code/session_01QZa9UccSfCKQyK5EPezwhK