### PR TITLE
feat(singbox): FakeIP — авто-перехват DNS LAN-клиентов на iptables (K…

### DIFF
--- a/.claude/skills/singbox/SKILL.md
+++ b/.claude/skills/singbox/SKILL.md
@@ -393,9 +393,25 @@ TUN, sing-box по fake-IP восстанавливает домен и прок
   (`web/js/pages/singbox.js`): ссылка/конфиг прокси, чекбоксы списков,
   доп. домены/подсети, прямой DNS, режим «весь трафик».
 
-Ограничение: FakeIP требует, чтобы клиентский DNS доходил до движка. На nft
-это делает `auto_redirect`; иначе LAN-клиенты должны ходить через роутер
-(шлюз/DNS) — об этом в карточке есть подсказка.
+**DNS-перехват LAN-клиентов** (FakeIP работает, только если их DNS доходит до
+движка):
+- **nft** (OpenWrt): `auto_redirect` TUN сам забирает forwarded :53 → ничего
+  не нужно.
+- **iptables** (Keenetic): конфиг несёт `dns-in` direct-inbound на `dns_port`
+  (1153), а `SingboxManager` на **старте** ставит REDIRECT udp/tcp `:53 →
+  dns_port` и на **остановке** снимает (живёт ровно пока конфиг запущен —
+  иначе LAN остался бы без DNS). Сделано через `singbox_transparent`
+  **`mode="dns-only"`** (только DNS-hijack, без traffic-redirect; своя
+  цепочка `SBT_REDIR_PRE` в nat PREROUTING — локальный DNS роутера/движка в
+  OUTPUT не трогается → без петли). Состояние сохраняется как
+  `singbox.transparent={mode:dns-only,...}`, поэтому переживает перезагрузку
+  через штатный `--apply-singbox-transparent`. Сигнал «этому конфигу нужен
+  перехват» — наличие inbound'а `tag=dns-in` (`_config_dns_in_port`).
+  Конфликт-гард: если активно прозрачное проксирование (redirect/tproxy) —
+  dns-only не ставится (общие цепочки).
+- Управление — чекбокс «Перехватывать DNS LAN-клиентов» в карточке FakeIP
+  (`capture_dns`, по умолчанию вкл); `build_and_save` возвращает `dns_capture`
+  ∈ {auto_redirect, iptables-redirect, manual}.
 
 ---
 

--- a/api/singbox.py
+++ b/api/singbox.py
@@ -645,6 +645,8 @@ def register(app):
             route_all=bool(body.get("route_all")),
             tun_iface=(body.get("tun_iface") or "singbox-tun"),
             stack=(body.get("stack") or "system"),
+            capture_dns=bool(body.get("capture_dns", True)),
+            dns_port=int(body.get("dns_port") or 1153),
         )
         if not res.get("ok"):
             response.status = 400

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -580,7 +580,9 @@ def build_fakeip_config(*, proxy_outbound: dict,
                         tun_address=None, mtu: int = 9000,
                         stack: str = "system",
                         auto_redirect: bool = False,
-                        typed_dns: bool = False) -> dict:
+                        typed_dns: bool = False,
+                        capture_dns: bool = False,
+                        dns_port: int = 1153) -> dict:
     """
     Собрать полный sing-box-конфиг FakeIP-роутинга.
 
@@ -602,6 +604,13 @@ def build_fakeip_config(*, proxy_outbound: dict,
     tun = make_tun_inbound(interface_name=tun_iface, address=tun_address,
                            mtu=mtu, stack=stack, auto_route=True,
                            strict_route=True, auto_redirect=auto_redirect)
+    inbounds = [tun]
+    if capture_dns:
+        # DNS-inbound для перехвата :53 LAN-клиентов (firewall REDIRECT :53 →
+        # dns_port); сам перехват ловит route-правило hijack-dns. Нужен на
+        # iptables-платформах (Keenetic), где auto_redirect недоступен.
+        inbounds.append({"type": "direct", "tag": "dns-in",
+                         "listen": "::", "listen_port": int(dns_port)})
 
     rules = [
         {"action": "sniff"},
@@ -618,7 +627,7 @@ def build_fakeip_config(*, proxy_outbound: dict,
         "log": {"level": "info", "timestamp": True},
         "dns": make_fakeip_dns(proxied_domains=proxied, direct_dns=direct_dns,
                                typed=typed_dns, fakeip=fakeip_on),
-        "inbounds": [tun],
+        "inbounds": inbounds,
         "outbounds": [proxy_ob, {"type": "direct", "tag": "direct"}],
         "route": {
             "rules": rules,

--- a/core/singbox_fakeip.py
+++ b/core/singbox_fakeip.py
@@ -116,7 +116,8 @@ def build_and_save(*, name: str = "fakeip", proxy_link: str = "",
                    proxy_config: str = "", hostlists=None, domains=None,
                    cidrs=None, direct_dns: str = "local",
                    route_all: bool = False, tun_iface: str = "singbox-tun",
-                   stack: str = "system") -> dict:
+                   stack: str = "system", capture_dns: bool = True,
+                   dns_port: int = 1153) -> dict:
     from core.singbox_config import build_fakeip_config, render_conf
     from core.singbox_manager import get_singbox_manager
     from core.singbox_platform import detect_singbox_platform
@@ -146,18 +147,22 @@ def build_and_save(*, name: str = "fakeip", proxy_link: str = "",
                 "error": "выберите списки/домены/подсети для проксирования "
                          "или включите режим «весь трафик»"}
 
-    auto_redirect = False
+    nft = False
     try:
-        auto_redirect = bool(detect_singbox_platform().supports_nftables())
+        nft = bool(detect_singbox_platform().supports_nftables())
     except Exception:
         pass
+    # nft: forwarded DNS забирает auto_redirect TUN. iptables (Keenetic):
+    # нужен REDIRECT :53 → dns-in порт (его ставит SingboxManager на старте).
+    auto_redirect = nft
+    fw_capture = bool(capture_dns) and not nft
 
     def _mk(typed: bool):
         cfg = build_fakeip_config(
             proxy_outbound=proxy_outbound, proxied_domains=proxied,
             proxied_cidrs=cidrs, route_all=route_all, direct_dns=direct_dns,
             tun_iface=tun_iface, stack=stack, auto_redirect=auto_redirect,
-            typed_dns=typed)
+            typed_dns=typed, capture_dns=fw_capture, dns_port=dns_port)
         return render_conf(cfg)
 
     # Порядок форматов: для свежих движков (≥1.14, legacy-DNS удалён) — typed
@@ -193,14 +198,22 @@ def build_and_save(*, name: str = "fakeip", proxy_link: str = "",
         return {"ok": False, "error": save.get("error")}
 
     fakeip_on = (not route_all) and bool(proxied)
+    if nft and capture_dns:
+        dns_capture = "auto_redirect"     # TUN auto_redirect сам ловит :53
+    elif fw_capture:
+        dns_capture = "iptables-redirect"  # REDIRECT :53 ставит менеджер на up
+    else:
+        dns_capture = "manual"             # LAN-клиенты должны слать DNS на роутер
     log.info("singbox FakeIP: конфиг '%s' создан (формат=%s, домены=%d, "
-             "подсети=%d, режим=%s)" % (name, fmt, len(proxied), len(cidrs),
-                                        "всё" if route_all else "выборочно"),
+             "подсети=%d, режим=%s, dns=%s)"
+             % (name, fmt, len(proxied), len(cidrs),
+                "всё" if route_all else "выборочно", dns_capture),
              source="singbox")
     return {
         "ok": True, "name": name, "dns_format": fmt, "fakeip": fakeip_on,
         "route_all": bool(route_all), "domains": len(proxied),
         "cidrs": len(cidrs), "auto_redirect": auto_redirect,
+        "dns_capture": dns_capture,
         "warning": warning,
         "warnings": save.get("warnings") or [],
     }

--- a/core/singbox_manager.py
+++ b/core/singbox_manager.py
@@ -228,6 +228,78 @@ class SingboxManager:
         return {"ok": True, "name": name, "path": path, "exists": True,
                 "log": _tail_file(path, lines), "debug": self._debug_enabled()}
 
+    # ─────── FakeIP DNS-capture (firewall :53 → движок) ───────
+    #
+    # FakeIP работает, только если клиентский DNS доходит до движка. На nft
+    # это делает auto_redirect TUN. На iptables (Keenetic) нужен REDIRECT
+    # udp/tcp :53 → dns-in порт конфига. Сигнал «этому конфигу нужен перехват»
+    # — наличие inbound'а с tag=dns-in. Правило живёт РОВНО пока конфиг
+    # запущен (иначе :53 уходит в никуда → LAN без DNS): ставим на up, снимаем
+    # на down; для переживания перезагрузки сохраняем как transparent
+    # mode=dns-only (его переподнимает штатный --apply-singbox-transparent).
+
+    def _config_dns_in_port(self, name: str) -> int:
+        """Порт dns-in inbound'а конфига (FakeIP-перехват), иначе 0."""
+        try:
+            cfg = self.get_config(name).get("parsed") or {}
+            for ib in cfg.get("inbounds") or []:
+                if (isinstance(ib, dict) and ib.get("tag") == "dns-in"
+                        and ib.get("type") == "direct"):
+                    return int(ib.get("listen_port") or 0)
+        except Exception:
+            pass
+        return 0
+
+    def _apply_dns_capture(self, port: int):
+        if port <= 0:
+            return
+        try:
+            from core.singbox_platform import detect_singbox_platform
+            if detect_singbox_platform().supports_nftables():
+                return            # nft: auto_redirect TUN сам забирает DNS
+        except Exception:
+            pass
+        try:
+            from core import singbox_transparent as tp
+            if not tp.available("v4"):
+                return
+            from core.config_manager import get_config_manager
+            cm = get_config_manager()
+            saved = cm.get("singbox", "transparent", default={}) or {}
+            if saved.get("mode") and saved.get("mode") != "dns-only":
+                log.warning("singbox FakeIP: активно прозрачное "
+                            "проксирование (%s) — DNS-перехват не ставлю "
+                            "(конфликт цепочек)" % saved.get("mode"),
+                            source="singbox")
+                return
+            cm.set("singbox", "transparent",
+                   {"mode": "dns-only", "dns_hijack_port": int(port),
+                    "families": ["v4"]})
+            cm.save()
+            res = tp.apply(mode="dns-only", dns_hijack_port=int(port),
+                           families=("v4",), backend="iptables")
+            log.info("singbox FakeIP: DNS-перехват :53→%d %s"
+                     % (port, "ok" if res.get("ok")
+                        else ("; ".join(res.get("errors") or []))),
+                     source="singbox")
+        except Exception as e:
+            log.warning("singbox FakeIP dns-capture: %s" % e, source="singbox")
+
+    def _remove_dns_capture(self):
+        try:
+            from core import singbox_transparent as tp
+            from core.config_manager import get_config_manager
+            cm = get_config_manager()
+            saved = cm.get("singbox", "transparent", default={}) or {}
+            if saved.get("mode") == "dns-only":
+                tp.remove()
+                cm.set("singbox", "transparent", {})
+                cm.save()
+                log.info("singbox FakeIP: DNS-перехват снят", source="singbox")
+        except Exception as e:
+            log.warning("singbox FakeIP dns-capture remove: %s" % e,
+                        source="singbox")
+
     # ─────── CRUD ───────
 
     def list_configs(self) -> list:
