### PR TITLE
feat(singbox): FakeIP «умный доменный роутинг» — podkop-уровень, муль…

### DIFF
--- a/.claude/skills/singbox/SKILL.md
+++ b/.claude/skills/singbox/SKILL.md
@@ -247,10 +247,11 @@ endpoint заменил старый `type:wireguard` outbound.
 > но это путь к будущим поломкам. DNS-перехват у нас делается route-action
 > `hijack-dns`, а не спец-outbound `dns` (тот удалён, §9).
 >
-> ⚠️ **Реальность нашего кода:** мы **НЕ эмитим секцию `dns`** и **не
-> используем fakeip**. `hijack-dns` добавляется только в transparent-режиме с
-> `dns_port>0`. Доменный selective-routing через TUN у нас сделан на уровне
-> ОС, а не DNS движка — см. §13.
+> ⚠️ **Реальность нашего кода:** базовый unified/OS-routing путь **НЕ эмитит
+> секцию `dns`** (`hijack-dns` — только в transparent-режиме с `dns_port>0`).
+> НО есть отдельный **FakeIP-режим** (`build_fakeip_config` /
+> `core/singbox_fakeip`), который генерирует полноценную `dns`-секцию с FakeIP
+> + `hijack-dns` — см. §13.
 
 ---
 
@@ -374,12 +375,27 @@ TUN, sing-box по fake-IP восстанавливает домен и прок
 - Режим «весь трафик» (`auto_route=true`) без секции `dns` → системный
   резолвер может течь.
 
-**Возможность (НЕ реализовано):** опциональный режим **fakeip + hijack-dns**
-для платформ, где резолвер можно перенаправить в sing-box (OpenWrt; Keenetic —
-через dns-override). Дал бы podkop-уровень надёжности доменного роутинга.
-Требует генерации `dns`-секции (`servers:[{type:fakeip,...},{type:udp,...}]`,
-`fakeip:{enabled,inet4_range}`) + `experimental.cache_file.store_fakeip` в
-`singbox_config`.
+**FakeIP-режим (РЕАЛИЗОВАН)** — podkop-уровень надёжности доменного роутинга,
+мультиплатформенно:
+- `singbox_config.build_fakeip_config()` — собирает self-contained конфиг:
+  TUN(`auto_route`+`strict_route`[+`auto_redirect` на nft]) + `dns` с FakeIP +
+  `{action:sniff}` + `{protocol:dns,action:hijack-dns}` + domain/cidr-правила
+  → `proxy-out`; `experimental.cache_file.store_fakeip`. `ip_is_private→direct`.
+- `make_fakeip_dns()` — DNS-секция в **двух форматах**: legacy (`address:fakeip`
+  + top-level `dns.fakeip`; валиден 1.8–1.13) и typed (`type:fakeip`; 1.12+).
+- `core/singbox_fakeip.py` — оркестратор: резолвит прокси из ссылки
+  (`uri_to_outbound`) или из конфига; домены берёт из hostlist'ов
+  пользователя + формы; **подбирает формат DNS под версию и проверяет
+  `sing-box check`-ом ДО сохранения** (`SingboxManager.check_text`), legacy↔typed
+  fallback; `route_all` отключает FakeIP (весь трафик в прокси).
+- API: `GET /api/singbox/fakeip/options`, `POST /api/singbox/fakeip/build`.
+- UI: карточка «Умный доменный роутинг (FakeIP)» на дашборде sing-box
+  (`web/js/pages/singbox.js`): ссылка/конфиг прокси, чекбоксы списков,
+  доп. домены/подсети, прямой DNS, режим «весь трафик».
+
+Ограничение: FakeIP требует, чтобы клиентский DNS доходил до движка. На nft
+это делает `auto_redirect`; иначе LAN-клиенты должны ходить через роутер
+(шлюз/DNS) — об этом в карточке есть подсказка.
 
 ---
 

--- a/api/singbox.py
+++ b/api/singbox.py
@@ -91,6 +91,7 @@ REST API для sing-box.
   POST   /api/singbox/traffic/reset         — обнулить счётчики (body: {tags}?)
 """
 
+import re
 import threading
 from bottle import request, response
 
@@ -605,6 +606,48 @@ def register(app):
         res = get_singbox_manager().set_debug(enabled)
         if not res.get("ok"):
             response.status = 500
+        return res
+
+    # ─────── FakeIP-роутинг (умный доменный роутинг) ────────────
+
+    @app.route("/api/singbox/fakeip/options")
+    def singbox_fakeip_options():
+        """Данные для формы FakeIP: версия, hostlist'ы, конфиги, nft."""
+        response.content_type = "application/json; charset=utf-8"
+        from core.singbox_fakeip import build_options
+        return build_options()
+
+    @app.route("/api/singbox/fakeip/build", method="POST")
+    def singbox_fakeip_build():
+        """Собрать и сохранить FakeIP-конфиг (проверяется `sing-box check`)."""
+        response.content_type = "application/json; charset=utf-8"
+        from core.singbox_fakeip import build_and_save
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+
+        def _list(v):
+            if isinstance(v, list):
+                return [str(x).strip() for x in v if str(x).strip()]
+            if isinstance(v, str):
+                return [s.strip() for s in re.split(r"[\s,]+", v) if s.strip()]
+            return []
+
+        res = build_and_save(
+            name=(body.get("name") or "fakeip"),
+            proxy_link=(body.get("proxy_link") or ""),
+            proxy_config=(body.get("proxy_config") or ""),
+            hostlists=_list(body.get("hostlists")),
+            domains=_list(body.get("domains")),
+            cidrs=_list(body.get("cidrs")),
+            direct_dns=(body.get("direct_dns") or "local"),
+            route_all=bool(body.get("route_all")),
+            tun_iface=(body.get("tun_iface") or "singbox-tun"),
+            stack=(body.get("stack") or "system"),
+        )
+        if not res.get("ok"):
+            response.status = 400
         return res
 
     # ─────── outbounds CRUD (для Outbounds Builder UI) ────────────

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -32,6 +32,7 @@ sing-box принимает JSON (не INI-like .conf). Структура сх�
 import base64
 import binascii
 import json