@@ -495,6 +567,10 @@ class SingboxManager:
                              % popen.returncode,
                     "log_tail": tail}
 
+        # FakeIP: если у конфига есть dns-in inbound — поднять REDIRECT :53
+        # (живёт ровно пока конфиг запущен).
+        self._apply_dns_capture(self._config_dns_in_port(name))
+
         log.info("singbox: запущен '%s' (pid=%d)%s" % (
             name, popen.pid, " [debug]" if extra_cfg else ""),
                  source="singbox")
@@ -534,6 +610,10 @@ class SingboxManager:
             os.remove(pid_file)
         except OSError:
             pass
+
+        # FakeIP: снять REDIRECT :53, если этот конфиг его ставил.
+        if self._config_dns_in_port(name):
+            self._remove_dns_capture()
 
         log.info("singbox: остановлен '%s' (pid=%d)" % (name, pid),
                  source="singbox")

--- a/core/singbox_transparent.py
+++ b/core/singbox_transparent.py
@@ -525,7 +525,7 @@ def apply(*, mode: str,
                    когда 'v6' не в families.
       backend: 'auto' | 'iptables' | 'nftables'.
     """
-    if mode not in ("redirect", "tproxy", "hybrid"):
+    if mode not in ("redirect", "tproxy", "hybrid", "dns-only"):
         return {"ok": False, "error": "Неизвестный режим: %s" % mode}
 
     chosen = choose_backend(backend)
@@ -607,11 +607,20 @@ def apply(*, mode: str,
             errors.extend(r.get("errors", []))
 
         if dns_hijack_port:
-            via = "redirect" if mode == "redirect" else "tproxy"
+            # tproxy/hybrid → DNS через mangle TPROXY (MANGLE_PRE уже создан);
+            # redirect/dns-only → nat REDIRECT (NAT_PRE). В dns-only цепочку
+            # NAT_PRE никто не создавал — создаём/чистим/джампим её здесь
+            # (трафик через TUN+auto_route, firewall только заворачивает :53).
+            via = "tproxy" if mode in ("tproxy", "hybrid") else "redirect"
+            if via == "redirect" and mode == "dns-only":
+                _ensure_chain(family, "nat", NAT_PRE)
+                _flush_chain(family, "nat", NAT_PRE)
             for argv in build_dns_hijack_rules(
                     family=family, dns_port=dns_hijack_port,
                     lan_ifaces=lan_ifaces, via=via, mark=mark):
                 _exec(argv)
+            if via == "redirect" and mode == "dns-only":
+                _ensure_jump(family, "nat", "PREROUTING", NAT_PRE)
 
     # IPv6 anti-leak: если v6 не проксируем и политика drop — глушим
     # форвард-IPv6, чтобы клиенты не ходили мимо.

--- a/tests/test_singbox_fakeip.py
+++ b/tests/test_singbox_fakeip.py
@@ -122,6 +122,66 @@ class TestBuildFakeipConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             build_fakeip_config(proxy_outbound={"no": "type"})
 
+    def test_capture_dns_adds_dns_in_inbound(self):
+        off = build_fakeip_config(proxy_outbound=_vless(),
+                                  proxied_domains=["a.com"])
+        self.assertEqual([i["tag"] for i in off["inbounds"]], ["tun-in"])
+        on = build_fakeip_config(proxy_outbound=_vless(),
+                                 proxied_domains=["a.com"],
+                                 capture_dns=True, dns_port=1153)
+        tags = {i["tag"]: i for i in on["inbounds"]}
+        self.assertIn("dns-in", tags)
+        self.assertEqual(tags["dns-in"]["type"], "direct")
+        self.assertEqual(tags["dns-in"]["listen_port"], 1153)
+
+
+class TestTransparentDnsOnly(unittest.TestCase):
+    """mode='dns-only' строит REDIRECT :53 (без traffic-redirect)."""
+
+    def test_dns_hijack_redirect_rules(self):
+        from core.singbox_transparent import build_dns_hijack_rules
+        rules = build_dns_hijack_rules(family="v4", dns_port=1153,
+                                       lan_ifaces=None, via="redirect")
+        # udp+tcp → REDIRECT --to-ports 1153 в nat
+        self.assertEqual(len(rules), 2)
+        for r in rules:
+            self.assertIn("-t", r)
+            self.assertIn("nat", r)
+            self.assertIn("REDIRECT", r)
+            self.assertIn("1153", r)
+            self.assertIn("53", r)
+
+    def test_apply_rejects_unknown_mode_but_accepts_dns_only(self):
+        from unittest import mock
+        from core import singbox_transparent as tp
+        # неизвестный режим — ошибка ещё до выбора бэкенда.
+        self.assertFalse(tp.apply(mode="bogus").get("ok"))
+        # dns-only — допустимый режим: гасим iptables-доступность, чтобы тест
+        # не трогал реальный netfilter — важно лишь, что это НЕ «Неизвестный
+        # режим» (т.е. режим распознан).
+        with mock.patch.object(tp, "available", return_value=False):
+            r = tp.apply(mode="dns-only", dns_hijack_port=1153,
+                         families=("v4",), backend="iptables")
+        self.assertNotIn("Неизвестный режим", str(r.get("error", "")))
+
+
+class TestManagerDnsInDetect(unittest.TestCase):
+    def test_detects_dns_in_port(self):
+        from unittest import mock
+        from core.singbox_manager import SingboxManager
+        mgr = SingboxManager()
+        cfg = build_fakeip_config(proxy_outbound=_vless(),
+                                  proxied_domains=["a.com"],
+                                  capture_dns=True, dns_port=1153)
+        with mock.patch.object(mgr, "get_config",
+                               return_value={"ok": True, "parsed": cfg}):
+            self.assertEqual(mgr._config_dns_in_port("x"), 1153)
+        plain = build_fakeip_config(proxy_outbound=_vless(),
+                                    proxied_domains=["a.com"])
+        with mock.patch.object(mgr, "get_config",
+                               return_value={"ok": True, "parsed": plain}):
+            self.assertEqual(mgr._config_dns_in_port("x"), 0)
+
 
 class _FakeMgr:
     def __init__(self, check_results):
@@ -151,8 +211,11 @@ class _FakeHM:
 
 
 class _FakePlat:
+    def __init__(self, nft=False):
+        self._nft = nft
+
     def supports_nftables(self):
-        return False
+        return self._nft
 
 
 class _FakeDet:
@@ -163,14 +226,14 @@ class _FakeDet:
         return {"version": self._v, "installed": self._i}
 
 
-def _patch(fakeip_mgr, ver="1.13.0", installed=True):
+def _patch(fakeip_mgr, ver="1.13.0", installed=True, nft=False):
     """Контекст: подменить зависимости build_and_save."""
     from unittest import mock
     return [
         mock.patch("core.singbox_manager.get_singbox_manager",
                    return_value=fakeip_mgr),
         mock.patch("core.singbox_platform.detect_singbox_platform",
-                   return_value=_FakePlat()),
+                   return_value=_FakePlat(nft)),
         mock.patch("core.singbox_detector.get_singbox_detector",
                    return_value=_FakeDet(ver, installed)),
         mock.patch("core.hostlist_manager.get_hostlist_manager",
@@ -186,8 +249,8 @@ class TestOrchestrator(unittest.TestCase):
         from core import singbox_fakeip
         self.sf = singbox_fakeip
 
-    def _run(self, mgr, ver="1.13.0", installed=True, **kw):
-        patches = _patch(mgr, ver, installed)
+    def _run(self, mgr, ver="1.13.0", installed=True, nft=False, **kw):
+        patches = _patch(mgr, ver, installed, nft)
         for p in patches:
             p.start()
         try:
@@ -242,6 +305,24 @@ class TestOrchestrator(unittest.TestCase):
         res = self._run(mgr, proxy_link="vless://u@h:443", hostlists=["svc"])
         self.assertTrue(res["ok"])
         self.assertGreaterEqual(res["domains"], 1)   # youtube.com из svc
+
+    def test_dns_capture_iptables(self):
+        mgr = _FakeMgr([{"ok": True}])
+        res = self._run(mgr, proxy_link="vless://u@h:443", domains="a.com",
+                        nft=False, capture_dns=True)
+        self.assertEqual(res["dns_capture"], "iptables-redirect")
+
+    def test_dns_capture_nft_auto_redirect(self):
+        mgr = _FakeMgr([{"ok": True}])
+        res = self._run(mgr, proxy_link="vless://u@h:443", domains="a.com",
+                        nft=True, capture_dns=True)
+        self.assertEqual(res["dns_capture"], "auto_redirect")
+
+    def test_dns_capture_manual_when_off(self):
+        mgr = _FakeMgr([{"ok": True}])
+        res = self._run(mgr, proxy_link="vless://u@h:443", domains="a.com",
+                        nft=False, capture_dns=False)
+        self.assertEqual(res["dns_capture"], "manual")
 
 
 if __name__ == "__main__":

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -33,7 +33,7 @@ const SingboxDashboardPage = (() => {
     let fakeipForm = {               // состояние формы FakeIP-роутинга
         name: 'fakeip', source: 'link', proxy_link: '', proxy_config: '',
         route_all: false, hostlists: {}, domains: '', cidrs: '',
-        direct_dns: 'local', stack: 'system',
+        direct_dns: 'local', stack: 'system', capture_dns: true,
     };
 
     // ══════════════ render ══════════════
@@ -666,8 +666,8 @@ const SingboxDashboardPage = (() => {
             </label>`).join('') || '<span class="text-muted" style="font-size:12px;">нет списков</span>';
 
         const autoNote = o.nft
-            ? 'Платформа nftables: трафик LAN-клиентов забирается автоматически (auto_redirect).'
-            : 'Платформа без nftables: LAN-клиенты должны использовать роутер как шлюз/DNS.';
+            ? 'Платформа nftables: DNS и трафик LAN-клиентов забираются автоматически (auto_redirect TUN).'
+            : 'Платформа iptables (Keenetic): при включённом перехвате правило REDIRECT :53 ставится автоматически на время работы конфига (снимается при остановке). LAN-клиенты должны ходить через роутер как шлюз.';
 
         body.innerHTML = `
             <p class="text-muted" style="font-size:12.5px; margin-top:0;">
@@ -724,6 +724,12 @@ const SingboxDashboardPage = (() => {
                     <span class="text-muted" style="font-size:11px;">local = системный резолвер; или IP, напр. 77.88.8.8</span>
                 </label>
 
+                <label style="display:flex; align-items:center; gap:6px; font-size:12px;">
+                    <input type="checkbox" ${f.capture_dns ? 'checked' : ''}
+                           onchange="SingboxDashboardPage.setFakeip('capture_dns', this.checked)">
+                    Перехватывать DNS LAN-клиентов автоматически (нужно для FakeIP)
+                </label>
+
                 <div class="text-muted" style="font-size:11px;">${escapeHtml(autoNote)}</div>
 
                 <div>
@@ -760,7 +766,7 @@ const SingboxDashboardPage = (() => {
             hostlists: hostlists,
             domains: f.domains, cidrs: f.cidrs,
             direct_dns: f.direct_dns.trim() || 'local',
-            stack: f.stack,
+            stack: f.stack, capture_dns: f.capture_dns,
         };
         fakeipBusy = true;
         const btn = document.getElementById('sb-fakeip-create');
@@ -772,6 +778,9 @@ const SingboxDashboardPage = (() => {
                     : `${r.domains} доменов${r.cidrs ? ', ' + r.cidrs + ' подсетей' : ''}`;
                 Toast.success(`Конфиг «${r.name}» создан (${mode}, DNS=${r.dns_format}). Запустите его в списке выше.`);
                 if (r.warning) Toast.error(r.warning, 8000);
+                if (r.dns_capture === 'manual') {
+                    Toast.error('Авто-перехват DNS недоступен/выключен — FakeIP сработает, только если DNS клиентов идёт через этот sing-box (укажите роутер как DNS).', 10000);
+                }
                 await refresh();
             } else {
                 Toast.error((r && r.error) || 'ошибка создания');


### PR DESCRIPTION
…eenetic)

Без этого FakeIP помогал только трафику самого роутера: на iptables DNS LAN-клиентов не доходил до движка, и домены не получали fake-IP. Теперь перехват :53 поднимается автоматически и привязан к жизненному циклу конфига (никаких «DNS-чёрных дыр», когда конфиг остановлен).

- singbox_transparent: новый режим apply(mode="dns-only") — только DNS-hijack (REDIRECT :53 → dns-port), без traffic-redirect. Своя цепочка в nat PREROUTING; локальный DNS роутера/движка (OUTPUT) не трогается → без петли.
- build_fakeip_config(capture_dns, dns_port): добавляет direct-inbound `dns-in` на dns_port (1153) — приёмник перенаправленного :53.
- SingboxManager: на старте конфига с inbound'ом `dns-in` ставит dns-only REDIRECT (только iptables; на nft DNS забирает auto_redirect TUN), на остановке снимает. Состояние сохраняется как transparent mode=dns-only — переживает перезагрузку через штатный --apply-singbox-transparent. Гард от конфликта с активным прозрачным проксированием.
- singbox_fakeip.build_and_save(capture_dns): прокидывает флаг, возвращает dns_capture ∈ {auto_redirect, iptables-redirect, manual}.
- API: capture_dns/dns_port в /api/singbox/fakeip/build.
- UI: чекбокс «Перехватывать DNS LAN-клиентов» + платформенная подсказка; предупреждение при dns_capture=manual.
- skill singbox §13: описан жизненный цикл DNS-перехвата.
- tests: dns-in inbound, dns-only rule building, детект dns-in в менеджере, режимы dns_capture (nft/iptables/off).