+import re
 from typing import Any
 
 
@@ -333,7 +334,8 @@ def make_tun_inbound(*, interface_name: str = "singbox-tun",
                      address=None, mtu: int = 9000,
                      stack: str = "system",
                      auto_route: bool = False,
-                     strict_route: bool = False) -> dict:
+                     strict_route: bool = False,
+                     auto_redirect: bool = False) -> dict:
     """
     Собрать TUN-inbound sing-box (создаёт сетевой интерфейс
     `interface_name`). Используются ТОЛЬКО актуальные поля 1.11+/1.13:
@@ -344,10 +346,15 @@ def make_tun_inbound(*, interface_name: str = "singbox-tun",
     заворачивать, решает страница «Selective routing» (ip rule/nftset).
     Для режима «весь трафик» выставьте auto_route=True.
 
+    auto_redirect=True (только вместе с auto_route и на nftables-платформах,
+    sing-box 1.10+) — sing-box сам ставит nftables-redirect, чтобы забирать
+    и ПЕРЕСЫЛАЕМЫЙ трафик LAN-клиентов (нужно для FakeIP-роутинга без ручной
+    правки firewall). На iptables-only платформах не включаем.
+
     stack: 'system' (быстрее, нужен модуль tun ядра — на Keenetic есть),
            'gvisor' (userspace, переносимее) или 'mixed'.
     """
-    return {
+    ib = {
         "type": "tun",
         "tag": _TUN_TAG,
         "interface_name": interface_name or "singbox-tun",
@@ -357,6 +364,9 @@ def make_tun_inbound(*, interface_name: str = "singbox-tun",
         "strict_route": bool(strict_route),
         "stack": stack or "system",
     }
+    if auto_redirect and auto_route:
+        ib["auto_redirect"] = True
+    return ib
 
 
 def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
@@ -472,6 +482,154 @@ def find_tun_interface(cfg: dict) -> str:
         if isinstance(ib, dict) and ib.get("type") == "tun":
             return ib.get("interface_name") or ""
     return ""
+
+
+# ─────── FakeIP-роутинг (умный доменный роутинг через движок) ───────
+#
+# Полный self-contained конфиг «как podkop, но мультиплатформенно»: TUN с
+# auto_route + DNS с FakeIP. Клиентский DNS перехватывается движком
+# (hijack-dns), домены из списка получают fake-IP (198.18.0.0/15), их трафик
+# по fake-IP роутится в прокси-outbound; остальное идёт напрямую. Это решает
+# проблемы ipset-пути: нет DNS-leak, работает для CDN/QUIC/ECH (роутинг по
+# домену из DNS, до handshake). См. skill §13.
+
+FAKEIP_INET4 = "198.18.0.0/15"
+FAKEIP_INET6 = "fc00::/18"
+
+_IPV4_RE = re.compile(r"^\d{1,3}(?:\.\d{1,3}){3}$")
+
+
+def _norm_suffix_domains(domains) -> list:
+    """Нормализовать домены под `domain_suffix`: lower, без схемы/www/*., без
+    дублей; отбросить IP/localhost (это не суффиксы)."""
+    out, seen = [], set()
+    for d in (domains or []):
+        s = str(d).strip().lower()
+        for pre in ("https://", "http://", "//", "*.", "www."):
+            if s.startswith(pre):
+                s = s[len(pre):]
+        s = s.split("/")[0].rstrip(".")
+        if not s or s in seen:
+            continue
+        if s == "localhost" or _IPV4_RE.match(s) or ":" in s:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def make_fakeip_dns(*, proxied_domains=None, direct_dns: str = "local",
+                    typed: bool = False, fakeip: bool = True) -> dict:
+    """
+    DNS-секция для FakeIP-роутинга.
+
+    typed=False → legacy-формат (`address`/top-level `dns.fakeip`), валиден
+    sing-box 1.8–1.13 (legacy удалён в 1.14). typed=True → формат 1.12+
+    (`type:`/`type:fakeip`). Оркестратор (core/singbox_fakeip) пробует один,
+    при провале `sing-box check` — другой.
+
+    direct_dns: 'local'/'' → системный резолвер (без host-поля, переносимо);
+    голый IP → udp-резолвер. fakeip=False → секция без FakeIP (для режима
+    «весь трафик»), только direct-сервер, чтобы hijack-dns был куда отдавать.
+    """
+    dd = (direct_dns or "local").strip()
+    is_local = dd in ("", "local")
+    is_ip = bool(_IPV4_RE.match(dd))
+
+    if typed:
+        if is_local:
+            direct_srv = {"tag": "dns-direct", "type": "local"}
+        elif is_ip:
+            direct_srv = {"tag": "dns-direct", "type": "udp", "server": dd,
+                          "detour": "direct"}
+        else:                                   # https:// / tls:// и т.п.
+            direct_srv = {"tag": "dns-direct", "type": "local"}
+    else:
+        direct_srv = {"tag": "dns-direct", "address": dd if dd else "local"}
+        if not is_local:
+            direct_srv["detour"] = "direct"
+
+    servers = [direct_srv]
+    rules = []
+    proxied = _norm_suffix_domains(proxied_domains)
+
+    if fakeip:
+        if typed:
+            servers.append({"tag": "dns-fakeip", "type": "fakeip",
+                            "inet4_range": FAKEIP_INET4,
+                            "inet6_range": FAKEIP_INET6})
+        else:
+            servers.append({"tag": "dns-fakeip", "address": "fakeip"})
+        if proxied:
+            rules.append({"domain_suffix": proxied, "server": "dns-fakeip"})
+
+    dns = {"servers": servers, "rules": rules,
+           "final": "dns-direct", "independent_cache": True}
+    if fakeip and not typed:
+        dns["fakeip"] = {"enabled": True,
+                         "inet4_range": FAKEIP_INET4,
+                         "inet6_range": FAKEIP_INET6}
+    return dns
+
+
+def build_fakeip_config(*, proxy_outbound: dict,
+                        proxied_domains=None, proxied_cidrs=None,
+                        route_all: bool = False,
+                        direct_dns: str = "local",
+                        tun_iface: str = "singbox-tun",
+                        tun_address=None, mtu: int = 9000,
+                        stack: str = "system",
+                        auto_redirect: bool = False,
+                        typed_dns: bool = False) -> dict:
+    """
+    Собрать полный sing-box-конфиг FakeIP-роутинга.
+
+    proxy_outbound — готовый dict outbound'а (vless/ss/...); его тег
+    принудительно = 'proxy-out'. route_all=True → весь трафик в прокси
+    (FakeIP не нужен, DNS прямой). Иначе — выбранные домены/подсети в прокси,
+    остальное напрямую, домены через FakeIP.
+    """
+    if not isinstance(proxy_outbound, dict) or not proxy_outbound.get("type"):
+        raise ValueError("proxy_outbound должен быть dict с полем type")
+
+    proxied = _norm_suffix_domains(proxied_domains)
+    cidrs = [str(c).strip() for c in (proxied_cidrs or []) if str(c).strip()]
+    fakeip_on = (not route_all) and bool(proxied)
+
+    proxy_ob = dict(proxy_outbound)
+    proxy_ob["tag"] = "proxy-out"
+
+    tun = make_tun_inbound(interface_name=tun_iface, address=tun_address,
+                           mtu=mtu, stack=stack, auto_route=True,
+                           strict_route=True, auto_redirect=auto_redirect)
+
+    rules = [
+        {"action": "sniff"},
+        {"protocol": "dns", "action": "hijack-dns"},
+        {"ip_is_private": True, "outbound": "direct"},
+    ]
+    if not route_all:
+        if proxied:
+            rules.append({"domain_suffix": proxied, "outbound": "proxy-out"})
+        if cidrs:
+            rules.append({"ip_cidr": cidrs, "outbound": "proxy-out"})
+
+    return {
+        "log": {"level": "info", "timestamp": True},
+        "dns": make_fakeip_dns(proxied_domains=proxied, direct_dns=direct_dns,
+                               typed=typed_dns, fakeip=fakeip_on),
+        "inbounds": [tun],
+        "outbounds": [proxy_ob, {"type": "direct", "tag": "direct"}],
+        "route": {
+            "rules": rules,
+            "final": "proxy-out" if route_all else "direct",
+            "auto_detect_interface": True,
+        },
+        "experimental": {
+            "cache_file": {"enabled": True, "store_fakeip": fakeip_on,
+                           "path": "cache.db"},
+        },
+    }
 
 
 def make_vless_outbound(tag: str, server: str, port: int, uuid: str,

--- a/core/singbox_fakeip.py
+++ b/core/singbox_fakeip.py
@@ -1,0 +1,206 @@
+# core/singbox_fakeip.py
+"""
+FakeIP-роутинг для sing-box — «умный доменный роутинг» (как podkop, но
+мультиплатформенно).
+
+Собирает self-contained конфиг: TUN(auto_route) + DNS(FakeIP) + hijack-dns +
+domain/cidr route-правила. Домены берём из существующих hostlist-списков
+пользователя (те же, что для nfqws) + произвольные домены/подсети из формы.
+Прокси-сервер — из вставленной ссылки (vless:// / ss:// / …) или из готового
+конфига.
+
+Формат DNS подбираем под версию движка и ПРОВЕРЯЕМ `sing-box check`-ом до
+сохранения: legacy (1.8–1.13) или typed (1.12+). См. skill §13.
+
+Точки входа (вызываются из api/singbox.py):
+  build_options()  — данные для формы (версия, списки, конфиги, nft).
+  build_and_save() — собрать, проверить бинарём, сохранить конфиг.
+"""
+
+from __future__ import annotations
+
+import re
+
+from core.log_buffer import log
+
+
+_VER_RE = re.compile(r"(\d+)\.(\d+)")
+
+
+def _parse_minor(version: str):
+    """'1.13.0' → (1, 13). Неразобранное → (0, 0)."""
+    m = _VER_RE.search(version or "")
+    if not m:
+        return (0, 0)
+    return (int(m.group(1)), int(m.group(2)))
+
+
+# ─────────────────────── proxy resolution ───────────────────────
+
+def _resolve_proxy(proxy_link: str, proxy_config: str) -> dict:
+    """Вернуть {ok, outbound} — конкретный прокси-outbound (vless/ss/...)."""
+    link = (proxy_link or "").strip()
+    if link:
+        from core.singbox_subscription import uri_to_outbound
+        res = uri_to_outbound(link)
+        if not res.get("ok"):
+            return {"ok": False,
+                    "error": "ссылка не распознана: %s" % res.get("error")}
+        return {"ok": True, "outbound": res["outbound"]}
+
+    cfgname = (proxy_config or "").strip()
+    if cfgname:
+        from core.singbox_manager import get_singbox_manager
+        from core.singbox_config import parse_conf
+        mgr = get_singbox_manager()
+        r = mgr.get_config(cfgname)
+        if not r.get("ok"):
+            return {"ok": False, "error": "конфиг '%s' не найден" % cfgname}
+        cfg = r.get("parsed") or parse_conf(r.get("text") or "{}")
+        for ob in (cfg.get("outbounds") or []):
+            if (isinstance(ob, dict)
+                    and ob.get("type") not in ("direct", "block", "dns",
+                                               "selector", "urltest")
+                    and ob.get("server")):
+                return {"ok": True, "outbound": dict(ob)}
+        return {"ok": False,
+                "error": "в конфиге '%s' нет простого прокси-сервера — "
+                         "вставьте ссылку vless://…" % cfgname}
+
+    return {"ok": False,
+            "error": "укажите ссылку на прокси или существующий конфиг"}
+
+
+# ─────────────────────── options for the form ───────────────────────
+
+def build_options() -> dict:
+    from core.singbox_detector import get_singbox_detector
+    from core.singbox_manager import get_singbox_manager
+    from core.singbox_platform import detect_singbox_platform
+    from core.hostlist_manager import get_hostlist_manager
+
+    det = get_singbox_detector().detect_binary()
+    mgr = get_singbox_manager()
+    hm = get_hostlist_manager()
+
+    stats = hm.get_stats()
+    hostlists = [{"name": n, "count": stats[n]["count"]}
+                 for n in hm.list_names() if n in stats]
+
+    try:
+        configs = [c["name"] for c in mgr.list_configs()]
+    except Exception:
+        configs = []
+
+    nft = False
+    try:
+        nft = bool(detect_singbox_platform().supports_nftables())
+    except Exception:
+        pass
+
+    return {
+        "ok": True,
+        "installed": bool(det.get("installed")),
+        "version": det.get("version") or "",
+        "nft": nft,
+        "hostlists": hostlists,
+        "configs": configs,
+        "default_direct_dns": "local",
+        "fakeip_range": "198.18.0.0/15",
+    }
+
+
+# ─────────────────────── build + validate + save ───────────────────────
+
+def build_and_save(*, name: str = "fakeip", proxy_link: str = "",
+                   proxy_config: str = "", hostlists=None, domains=None,
+                   cidrs=None, direct_dns: str = "local",
+                   route_all: bool = False, tun_iface: str = "singbox-tun",
+                   stack: str = "system") -> dict:
+    from core.singbox_config import build_fakeip_config, render_conf
+    from core.singbox_manager import get_singbox_manager
+    from core.singbox_platform import detect_singbox_platform
+    from core.singbox_detector import get_singbox_detector
+    from core.hostlist_manager import get_hostlist_manager
+
+    name = (name or "fakeip").strip()
+    tun_iface = (tun_iface or "singbox-tun").strip()[:15]
+
+    pr = _resolve_proxy(proxy_link, proxy_config)
+    if not pr.get("ok"):
+        return pr
+    proxy_outbound = pr["outbound"]
+
+    # Домены: из выбранных hostlist'ов + произвольные из формы.
+    hm = get_hostlist_manager()
+    proxied = list(domains or [])
+    for hl in (hostlists or []):
+        try:
+            proxied += hm.get_hostlist(hl)
+        except Exception:
+            pass
+    cidrs = [str(c).strip() for c in (cidrs or []) if str(c).strip()]
+
+    if not route_all and not proxied and not cidrs:
+        return {"ok": False,
+                "error": "выберите списки/домены/подсети для проксирования "
+                         "или включите режим «весь трафик»"}
+
+    auto_redirect = False
+    try:
+        auto_redirect = bool(detect_singbox_platform().supports_nftables())
+    except Exception:
+        pass
+
+    def _mk(typed: bool):
+        cfg = build_fakeip_config(
+            proxy_outbound=proxy_outbound, proxied_domains=proxied,
+            proxied_cidrs=cidrs, route_all=route_all, direct_dns=direct_dns,
+            tun_iface=tun_iface, stack=stack, auto_redirect=auto_redirect,
+            typed_dns=typed)
+        return render_conf(cfg)
+
+    # Порядок форматов: для свежих движков (≥1.14, legacy-DNS удалён) — typed
+    # первым, иначе legacy (он валиден на 1.8–1.13, т.е. почти везде сейчас).
+    ver = _parse_minor(get_singbox_detector().detect_binary().get("version"))
+    order = [True, False] if ver >= (1, 14) else [False, True]
+
+    mgr = get_singbox_manager()
+    chosen_text, fmt, warning = None, "", ""
+    last_err = ""
+    for typed in order:
+        text = _mk(typed)
+        chk = mgr.check_text(text)
+        if chk.get("no_binary"):
+            # Проверить нечем — берём первый (самый совместимый) формат.
+            chosen_text = text
+            fmt = "typed" if typed else "legacy"
+            warning = "sing-box не установлен — конфиг сохранён без проверки"
+            break
+        if chk.get("ok"):
+            chosen_text = text
+            fmt = "typed" if typed else "legacy"
+            break
+        last_err = chk.get("error") or last_err
+
+    if chosen_text is None:
+        return {"ok": False,
+                "error": "sing-box отверг сгенерированный конфиг: %s"
+                         % (last_err or "неизвестная ошибка")}
+
+    save = mgr.save_config(name, text=chosen_text)
+    if not save.get("ok"):
+        return {"ok": False, "error": save.get("error")}
+
+    fakeip_on = (not route_all) and bool(proxied)
+    log.info("singbox FakeIP: конфиг '%s' создан (формат=%s, домены=%d, "
+             "подсети=%d, режим=%s)" % (name, fmt, len(proxied), len(cidrs),
+                                        "всё" if route_all else "выборочно"),
+             source="singbox")
+    return {
+        "ok": True, "name": name, "dns_format": fmt, "fakeip": fakeip_on,
+        "route_all": bool(route_all), "domains": len(proxied),
+        "cidrs": len(cidrs), "auto_redirect": auto_redirect,
+        "warning": warning,
+        "warnings": save.get("warnings") or [],
+    }

--- a/core/singbox_manager.py
+++ b/core/singbox_manager.py
@@ -362,6 +362,30 @@ class SingboxManager:
         return {"ok": rc == 0, "stdout": out, "stderr": err,
                 "returncode": rc}
 
+    def check_text(self, text: str) -> dict:
+        """Проверить произвольный конфиг-текст бинарём sing-box (через
+        временный файл). Нужен, чтобы валидировать сгенерированный FakeIP-
+        конфиг ДО сохранения и выбрать формат DNS под версию движка."""
+        binary = self._binary()
+        if not binary:
+            return {"ok": False, "error": "sing-box не установлен",
+                    "no_binary": True}
+        self._ensure_run_dir()
+        tmp = os.path.join(self._platform().run_dir, "_zg-check.json")
+        try:
+            with open(tmp, "w") as f:
+                f.write(text)
+        except OSError as e:
+            return {"ok": False, "error": "write: %s" % e}
+        try:
+            rc, _out, err = _run([binary, "check", "-c", tmp], timeout=10)
+        finally:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+        return {"ok": rc == 0, "error": (err or "").strip(), "returncode": rc}
+
     # ─────── lifecycle ───────
 
     def is_running(self, name: str) -> bool:

--- a/tests/test_singbox_fakeip.py
+++ b/tests/test_singbox_fakeip.py
@@ -1,0 +1,248 @@
+# tests/test_singbox_fakeip.py
+"""FakeIP-роутинг: сборка конфига (core/singbox_config.build_fakeip_config).
+
+Проверяем структуру (TUN auto_route, DNS с FakeIP, hijack-dns, domain/cidr
+route-правила, cache_file), оба формата DNS (legacy/typed) и режим «весь
+трафик», а также нормализацию доменов под domain_suffix.
+"""
+
+import json
+import unittest
+
+from core.singbox_config import (
+    build_fakeip_config, make_fakeip_dns, _norm_suffix_domains,
+    render_conf, parse_conf, validate, FAKEIP_INET4,
+)
+
+
+def _vless():
+    return {"type": "vless", "tag": "myserver", "server": "1.2.3.4",
+            "server_port": 443, "uuid": "u-1",
+            "tls": {"enabled": True, "server_name": "ex.com"}}
+
+
+class TestNormalizeSuffix(unittest.TestCase):
+    def test_strips_and_dedups(self):
+        out = _norm_suffix_domains(
+            ["WWW.YouTube.com", "*.youtube.com", "https://x.org/path",
+             "youtube.com", "localhost", "127.0.0.1", ""])
+        self.assertIn("youtube.com", out)
+        self.assertIn("x.org", out)
+        self.assertNotIn("localhost", out)
+        self.assertNotIn("127.0.0.1", out)
+        # www.youtube.com / *.youtube.com / youtube.com → один youtube.com
+        self.assertEqual(out.count("youtube.com"), 1)
+
+
+class TestFakeipDns(unittest.TestCase):
+    def test_legacy_has_toplevel_fakeip(self):
+        dns = make_fakeip_dns(proxied_domains=["youtube.com"],
+                              direct_dns="local", typed=False, fakeip=True)
+        self.assertIn("fakeip", dns)
+        self.assertEqual(dns["fakeip"]["inet4_range"], FAKEIP_INET4)
+        tags = {s["tag"]: s for s in dns["servers"]}
+        self.assertEqual(tags["dns-fakeip"]["address"], "fakeip")
+        self.assertEqual(tags["dns-direct"]["address"], "local")
+        self.assertEqual(dns["rules"][0]["server"], "dns-fakeip")
+
+    def test_typed_uses_type_field(self):
+        dns = make_fakeip_dns(proxied_domains=["youtube.com"],
+                              direct_dns="local", typed=True, fakeip=True)
+        self.assertNotIn("fakeip", dns)        # нет top-level в typed
+        tags = {s["tag"]: s for s in dns["servers"]}
+        self.assertEqual(tags["dns-fakeip"]["type"], "fakeip")
+        self.assertEqual(tags["dns-direct"]["type"], "local")
+
+    def test_direct_ip_gets_udp_detour(self):
+        dns = make_fakeip_dns(proxied_domains=["a.com"], direct_dns="8.8.8.8",
+                              typed=False, fakeip=True)
+        d = {s["tag"]: s for s in dns["servers"]}["dns-direct"]
+        self.assertEqual(d["address"], "8.8.8.8")
+        self.assertEqual(d["detour"], "direct")
+
+
+class TestBuildFakeipConfig(unittest.TestCase):
+    def test_selective_structure(self):
+        cfg = build_fakeip_config(
+            proxy_outbound=_vless(), proxied_domains=["youtube.com", "x.com"],
+            proxied_cidrs=["203.0.113.0/24"], route_all=False)
+        # JSON-валидно и проходит наш структурный валидатор
+        self.assertEqual(parse_conf(render_conf(cfg)), cfg)
+        self.assertEqual(validate(cfg), [])
+        # TUN auto_route + strict_route
+        tun = cfg["inbounds"][0]
+        self.assertEqual(tun["type"], "tun")
+        self.assertTrue(tun["auto_route"] and tun["strict_route"])
+        # прокси-outbound переименован
+        self.assertEqual(cfg["outbounds"][0]["tag"], "proxy-out")
+        self.assertEqual(cfg["outbounds"][0]["type"], "vless")
+        self.assertEqual(cfg["outbounds"][1], {"type": "direct",
+                                               "tag": "direct"})
+        # route: sniff, hijack-dns, private→direct, domain→proxy, cidr→proxy
+        rules = cfg["route"]["rules"]
+        self.assertEqual(rules[0], {"action": "sniff"})
+        self.assertEqual(rules[1], {"protocol": "dns",
+                                    "action": "hijack-dns"})
+        self.assertTrue(any(r.get("ip_is_private") for r in rules))
+        self.assertTrue(any(r.get("domain_suffix") and
+                            r.get("outbound") == "proxy-out" for r in rules))
+        self.assertTrue(any(r.get("ip_cidr") and
+                            r.get("outbound") == "proxy-out" for r in rules))
+        self.assertEqual(cfg["route"]["final"], "direct")
+        # FakeIP включён + cache.store_fakeip
+        self.assertIn("fakeip", cfg["dns"])
+        self.assertTrue(cfg["experimental"]["cache_file"]["store_fakeip"])
+
+    def test_route_all_disables_fakeip_and_routes_everything(self):
+        cfg = build_fakeip_config(proxy_outbound=_vless(), route_all=True)
+        self.assertEqual(cfg["route"]["final"], "proxy-out")
+        self.assertNotIn("fakeip", cfg["dns"])      # FakeIP не нужен
+        self.assertFalse(cfg["experimental"]["cache_file"]["store_fakeip"])
+        # нет domain/cidr правил «в прокси» (всё идёт через final)
+        for r in cfg["route"]["rules"]:
+            if r.get("outbound") == "proxy-out":
+                self.fail("в route_all не должно быть точечных proxy-правил")
+
+    def test_auto_redirect_only_when_requested(self):
+        off = build_fakeip_config(proxy_outbound=_vless(),
+                                  proxied_domains=["a.com"])
+        self.assertNotIn("auto_redirect", off["inbounds"][0])
+        on = build_fakeip_config(proxy_outbound=_vless(),
+                                 proxied_domains=["a.com"], auto_redirect=True)
+        self.assertTrue(on["inbounds"][0]["auto_redirect"])
+
+    def test_typed_dns_variant_valid_json(self):
+        cfg = build_fakeip_config(proxy_outbound=_vless(),
+                                  proxied_domains=["a.com"], typed_dns=True)
+        self.assertEqual(parse_conf(render_conf(cfg)), cfg)
+        tags = {s["tag"]: s for s in cfg["dns"]["servers"]}
+        self.assertEqual(tags["dns-fakeip"]["type"], "fakeip")
+
+    def test_bad_proxy_raises(self):
+        with self.assertRaises(ValueError):
+            build_fakeip_config(proxy_outbound={"no": "type"})
+
+
+class _FakeMgr:
+    def __init__(self, check_results):
+        self._cr = list(check_results)
+        self.saved = None
+
+    def check_text(self, text):
+        return self._cr.pop(0) if self._cr else {"ok": True}
+
+    def save_config(self, name, text=""):
+        self.saved = (name, text)
+        return {"ok": True, "warnings": []}
+
+    def list_configs(self):
+        return []
+
+
+class _FakeHM:
+    def get_hostlist(self, name):
+        return {"svc": ["youtube.com", "*.youtube.com"]}.get(name, [])
+
+    def get_stats(self):
+        return {"svc": {"count": 2}}
+
+    def list_names(self):
+        return ["svc"]
+
+
+class _FakePlat:
+    def supports_nftables(self):
+        return False
+
+
+class _FakeDet:
+    def __init__(self, ver="1.13.0", installed=True):
+        self._v, self._i = ver, installed
+
+    def detect_binary(self):
+        return {"version": self._v, "installed": self._i}
+
+
+def _patch(fakeip_mgr, ver="1.13.0", installed=True):
+    """Контекст: подменить зависимости build_and_save."""
+    from unittest import mock
+    return [
+        mock.patch("core.singbox_manager.get_singbox_manager",
+                   return_value=fakeip_mgr),
+        mock.patch("core.singbox_platform.detect_singbox_platform",
+                   return_value=_FakePlat()),
+        mock.patch("core.singbox_detector.get_singbox_detector",
+                   return_value=_FakeDet(ver, installed)),
+        mock.patch("core.hostlist_manager.get_hostlist_manager",
+                   return_value=_FakeHM()),
+        mock.patch("core.singbox_subscription.uri_to_outbound",
+                   return_value={"ok": True, "tag": "s",
+                                 "outbound": _vless()}),
+    ]
+
+
+class TestOrchestrator(unittest.TestCase):
+    def setUp(self):
+        from core import singbox_fakeip
+        self.sf = singbox_fakeip
+
+    def _run(self, mgr, ver="1.13.0", installed=True, **kw):
+        patches = _patch(mgr, ver, installed)
+        for p in patches:
+            p.start()
+        try:
+            return self.sf.build_and_save(**kw)
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_link_proxy_legacy_saved_and_validated(self):
+        mgr = _FakeMgr([{"ok": True}])               # legacy прошёл check
+        res = self._run(mgr, name="fi", proxy_link="vless://u@h:443",
+                        domains="youtube.com")
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["dns_format"], "legacy")
+        self.assertTrue(res["fakeip"])
+        self.assertEqual(mgr.saved[0], "fi")
+        self.assertIn("fakeip", mgr.saved[1])         # FakeIP в сохранённом
+
+    def test_falls_back_to_typed_when_legacy_rejected(self):
+        # legacy отвергнут, typed принят → формат typed.
+        mgr = _FakeMgr([{"ok": False, "error": "legacy removed"},
+                        {"ok": True}])
+        res = self._run(mgr, proxy_link="vless://u@h:443", domains="a.com")
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["dns_format"], "typed")
+
+    def test_no_binary_saves_without_check(self):
+        mgr = _FakeMgr([{"ok": False, "no_binary": True}])
+        res = self._run(mgr, installed=False, proxy_link="vless://u@h:443",
+                        domains="a.com")
+        self.assertTrue(res["ok"])
+        self.assertTrue(res["warning"])
+
+    def test_guard_requires_proxy(self):
+        mgr = _FakeMgr([{"ok": True}])
+        res = self._run(mgr, domains="a.com")        # без ссылки/конфига
+        self.assertFalse(res["ok"])
+
+    def test_guard_requires_targets_when_not_route_all(self):
+        mgr = _FakeMgr([{"ok": True}])
+        res = self._run(mgr, proxy_link="vless://u@h:443")  # нет доменов/cidr
+        self.assertFalse(res["ok"])
+
+    def test_route_all_needs_no_targets(self):
+        mgr = _FakeMgr([{"ok": True}])
+        res = self._run(mgr, proxy_link="vless://u@h:443", route_all=True)
+        self.assertTrue(res["ok"])
+        self.assertTrue(res["route_all"])
+
+    def test_hostlist_domains_collected(self):
+        mgr = _FakeMgr([{"ok": True}])
+        res = self._run(mgr, proxy_link="vless://u@h:443", hostlists=["svc"])
+        self.assertTrue(res["ok"])
+        self.assertGreaterEqual(res["domains"], 1)   # youtube.com из svc
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -27,6 +27,14 @@ const SingboxDashboardPage = (() => {
     let tpNote = '';                 // последняя ошибка применения firewall (persist)
     let debugEnabled = false;        // /api/singbox/debug (log.level=debug при запуске)
     let logState = {};               // name -> { open, text, loading }
+    let fakeipOpts = null;           // /api/singbox/fakeip/options
+    let fakeipRendered = false;      // форму рендерим один раз (не теряем ввод при poll)
+    let fakeipBusy = false;
+    let fakeipForm = {               // состояние формы FakeIP-роутинга
+        name: 'fakeip', source: 'link', proxy_link: '', proxy_config: '',
+        route_all: false, hostlists: {}, domains: '', cidrs: '',
+        direct_dns: 'local', stack: 'system',
+    };
 
     // ══════════════ render ══════════════
 
@@ -62,6 +70,13 @@ const SingboxDashboardPage = (() => {
 
             <div id="sb-instances"></div>
 
+            <div class="card" id="sb-fakeip" style="margin-top:16px;">
+                <div class="card-title">Умный доменный роутинг (FakeIP)</div>
+                <div id="sb-fakeip-body" style="margin-top:8px;">
+                    <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
+                </div>
+            </div>
+
             <div class="card" id="sb-transparent" style="margin-top:16px;">
                 <div class="card-title">Прозрачное проксирование (TProxy / Redirect / Hybrid)${typeof Help !== 'undefined' ? Help.button('transparent') : ''}</div>
                 <div id="sb-transparent-body" style="margin-top:8px;">
@@ -88,18 +103,20 @@ const SingboxDashboardPage = (() => {
 
     async function loadAll() {
         try {
-            const [envResp, cfgsResp, autoResp, tpResp, dbgResp] = await Promise.all([
+            const [envResp, cfgsResp, autoResp, tpResp, dbgResp, fiResp] = await Promise.all([
                 API.get('/api/singbox/environment').catch(() => null),
                 API.get('/api/singbox/configs').catch(() => null),
                 API.get('/api/singbox/autostart').catch(() => null),
                 API.get('/api/singbox/transparent/status').catch(() => null),
                 API.get('/api/singbox/debug').catch(() => null),
+                API.get('/api/singbox/fakeip/options').catch(() => null),
             ]);
             env       = envResp || null;
             configs   = (cfgsResp && cfgsResp.configs) || [];
             autostart = (autoResp && autoResp.status && autoResp.status.autostart) || {};
             transparent = tpResp || null;
             debugEnabled = !!(dbgResp && dbgResp.enabled);
+            if (fiResp && fiResp.ok) fakeipOpts = fiResp;
             // Подхватываем сохранённые настройки в форму (один раз и при смене).
             if (transparent && transparent.settings && transparent.settings.mode) {
                 const s = transparent.settings;
@@ -121,6 +138,7 @@ const SingboxDashboardPage = (() => {
         await loadAll();
         renderSummary();
         renderInstances();
+        renderFakeip();
         renderTransparent();
         renderTun();
     }
@@ -618,6 +636,154 @@ const SingboxDashboardPage = (() => {
         } catch (e) { Toast.error(e.message); }
     }
 
+    // ══════════════ FakeIP smart routing ══════════════
+
+    function renderFakeip() {
+        const body = document.getElementById('sb-fakeip-body');
+        if (!body) return;
+        if (!fakeipOpts) {
+            body.innerHTML = `<div class="text-muted">Нет данных от сервера.</div>`;
+            return;
+        }
+        // Рендерим один раз — иначе 5-секундный poll стирал бы ввод формы.
+        if (fakeipRendered) return;
+        fakeipRendered = true;
+
+        const o = fakeipOpts;
+        const f = fakeipForm;
+        const notInstalled = !o.installed
+            ? `<div style="color:#e58; font-size:12px; margin-bottom:8px;">
+                 sing-box не установлен — конфиг сохранится без проверки.
+               </div>` : '';
+        const cfgOptions = (o.configs || []).map(n =>
+            `<option value="${escapeAttr(n)}" ${f.proxy_config === n ? 'selected' : ''}>${escapeHtml(n)}</option>`
+        ).join('');
+        const hostlistChecks = (o.hostlists || []).map(h => `
+            <label style="display:inline-flex; align-items:center; gap:5px; margin:2px 10px 2px 0; font-size:12px;">
+                <input type="checkbox" ${f.hostlists[h.name] ? 'checked' : ''}
+                       onchange="SingboxDashboardPage.toggleFakeipHostlist('${escapeAttr(h.name)}', this.checked)">
+                ${escapeHtml(h.name)} <span class="text-muted">(${h.count})</span>
+            </label>`).join('') || '<span class="text-muted" style="font-size:12px;">нет списков</span>';
+
+        const autoNote = o.nft
+            ? 'Платформа nftables: трафик LAN-клиентов забирается автоматически (auto_redirect).'
+            : 'Платформа без nftables: LAN-клиенты должны использовать роутер как шлюз/DNS.';
+
+        body.innerHTML = `
+            <p class="text-muted" style="font-size:12.5px; margin-top:0;">
+                Создаёт готовый sing-box-конфиг, который заворачивает выбранные
+                домены/подсети в ваш прокси через TUN + <strong>FakeIP</strong>
+                (надёжно для CDN/QUIC, без DNS-leak). Остальное идёт напрямую.
+                После создания запустите конфиг кнопкой выше.
+            </p>
+            ${notInstalled}
+            <div style="display:flex; flex-direction:column; gap:10px; max-width:680px;">
+                <label style="font-size:12px;">Имя конфига
+                    <input type="text" value="${escapeAttr(f.name)}" style="width:100%;"
+                           oninput="SingboxDashboardPage.setFakeip('name', this.value)">
+                </label>
+
+                <div>
+                    <div style="font-size:12px; margin-bottom:3px;">Прокси-сервер</div>
+                    <textarea rows="2" placeholder="vless:// ss:// trojan:// hysteria2:// tuic:// — вставьте ссылку"
+                              style="width:100%; font-family:monospace; font-size:12px;"
+                              oninput="SingboxDashboardPage.setFakeip('proxy_link', this.value)">${escapeHtml(f.proxy_link)}</textarea>
+                    <div class="text-muted" style="font-size:11px; margin-top:3px;">
+                        …или взять из конфига:
+                        <select onchange="SingboxDashboardPage.setFakeip('proxy_config', this.value)">
+                            <option value="">—</option>${cfgOptions}
+                        </select>
+                        <span>(если вставлена ссылка — используется она)</span>
+                    </div>
+                </div>
+
+                <label style="display:flex; align-items:center; gap:6px; font-size:12px;">
+                    <input type="checkbox" ${f.route_all ? 'checked' : ''}
+                           onchange="SingboxDashboardPage.setFakeip('route_all', this.checked)">
+                    Проксировать <strong>весь</strong> трафик (иначе — только выбранное ниже)
+                </label>
+
+                <div>
+                    <div style="font-size:12px; margin-bottom:3px;">Заворачивать списки доменов:</div>
+                    <div>${hostlistChecks}</div>
+                </div>
+
+                <label style="font-size:12px;">Доп. домены (по одному в строке)
+                    <textarea rows="2" placeholder="example.com&#10;site.org" style="width:100%; font-size:12px;"
+                              oninput="SingboxDashboardPage.setFakeip('domains', this.value)">${escapeHtml(f.domains)}</textarea>
+                </label>
+
+                <label style="font-size:12px;">Доп. подсети / IP (CIDR, по одному в строке)
+                    <textarea rows="2" placeholder="203.0.113.0/24" style="width:100%; font-size:12px;"
+                              oninput="SingboxDashboardPage.setFakeip('cidrs', this.value)">${escapeHtml(f.cidrs)}</textarea>
+                </label>
+
+                <label style="font-size:12px;">Прямой DNS (для остального трафика)
+                    <input type="text" value="${escapeAttr(f.direct_dns)}" style="width:220px;"
+                           oninput="SingboxDashboardPage.setFakeip('direct_dns', this.value)">
+                    <span class="text-muted" style="font-size:11px;">local = системный резолвер; или IP, напр. 77.88.8.8</span>
+                </label>
+
+                <div class="text-muted" style="font-size:11px;">${escapeHtml(autoNote)}</div>
+
+                <div>
+                    <button class="btn btn-primary btn-sm" id="sb-fakeip-create"
+                            onclick="SingboxDashboardPage.createFakeip()">
+                        Создать конфиг
+                    </button>
+                </div>
+            </div>`;
+    }
+
+    function setFakeip(key, val) {
+        if (key === 'route_all') fakeipForm.route_all = !!val;
+        else fakeipForm[key] = val;
+    }
+
+    function toggleFakeipHostlist(name, checked) {
+        fakeipForm.hostlists[name] = !!checked;
+    }
+
+    async function createFakeip() {
+        if (fakeipBusy) return;
+        const f = fakeipForm;
+        if (!f.proxy_link.trim() && !f.proxy_config) {
+            Toast.error('Укажите прокси: вставьте ссылку или выберите конфиг');
+            return;
+        }
+        const hostlists = Object.keys(f.hostlists).filter(k => f.hostlists[k]);
+        const payload = {
+            name: f.name.trim() || 'fakeip',
+            proxy_link: f.proxy_link.trim(),
+            proxy_config: f.proxy_config,
+            route_all: f.route_all,
+            hostlists: hostlists,
+            domains: f.domains, cidrs: f.cidrs,
+            direct_dns: f.direct_dns.trim() || 'local',
+            stack: f.stack,
+        };
+        fakeipBusy = true;
+        const btn = document.getElementById('sb-fakeip-create');
+        if (btn) { btn.disabled = true; btn.textContent = 'Создаю…'; }
+        try {
+            const r = await API.post('/api/singbox/fakeip/build', payload);
+            if (r && r.ok) {
+                const mode = r.route_all ? 'весь трафик'
+                    : `${r.domains} доменов${r.cidrs ? ', ' + r.cidrs + ' подсетей' : ''}`;
+                Toast.success(`Конфиг «${r.name}» создан (${mode}, DNS=${r.dns_format}). Запустите его в списке выше.`);
+                if (r.warning) Toast.error(r.warning, 8000);
+                await refresh();
+            } else {
+                Toast.error((r && r.error) || 'ошибка создания');
+            }
+        } catch (e) {
+            Toast.error(e.message);
+        } finally {
+            fakeipBusy = false;
+            if (btn) { btn.disabled = false; btn.textContent = 'Создать конфиг'; }
+        }
+    }
+
     // ══════════════ helpers ══════════════
 
     function escapeHtml(s) {
@@ -632,6 +798,7 @@ const SingboxDashboardPage = (() => {
         render, destroy, refresh,
         up, down, restart,
         toggleDebug, showLog,
+        setFakeip, toggleFakeipHostlist, createFakeip,
         setTp, applyTransparent, removeTransparent, injectInbounds,
         setTun, createTunInbound,
     };


### PR DESCRIPTION
…типлатформенно

Закрывает пробел из сравнения с podkop: надёжный доменный роутинг через sing-box без DNS-leak и с поддержкой CDN/QUIC/ECH (роутинг по домену из DNS, до handshake), при этом мультиплатформенно (не только OpenWrt).

- singbox_config.build_fakeip_config(): self-contained конфиг — TUN (auto_route+strict_route[+auto_redirect на nft]) + dns(FakeIP) + sniff + hijack-dns + domain/cidr-правила → proxy, ip_is_private→direct, experimental.cache_file.store_fakeip. make_fakeip_dns() — два формата DNS: legacy (1.8–1.13) и typed (1.12+).
- core/singbox_fakeip.py: оркестратор — прокси из ссылки (uri_to_outbound) или из конфига; домены из hostlist'ов пользователя + формы; подбор формата DNS под версию и проверка `sing-box check` ДО сохранения (legacy↔typed fallback); режим route_all (весь трафик в прокси).
- SingboxManager.check_text(): валидация произвольного конфига бинарём.
- make_tun_inbound(): опция auto_redirect (nft, 1.10+) — забор трафика LAN-клиентов без ручной правки firewall.
- API: GET /api/singbox/fakeip/options, POST /api/singbox/fakeip/build.
- UI: карточка «Умный доменный роутинг (FakeIP)» на дашборде sing-box (источник прокси, чекбоксы списков, доп. домены/подсети, прямой DNS, режим «весь трафик»), с подсказкой про DNS LAN-клиентов.
- skill singbox §7/§13: FakeIP отмечен как реализованный, описаны модули.
- tests: test_singbox_fakeip (билдер обоих форматов + оркестратор, 16 тестов).