### PR TITLE
docs(skills): add awg + mihomo references, re-verify singbox migrations

### DIFF
--- a/.claude/skills/awg/SKILL.md
+++ b/.claude/skills/awg/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: awg
+description: >-
+  Полный справочник по AmneziaWG (AWG) в проекте zapret-gui (роутеры Keenetic на
+  Entware / OpenWrt / Linux). Использовать при любых задачах о: конфигах AWG
+  (.conf — [Interface]/[Peer], wg-quick-расширения), параметрах обфускации
+  (Jc/Jmin/Jmax, S1-S4, H1-H4, I1-I5, J1-J3, Itime) и версиях протокола
+  1.0/1.5/2.0, разборе/генерации конфигов (awg_config), жизненном цикле туннеля
+  (amneziawg-go + awg setconf + ip link/addr/route, awg_manager), установке/детекте
+  бинарей (amneziawg-go, awg/awg-quick), платформенных путях, Cloudflare WARP и
+  WARP-in-WARP (warp_generator/warp_importer/awg_warp_in_warp), интеграции с
+  нативным WireGuard Keenetic через NDMS (ndms/wg_discovery), watchdog/autostart,
+  подписках, и диагностике «handshake есть, трафика нет / 92 B in, 20 KB out /
+  туннель не поднимается». Источник истины — amnezia-vpn/amneziawg-go +
+  amneziawg-tools + docs.amnezia.org, привязка — наш код core/awg_*.py,
+  core/warp_*.py, core/ndms/wg_discovery.py, api/awg.py, web/js/pages/awg_*.js.
+---
+
+# AmneziaWG (AWG) — справочник для zapret-gui
+
+Единый источник истины о том, **как AmneziaWG реально работает** и как с ним
+обращаться в `zapret-gui`. Читать перед тем, как трогать разбор/генерацию
+`.conf`, менеджер туннелей, параметры обфускации, WARP, интеграцию с Keenetic
+или объяснять пользователю «почему handshake есть, а трафика нет».
+
+Источники истины (в порядке убывания авторитета):
+1. **amnezia-vpn/amneziawg-go** — userspace-реализация протокола на Go
+   (`README.md` = спецификация параметров обфускации); **amnezia-vpn/amneziawg-tools**
+   — форк `wireguard-tools` (`awg`/`awg-quick`); **docs.amnezia.org** —
+   описание протокола и версий (1.0 / 1.5 / 2.0).
+2. **`awg show <iface>` / `awg showconf <iface>`** — что демон реально принял.
+   Если в `showconf` нет ваших `I1`/`S3`/`H*` — значит до `awg setconf` они не
+   дошли (см. §3, §12). Это первичная диагностика.
+3. **Наш код** — `core/awg_config.py` (парсер/генератор `.conf`, ключи),
+   `core/awg_manager.py` (up/down/status/diagnostics), `core/awg_platform.py`
+   (пути), `core/awg_installer.py` + `core/awg_detector.py` (бинари/арх),
+   `core/warp_generator.py` + `core/warp_importer.py` + `core/awg_warp_in_warp.py`
+   (WARP), `core/ndms/wg_discovery.py` (нативный WG Keenetic),
+   `core/awg_watchdog.py`, `core/awg_autostart_manager.py` +
+   `core/awg_init_script.py`, `api/awg.py`, `web/js/pages/awg_*.js`.
+
+> ⚠️ **Версия протокола — главный источник «handshake есть, трафика нет».**
+> AmneziaWG несовместим между мажорными версиями обфускации (§2.3). Если
+> клиент шлёт data-пакеты в формате одной версии, а пир ждёт другую — handshake
+> проходит (он на общих параметрах), а transport-пакеты дропаются. Классическая
+> картина в `awg show`: **`transfer: 92 B received, 20 KB sent`** — мы
+> отправляем, сервер молчит. См. §12.
+
+---
+
+## 1. Как AWG используется в zapret-gui
+
+Модель: **один туннель = один сетевой интерфейс** (как у WireGuard; в отличие
+от sing-box, где инстанс = файл). Имя инстанса = имя `.conf` без расширения и =
+имя интерфейса (конфиг `awg0.conf` → интерфейс `awg0`).
+
+**Мы НЕ используем `awg-quick`.** Логику wg-quick (Address/MTU/Table/DNS/
+PreUp…PostDown, маршруты из `AllowedIPs`) мы реализуем сами в
+`awg_manager._do_up`, а ядро поднимаем напрямую:
+
+```
+amneziawg-go <iface>                 # форкает userspace-демон + TUN-устройство
+awg setconf <iface> <filtered.conf>  # заливает крипто + обфускацию в демон
+ip link set dev <iface> mtu <MTU>
+ip addr add <Address> dev <iface>
+ip link set dev <iface> up
+ip route add <AllowedIPs> dev <iface> table <id>   # если Table != off
+```
+
+Почему так, а не `awg-quick up`: на Keenetic/Entware нет полноценного bash и
+ряда утилит, которые тянет `awg-quick`; нам нужен контроль над таблицами
+маршрутизации (Selective routing GUI) и устойчивый teardown. Поэтому
+`amneziawg-go` (userspace) + `awg setconf` + ручной `ip` — наш базовый путь.
+
+**Поток:**
+- **Конфиги** лежат в `platform.config_dir` (Keenetic: `/opt/etc/amneziawg/`).
+  CRUD — через `api/awg.py` поверх `core/awg_config.py`.
+- **`awg setconf`** получает НЕ весь `.conf`, а отфильтрованный (только
+  `WG_INTERFACE_FIELDS` + `WG_PEER_FIELDS`, §3) — wg-quick-поля демон не
+  понимает.
+- **Маршрутизация GUI** поверх: `target_iface = <iface>`, правила навешивает
+  `core/routing/applier` при подъёме интерфейса.
+
+---
+
+## 2. Параметры обфускации AmneziaWG (официальная истина)
+
+AmneziaWG — форк WireGuard-Go, который убирает узнаваемые DPI-сигнатуры
+WireGuard, **сохраняя его крипто и производительность**. Все «магия» —
+дополнительные поля в секции **`[Interface]`** (одинаковые у клиента и сервера,
+кроме случаев, где иначе сказано). **Если все параметры = 0 → ведёт себя как
+обычный WireGuard** (для плавной миграции).
+
+### 2.1 Таблица параметров (источник: amneziawg-go README + docs.amnezia.org)
+
+| Параметр | Что делает | Диапазон/рекомендация | Версия |
+|----------|-----------|------------------------|--------|
+| **Jc** | **Кол-во** junk-пакетов перед handshake (после I1–I5) | рекоменд. 4–12 (docs: 0–10) | 1.0 |
+| **Jmin** | Мин. **размер** junk-пакета | байты; `Jmin ≤ Jmax` | 1.0 |
+| **Jmax** | Макс. **размер** junk-пакета | байты; **`Jmax < MTU`** (иначе фрагментация); docs: 64–1024 | 1.0 |
+| **S1** | Префикс-padding handshake **init** | 0–64 байт | 1.0 |
+| **S2** | Префикс-padding handshake **response** | 0–64 байт | 1.0 |
+| **S3** | Префикс-padding handshake **cookie** | 0–64 байт | **2.0** |
+| **S4** | Префикс-padding **transport** (data) | 0–32 байта | **2.0** |
+| **H1** | Магический заголовок (тип) пакета **init** | 0…4294967295 | 1.0 |
+| **H2** | Магический заголовок пакета **response** | 0…4294967295 | 1.0 |
+| **H3** | Магический заголовок пакета **cookie** | 0…4294967295 | 1.0 |
+| **H4** | Магический заголовок **transport** (data) | 0…4294967295 | 1.0 |
+| **I1…I5** | Signature-пакеты перед handshake (мимикрия под реальный протокол), hex-blob в формате Custom Protocol Signature | произвольный hex | **1.5** |
+| **J1…J3** | Доп. junk-параметры | — | 1.5, **удалены в 2.0** |
+| **Itime** | Тайминг signature-пакетов | — | 1.5, **удалён в 2.0** |
+
+> **Junk vs padding vs header — не путать.** `Jc/Jmin/Jmax` — отдельные
+> мусорные пакеты ДО рукопожатия. `S1–S4` — случайный префикс ВНУТРИ реальных
+> пакетов каждого типа. `H1–H4` — подменяют первый байт (тип сообщения), чтобы
+> DPI не видел сигнатуру WireGuard.
+
+### 2.2 H1–H4: ограничения
+
+- Стандартный WireGuard использует типы сообщений **1, 2, 3, 4** (init/
+  response/cookie/transport). `H1–H4` их заменяют → значения должны **отличаться
+  от 1–4 и друг от друга**. Поэтому наш `warp_generator` берёт `H*` из диапазона
+  **`5 … 0x7FFFFFFF`** (`core/warp_generator.py`).
+- В **AmneziaWG 2.0** у `H1–H4` появилась **поддержка диапазонов** (range): значения
+  выбираются случайно в заданном окне и **не должны перекрываться**. В `.conf`
+  это строка вида `H1 = 123-456`. Поэтому в нашем парсере `H*` — строковые поля,
+  а не строго int (хотя одиночное число тоже валидно).
+
+### 2.3 Версии протокола и совместимость (КРИТИЧНО)
+
+| Версия | Что добавляет | Параметры |
+|--------|---------------|-----------|
+| **1.0** | базовая обфускация: junk + magic-headers + padding init/response | Jc, Jmin, Jmax, S1, S2, H1–H4 |
+| **1.5** | мимикрия под обычные UDP-протоколы (QUIC, DNS…) через signature-пакеты | + I1–I5, J1–J3, Itime |
+| **2.0** | «полная мимикрия»: меняющиеся заголовки и размеры пакетов и в data-фазе | + S3, S4; range для H1–H4; **− J1–J3, Itime** |
+
+> **Версия должна совпадать на обоих концах.** Подключиться по 2.0 к
+> старому пиру нельзя; в старом AmneziaVPN профиль 2.0 даже не покажется, хотя
+> сервер его поддерживает (docs.amnezia.org). **Это и есть инженерная причина
+> "92 B in / 20 KB out"**: handshake собирается на общих параметрах и проходит,
+> а data-пакеты пир дропает, потому что ждёт другой набор обфускации (например,
+> на сервере включены S3/S4/I1, а в нашем конфиге их нет — или наоборот, мы их
+> потеряли при парсинге, см. §3).
+
+---
+
+## 3. Формат `.conf` и наш парсер (`core/awg_config.py`)
+
+API модуля: `parse_conf(text) -> {"interface": {...}, "peers": [{...}]}`,
+`render_conf(cfg) -> text`, `validate(cfg) -> [errors]`, `generate_keypair()`.
+
+### 3.1 Какие поля куда идут
+
+| Группа | Константа | Куда применяется |
+|--------|-----------|------------------|
+| Крипто + ListenPort + FwMark + **вся обфускация** | `WG_INTERFACE_FIELDS` | в демон через **`awg setconf`** |
+| `Address, DNS, MTU, Table, PreUp, PostUp, PreDown, PostDown, SaveConfig` | `WGQUICK_INTERFACE_FIELDS` | **наша wg-quick-логика** в `_do_up` (демон их НЕ видит) |
+| `PublicKey, PresharedKey, AllowedIPs, Endpoint, PersistentKeepalive` | `WG_PEER_FIELDS` | в демон через `awg setconf` |
+
+`WG_INTERFACE_FIELDS` содержит: `PrivateKey, ListenPort, FwMark`, обфускацию v1
+(`Jc, Jmin, Jmax, S1, S2, H1, H2, H3, H4, I`) и расширенную (`S3, S4, I1–I5,
+J1–J3, Itime`). Числовые валидируются как int (`AWG_OBFUSCATION_FIELDS`); hex-blob
+`I1–I5, J1–J3` — отдельно (`AWG_V2_BLOB_FIELDS`).
+
+> **Поле `I` (без цифры)** присутствует в нашем списке полей, но **в upstream
+> AmneziaWG такого параметра нет** — там только `I1…I5`. Это технический
+> passthrough; не предлагай его пользователю как параметр обфускации.
+> Расширенный набор у нас исторически назван «v2», хотя по docs.amnezia.org
+> `J1–J3`/`Itime` относятся к 1.5 и **удалены в 2.0** — мы их просто
+> пропускаем как есть, решение принимает движок.
+
+### 3.2 Парсинг hex-blob `I1–I5` (многострочный `<b …>`) — частый баг
+
+`I1…I5` в `.conf` приходят как бинарный blob в одной из форм:
+
+```ini
+# однострочная
+I1 = <b 0xf6ab...>
+
+# многострочная (закрывается '>' или новым 'Key=' или пустой строкой)
+I1 = <b
+0xf6ab34c1...
+9d2e...
+>
+```
+
+`parse_conf` накапливает hex-куски (`pending_*`/`flush_pending`) и склеивает их.
+**Без этой обработки парсер брал только `<b`, и `I1` терялся при
+`render_setconf`** → handshake проходил, а сервер дропал data → ровно «92 B in /
+20 KB out». Если меняешь парсер — не сломай blob-склейку; тесты —
+`tests/test_awg_config.py`.
+
+### 3.3 Прочее
+
+- Голым адресам без маски `parse_conf` добавляет `/32`/`/128`, чтобы `awg`/`ip`
+  их приняли.
+- `_is_base64_key` проверяет ключи: 44 символа, заканчивается `=`, декодится в
+  32 байта. `validate()` ругается на кривые ключи/`Endpoint`/`AllowedIPs`.
+- `render_conf` пишет полный `.conf` (для хранения/показа), а в `awg setconf`
+  уходит **отфильтрованный** временный файл (только setconf-поля).
+
+---
+
+## 4. Инструменты AmneziaWG (CLI)
+
+Форк wireguard-tools, CLI идентичен — просто `awg` вместо `wg`:
+
+| Команда | Назначение | Используем мы? |
+|---------|-----------|----------------|
+| `awg show [<iface>] [dump]` | статус: handshake, transfer, endpoint, allowed-ips | **да** (status/diagnostics; `dump` — таб-разделённый машинный вид) |
+| `awg showconf <iface>` | дамп активного конфига демона | да (диагностика — что реально принято) |
+| `awg setconf <iface> <file>` | залить конфиг в демон (replace) | **да** (основной путь конфигурации) |
+| `awg syncconf <iface> <file>` | применить дельту без сброса peers | нет (мы делаем setconf при up) |
+| `awg genkey` / `pubkey` / `genpsk` | генерация ключей | через наш `generate_keypair` (Python) |
+| `awg set <iface> …` | точечная правка | нет |
+| `awg-quick up/down <conf>` | bash-обёртка (Address/MTU/Table/routes/DNS) | **НЕТ** — реализуем сами (§1) |
+| `amneziawg-go <iface>` | запустить userspace-демон + TUN | **да** (это и есть «движок») |
+
+Альтернативы userspace-демону: модуль ядра `amneziawg` (DKMS /
+`amneziawg-linux-kernel-module`). Мы ставим/детектим **userspace `amneziawg-go`**
+(§7) — он не требует сборки под ядро роутера.
+
+---
+
+## 5. Жизненный цикл туннеля (`awg_manager`)
+
+### 5.1 Подъём — `_do_up`
+1. `validate()` конфига; если ошибки — не стартуем.
+2. `PreUp`-хуки.
+3. `amneziawg-go <iface>` (subprocess) — форкает демон + TUN. PID находим через
+   `pgrep`, пишем в `<run_dir>/awg-<iface>.pid`.
+4. короткая пауза (UAPI-сокет `/var/run/wireguard/<iface>.sock` должен подняться).
+5. `awg setconf <iface> <filtered.conf>` — крипто + обфускация.
+6. `ip link set dev <iface> mtu <MTU>` (если задан).
+7. `ip addr add <Address>` (каждый адрес).
+8. `ip link set dev <iface> up`.
+9. маршруты из `AllowedIPs` → `table <id>` (если `Table != off`). `id` —
+   стабильный хэш имени интерфейса в диапазоне **100…999**.
+10. снимок состояния `<run_dir>/awg-<iface>.last_up.json` + список добавленных
+    маршрутов `<run_dir>/awg-<iface>.routes.json` (чтобы корректно снять при down).
+11. `PostUp`-хуки → `core.routing.applier.apply_all_on_interface_up()`.
+
+### 5.2 Снятие — `_do_down`
+Обратный порядок: `PreDown` → снять правила роутинга → удалить добавленные
+маршруты → `ip link down` → `ip link delete dev <iface>` → SIGTERM (затем
+SIGKILL) демону по PID → удалить pid-файл и UAPI-сокет → `PostDown` →
+откат auto-dnsmasq (если это был последний AWG-интерфейс).
+
+`restart` = down → up. `status(name)` парсит `awg show <iface> dump`
+(per-peer: `latest_handshake` unix-ts, `rx_bytes`, `tx_bytes`).
+
+---
+
+## 6. Платформенные пути (`awg_platform`)
+
+| | Keenetic/Entware | OpenWrt | Generic Linux |
+|--|------------------|---------|---------------|
+| bin | `/opt/usr/sbin` | `/usr/sbin` | `/usr/local/bin` |
+| config | `/opt/etc/amneziawg` | `/etc/amneziawg` | `/etc/amneziawg` |
+| run | `/opt/var/run/awg` | `/var/run/awg` | `/var/run/awg` |
+| init | `/opt/etc/init.d` | `/etc/init.d` | `/etc/systemd/system` |
+
+Файлы в `run_dir`: `awg-<iface>.pid`, `awg-<iface>.routes.json`,
+`awg-<iface>.last_up.json`. UAPI-сокет демона — `/var/run/wireguard/<iface>.sock`
+(путь от wireguard-go, не от нашего run_dir).
+
+`awg_detector.CONFIG_DIR_CANDIDATES` ищет чужие конфиги и в
+`/opt/etc/amnezia/{amneziawg,awg}`, `/opt/etc/AmneziaWG`, `*/wireguard` и т.д. —
+импорт из существующих установок Amnezia.
+
+---
+
+## 7. Установка и детект (`awg_installer` / `awg_detector`)
+
+- **Что ставим:** `amneziawg-go` (userspace-демон) и утилиту `awg` (при отсутствии
+  — fallback на `wg`). Источник — GitHub-релизы (манифест через `api/awg/manifest`).
+- **Архитектура** (`detect_architecture()`): сначала `opkg print-architecture`
+  (берём приоритетный не-`all`/не-`noarch`), fallback — `uname -m` + `/proc`.
+  Артефактные архи: `mipsel-softfloat`, `mips-softfloat`, `aarch64`, `armv7`,
+  `x86_64`. **Endianness MIPS** определяется по `sys.byteorder` (т.к. `uname -m`
+  на mips неоднозначен).
+- **Версия бинаря** — `<bin> --version`/`-v`, regex `v?(\d+(\.\d+){1,3}…)`; fallback
+  `opkg status <pkg>` для Entware.
+- **Битый бинарь** (`_probe_binary`): ловим `exec format error`, `cannot execute
+  binary`, `syntax error` — типичная ситуация при неверной арх/endianness.
+
+---
+
+## 8. Cloudflare WARP и WARP-in-WARP
+
+### 8.1 Генерация WARP (`warp_generator.py`)
+- Регистрация: `POST https://api.cloudflareclient.com/v0a2483/reg` (генерим пару
+  ключей, регистрируем публичный, получаем peer/endpoint).
+- Дефолты: endpoint `engage.cloudflareclient.com:2408`, peer-pubkey
+  `bmXOC+F1FxEMF9dyiK2H5/1SUtzH0JuVo51h2wPfgyo=`.
+- **Диапазоны обфускации для WARP:** `Jc 4..12`, `Jmin=40`, `Jmax=70`,
+  `S1,S2 15..100`, `H1–H4 5..0x7FFFFFFF`. **Запрещённые размеры пакетов** (это
+  фиксированные размеры самого WireGuard, маскировку сломают): `32, 64, 92, 148`.
+
+### 8.2 Импорт WARP (`warp_importer.py`)
+Распознаёт готовый `.conf` как WARP по: endpoint в диапазонах Cloudflare
+(`162.159.192.0/24`, `162.159.193.0/24`, …), `AllowedIPs` = `0.0.0.0/0`/`::/0`,
+наличию AWG-обфускации.
+
+### 8.3 WARP-in-WARP (двойной туннель, `awg_warp_in_warp.py`)
+Состояние в `config["awg"]["warp_in_warp"]`. Подъём:
+1. **Резолв endpoint внутреннего** туннеля ДО подъёма (пока маршрут «наружу» ещё
+   прямой).
+2. поднять **внешний** туннель (если не запущен).
+3. добавить `/32` (или `/128`) маршрут к IP внутреннего endpoint **через внешний**
+   интерфейс (чтобы внутренний handshake пошёл сквозь внешний).
+4. поднять **внутренний** туннель.
+5. сохранить флаги «кого подняли мы» (чтобы при teardown не уронить чужое).
+
+Статус = оба туннеля живы + маршрут к inner-endpoint существует + handshake свежий.
+
+---
+
+## 9. Нативный WireGuard Keenetic (NDMS) — `core/ndms/wg_discovery.py`
+
+На Keenetic есть **свой** WireGuard (`Wireguard0`, `Wireguard1`, …), которым
+рулит прошивка через NDMS/RCI, а не наш `amneziawg-go`.
+
+- `wg_discovery` перечисляет такие интерфейсы через RCI (имя, описание, state,
+  address, `type: wireguard`, `source: ndms`), кэш **30 c**.
+- `awg_manager.list_interfaces()` показывает их рядом с нашими userspace-AWG.
+- Для NDMS-нативных интерфейсов `status()` **делегирует** чтение в NDMS
+  (`should_delegate_monitoring()`), а не дёргает `awg show` — иначе получим
+  пусто (демон-то не наш).
+
+> Не пытайся поднимать/опускать `WireguardN` через `ip`/`awg` — это сломает
+> состояние прошивки. Управление ими — через NDMS-команды (`core/ndms/`).
+
+---
+
+## 10. Watchdog и автозапуск
+
+**Watchdog** (`awg_watchdog.py`) — перезапуск при «протухшем» handshake:
+`handshake_timeout_sec=180`, `check_interval_sec=30`, `cooldown_sec=300`,
+`max_restarts_per_hour=6`, опциональный TCP-`probe` (host:port сквозь туннель).
+`decide_restart()`: рестарт, если возраст handshake ≥ timeout **или** probe
+падает N раз; учитывает per-iface cooldown и rate-limit.
+
+**Autostart** (`awg_autostart_manager` + `awg_init_script`): флаг на конфиг в
+`config["awg"]["autostart"]`. Init-скрипт:
+- **Entware:** `/opt/etc/init.d/S51amneziawg-gui` (`start|stop|restart`);
+- **OpenWrt:** procd (`start_service`/`stop_service`);
+- **systemd:** `awg-gui.service`.
+
+Все вызывают `python3 app.py --apply-awg-autostart` / `--stop-awg-autostart`
+(поднимает включённые конфиги + восстанавливает WARP-in-WARP).
+
+---
+
+## 11. API (`api/awg.py`)
+
+| Метод | Путь | Назначение |
+|-------|------|-----------|
+| GET | `/api/awg/environment` | отчёт детектора (платформа, арх, TUN, бинари) |
+| POST | `/api/awg/environment/refresh` | пере-сканировать |
+| GET | `/api/awg/manifest` | манифест GitHub-релизов |
+| POST | `/api/awg/install`, `/api/awg/uninstall` | бинари |
+| GET | `/api/awg/configs` | список конфигов |
+| GET/PUT/DELETE | `/api/awg/configs/<name>` | CRUD конфига |
+| POST | `/api/awg/configs/<name>/up`\|`down`\|`restart` | жизненный цикл |
+| GET | `/api/awg/configs/<name>/status` | статус интерфейса |
+| POST | `/api/awg/warp/import`, `/api/awg/warp/generate` | WARP |
+| GET/POST | `/api/awg/warp-in-warp` | двойной туннель |
+| GET/POST | `/api/awg/watchdog` | настройки watchdog |
+| GET/POST | `/api/awg/autostart` | автозапуск |
+| POST | `/api/awg/subscription/import`\|`preview` | импорт подписки |
+
+---
+
+## 12. Диагностика «не работает» (чек-лист)
+
+1. **`awg show <iface>`** — есть ли peer и свежий `latest handshake`?
+   - **нет handshake вообще** → не туда `Endpoint`/`PublicKey`, фаервол/маршрут
+     до endpoint (на Keenetic — проверь, что трафик к endpoint не заворачивается
+     в сам туннель; для WARP-in-WARP нужен `/32`-маршрут, §8.3), не тот
+     `ListenPort`, либо **H1–H4/обфускация не совпадает с пиром** (DPI/сервер
+     дропают и сам handshake).
+   - **handshake есть, но `transfer: ~92 B received, ~20 KB sent`** → классика
+     **рассинхрона версии/параметров обфускации** (§2.3). Мы шлём data, сервер
+     молчит. Проверь:
+     a) совпадают ли `S1–S4`, `H1–H4`, `I1–I5`, `Jc/Jmin/Jmax` с серверным
+        конфигом (версия 1.0/1.5/2.0 одинаковая!);
+     b) **не потерялся ли `I1` при парсинге** (§3.2) — сравни `awg showconf
+        <iface>` с исходным `.conf`; в `awg_manager` есть `_compute_i1_lengths()`,
+        который сверяет длину blob из конфига с тем, что эхо-ит `awg show`
+        (несовпадение = blob недопарсился или демон старый, не понимает 2.0).
+2. **`awg showconf <iface>`** — реально ли в демоне ваши `S3/S4/I1/H*`? Если их
+   там нет — они не дошли через `setconf` (фильтрация `WG_INTERFACE_FIELDS` или
+   баг парсера) или **бинарь старый** и игнорирует новые поля.
+3. **версия бинаря** `amneziawg-go --version` / `awg --version` — поддерживает ли
+   он 2.0-поля (`S3/S4`, range-`H*`)? Старый демон молча работает в 1.x.
+4. **MTU/фрагментация** — `Jmax`/`S*` не должны раздувать пакет за MTU; дефолт
+   `MTU=1420`. Симптом: handshake ок, мелкое работает, крупное/TLS виснет.
+5. **битый бинарь** (неверная арх/endianness MIPS) — `_probe_binary`,
+   «exec format error». Переустановить под верную арх (§7).
+6. **`awg_manager.diagnostics()`** даёт полный снимок: бинари, конфиг (privkey
+   замаскирован), `awg show`, `ip rule`/`ip route`, маршрут до каждого endpoint,
+   состояние фаервола/dnsmasq.
+7. **Keenetic native WG** не управляется нами — статус берётся из NDMS (§9), не
+   из `awg show`.
+
+---
+
+## 13. Layout (где что)
+
+- Парсер/генератор `.conf`, ключи: `core/awg_config.py`.
+- Жизненный цикл, статус, диагностика: `core/awg_manager.py`.
+- Пути/раскладка: `core/awg_platform.py`.
+- Установка/детект бинарей и арх: `core/awg_installer.py`, `core/awg_detector.py`.
+- WARP: `core/warp_generator.py`, `core/warp_importer.py`,
+  `core/awg_warp_in_warp.py`.
+- Нативный WG Keenetic: `core/ndms/wg_discovery.py`.
+- Watchdog/автозапуск: `core/awg_watchdog.py`, `core/awg_autostart_manager.py`,
+  `core/awg_init_script.py`, `core/awg_keenetic_setup.py`.
+- API: `api/awg.py`. UI: `web/js/pages/awg_{setup,dashboard,configs,routing,warp}.js`.
+- Тесты: `tests/test_awg_*.py`, `tests/test_api_awg.py`.

--- a/.claude/skills/mihomo/SKILL.md
+++ b/.claude/skills/mihomo/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: mihomo
+description: >-
+  Полный справочник по mihomo (MetaCubeX, ядро Clash.Meta) в проекте zapret-gui
+  (роутеры Keenetic на Entware / OpenWrt / Linux). Использовать при любых задачах
+  о: clash-YAML конфигах (general-ключи, proxies, proxy-groups, rules,
+  rule-providers, proxy-providers, dns/fake-ip, tun, sniffer, listeners), типах
+  прокси (ss/vmess/vless/trojan/hysteria2/tuic/wireguard/…), CLI (mihomo -d/-f/-t/-v),
+  external-controller (RESTful API + metacubexd), запуске/валидации/диагностике
+  инстансов (mihomo_manager), установке/детекте бинаря и архитектурах
+  (mihomo_installer/detector), платформенных путях, автозапуске, geo-базах, а также
+  о НАШЕМ конвертере clash-YAML → sing-box outbounds (core/clash_yaml.py) для
+  импорта clash-подписок. Источник истины — MetaCubeX/mihomo + wiki.metacubex.one,
+  привязка — наш код core/mihomo_*.py, core/clash_yaml.py, api/mihomo.py,
+  web/js/pages/mihomo.js.
+---
+
+# mihomo (Clash.Meta) — справочник для zapret-gui
+
+Единый источник истины о том, **как mihomo реально работает** и как с ним
+обращаться в `zapret-gui`. Читать перед тем, как трогать менеджер mihomo,
+конвертер clash-YAML, установку/детект или объяснять «почему mihomo не
+стартует / конфиг не валиден».
+
+Источники истины (в порядке убывания авторитета):
+1. **wiki.metacubex.one** — официальная документация конфигурации и CLI;
+   **MetaCubeX/mihomo** (Go-исходники, `docs/config.yaml`) — окончательная
+   истина по схеме. mihomo — наследник Clash.Meta, форк-линия от Dreamacro/clash.
+2. **`mihomo -t -f <config>`** — валидатор самого бинаря. Молчит → конфиг
+   валиден для ЭТОЙ версии; ругается — это и есть причина.
+3. **Наш код** — `core/mihomo_manager.py` (run/test/up/down/status),
+   `core/mihomo_platform.py` (пути), `core/mihomo_installer.py` +
+   `core/mihomo_detector.py` (бинарь/арх), `core/mihomo_autostart.py`,
+   `core/clash_yaml.py` (конвертер clash→sing-box, §10), `api/mihomo.py`,
+   `web/js/pages/mihomo.js`.
+
+> ⚠️ **Мы почти не трогаем содержимое YAML.** `mihomo_manager` хранит конфиг
+> как текст, проверяет минимально (валидный YAML + есть `proxies` или
+> `proxy-providers`) и отдаёт всё на откуп `mihomo -t`. Поэтому **истина по
+> ключам — официальная вики, а не наш код.** Не «угадывай» поля по нашему
+> парсеру — их там нет.
+
+---
+
+## 1. Две роли mihomo в zapret-gui (не путать)
+
+1. **Standalone движок.** `mihomo_manager` запускает `mihomo -d <config_dir> -f
+   <config.yaml>` как отдельный прокси-движок (clash-YAML конфиги, свой
+   inbound/DNS/TUN/правила, RESTful API). Это самостоятельная альтернатива
+   sing-box.
+2. **Конвертер импорта.** `core/clash_yaml.py` — это **НЕ про запуск mihomo**, а
+   про разбор clash-YAML подписки и **конвертацию proxies → sing-box
+   outbounds** (§10). Используется, когда пользователь импортирует clash-ссылку,
+   но гоняет трафик через sing-box.
+
+Когда говорят «mihomo не работает» — сначала пойми, о какой роли речь: упавший
+процесс mihomo (§11–16) или неконвертированный proxy при импорте в sing-box (§10).
+
+---
+
+## 2. CLI mihomo (что вызываем)
+
+| Флаг/команда | Назначение | Используем? |
+|--------------|-----------|-------------|
+| `-d <dir>` | home/workdir: тут лежат `config.yaml`, кэш, **geo-базы** | **да** (`-d <config_dir>`) |
+| `-f <file>` | путь к конфигу | **да** |
+| `-t` | проверить конфиг и выйти (test) | **да** (pre-flight + `/validate`) |
+| `-v` | версия | да (детект версии) |
+| `-ext-ctl <addr>` | переопределить external-controller | нет (через YAML) |
+| `-ext-ui`, `-secret`, `-m` | UI/секрет/лимит памяти | нет |
+
+Запуск у нас: `mihomo -d <config_dir> -f <config.yaml>` в новой сессии
+(`start_new_session`), `stdin=DEVNULL`, stdout/stderr → лог-файл,
+`RLIMIT_NOFILE=65536`, PID → `<run_dir>/mihomo-<name>.pid`.
+
+---
+
+## 3. Верхнеуровневые (general) ключи clash-YAML
+
+Источник: wiki.metacubex.one/en/config/general.
+
+| Ключ | Назначение |
+|------|-----------|
+| `port` / `socks-port` / `mixed-port` | HTTP / SOCKS / совмещённый порт |
+| `redir-port` / `tproxy-port` | прозрачный proxy (REDIRECT / TPROXY) |
+| `authentication` | логин:пароль для http/socks/mixed |
+| `allow-lan` / `bind-address` | доступ из LAN / какие адреса слушать |
+| `mode` | `rule` (по правилам, дефолт) / `global` / `direct` |
+| `log-level` | `silent`/`error`/`warning`/`info`/`debug` |
+| `ipv6` | принимать IPv6 (дефолт `true`) |
+| `external-controller` | адрес RESTful API (для metacubexd / нашего мониторинга) |
+| `external-ui` / `secret` | статика UI по `<api>/ui` / ключ доступа к API |
+| `tcp-concurrent` | конкурентные TCP по всем resolved-адресам |
+| `unified-delay` | двойной замер задержки (убрать вклад handshake) |
+| `geodata-mode` | формат geoip: `mmdb` или `dat` |
+| `geo-auto-update` / `geox-url` | автообновление / кастомные URL geo-баз |
+| `find-process-mode` | `always`/`strict`(дефолт)/`off` — матчинг процессов |
+| `global-client-fingerprint` | uTLS-отпечаток по умолчанию |
+| `profile` | `store-selected` (запоминать выбор в группах), `store-fake-ip` |
+
+Секции: `proxies` (§4), `proxy-groups` (§5), `rules`+`rule-providers` (§6),
+`proxy-providers` (§9), `dns` (§7), `tun`+`listeners` (§8), `sniffer`, `hosts`,
+`ntp`, `experimental`.
+
+> **geo-базы (`geoip.dat`/`geosite.dat`/`*.mmdb`) zapret-gui НЕ ставит** (в
+> отличие от sing-box). Они лежат в `-d`-workdir (= `config_dir`); mihomo сам
+> качает их при старте (`geox-url`) либо их кладёт пользователь. На роутере без
+> исходящего доступа правила `GEOIP/GEOSITE` упадут, если баз нет — см. §16.
+
+---
+
+## 4. Proxies (типы и поля)
+
+mihomo поддерживает: `ss` (shadowsocks), `ssr`, `snell`, `vmess`, `vless`,
+`trojan`, `anytls`, `mieru`, `hysteria`, `hysteria2`, `tuic`, `wireguard`,
+`tailscale`, `ssh`, `http`, `socks5`, плюс `direct`/`dns`. Общие поля:
+`name` (уникальное), `type`, `server`, `port`, `udp`, `ip-version`,
+`interface-name`, `routing-mark`, `tfo`, `mptcp`, `dialer-proxy`, `smux`.
+
+Ключевые поля по типам (вики, config/proxies):
+- **vless**: `uuid`, `flow` (`xtls-rprx-vision`), `network` (`tcp`/`ws`/`grpc`/`http`),
+  `tls`, `servername`, `client-fingerprint`, `reality-opts`(`public-key`,`short-id`),
+  `ws-opts`(`path`,`headers.Host`), `grpc-opts`(`grpc-service-name`).
+- **vmess**: `uuid`, `alterId`, `cipher`(`auto`), `network`, `tls`, `servername`, `ws-opts`.
+- **trojan**: `password`, `sni`, `skip-cert-verify`, `network`, `ws-opts`.
+- **ss**: `cipher`, `password`, `udp`, опц. `plugin`/`plugin-opts`.
+- **hysteria2**: `password`(или `auth`), `sni`, `skip-cert-verify`, `up`/`down`,
+  `obfs`/`obfs-password`.
+- **tuic**: `uuid`, `password`, `sni`, `alpn`, `congestion-controller`.
+- **wireguard**: `private-key`, `peers`/`public-key`, `allowed-ips`, `reserved`,
+  и — важно — **`amnezia-wg-option`** (mihomo умеет AmneziaWG-обфускацию прямо в
+  wireguard-outbound; см. skill `awg` про сами параметры).
+
+---
+
+## 5. Proxy-groups
+
+Типы: `select`, `url-test`, `fallback`, `load-balance`, `relay`. Поля:
+`name`, `type`, `proxies`, `use` (имена proxy-providers), `url`, `interval`,
+`tolerance`, `lazy`, `timeout`, `max-failed-times`, `filter`, `exclude-filter`,
+`include-all` / `include-all-proxies` / `include-all-providers`, `disable-udp`,
+`hidden`, `icon`. У `load-balance` — `strategy`
+(`round-robin`/`consistent-hashing`/`sticky-sessions`).
+
+---
+
+## 6. Rules и rule-providers
+
+Формат правила: `ТИП,аргумент,цель[,модификатор]`. Цель — имя proxy/группы,
+`DIRECT`, `REJECT`, `PASS`.
+
+Типы (вики, config/rules): `DOMAIN`, `DOMAIN-SUFFIX`, `DOMAIN-KEYWORD`,
+`DOMAIN-REGEX`, `GEOSITE`, `IP-CIDR`, `IP-CIDR6`, `IP-SUFFIX`, `IP-ASN`,
+`GEOIP`, `SRC-GEOIP`, `SRC-IP-CIDR`, `SRC-PORT`, `DST-PORT`, `IN-PORT`,
+`IN-TYPE`, `IN-USER`, `NETWORK` (`tcp`/`udp`), `DSCP`, `PROCESS-NAME`,
+`PROCESS-PATH`, `RULE-SET`, `AND`/`OR`/`NOT`, `SUB-RULE`, `MATCH` (последнее,
+ловит всё). Модификаторы: **`no-resolve`** (не резолвить для IP-правил),
+**`src`** (матчить source IP). Примеры:
+`DOMAIN-SUFFIX,google.com,PROXY` · `IP-CIDR,127.0.0.0/8,DIRECT,no-resolve` ·
+`GEOIP,CN,DIRECT` · `MATCH,PROXY`.
+
+**rule-providers** — внешние списки правил: `type` (`http`/`file`/`inline`),
+`behavior` (`domain`/`ipcidr`/`classical`), `format` (`yaml`/`text`/`mrs`),
+`url`, `path`, `interval`. Ссылаются из `rules` через `RULE-SET,<name>,<цель>`.
+
+---
+
+## 7. DNS (включая fake-ip)
+
+Ключи (вики, config/dns): `enable`, `listen`, `ipv6`, `prefer-h3`,
+`enhanced-mode` (`fake-ip` / `redir-host`), `fake-ip-range` (дефолт
+`198.18.0.1/16`), `fake-ip-filter` + `fake-ip-filter-mode`
+(`blacklist`/`whitelist`/`rule`), `default-nameserver` (только IP — ими
+резолвятся хостнеймы других DNS), `nameserver`, `fallback`, `fallback-filter`
+(`geoip`,`geoip-code`,`geosite`,`ipcidr`,`domain`), `nameserver-policy`,
+`proxy-server-nameserver` (резолв доменов прокси-узлов), `direct-nameserver`,
+`use-hosts`, `use-system-hosts`, `respect-rules`.
+
+Схемы nameserver: `udp://`, `tcp://`, `tls://`(DoT), `https://`(DoH),
+`quic://`(DoQ), `system`, `dhcp`, `rcode://`. Суффикс `#` задаёт параметры
+сервера (например `#proxy` — гонять DNS-запрос по правилам/через прокси,
+`&ecs=…` — EDNS Client Subnet).
+
+> **fake-ip** — аналог singbox-fakeip: доменам выдаются адреса из
+> `fake-ip-range`, маршрутизация идёт по ним, по правилам восстанавливается
+> домен. На роутере это самый надёжный доменный роутинг, но требует, чтобы DNS
+> LAN-клиентов доходил до mihomo (TUN `dns-hijack` или REDIRECT :53).
+
+---
+
+## 8. TUN / прозрачное проксирование / listeners
+
+**tun** (вики, config/inbound): `enable`, `stack` (`system`/`gvisor`/`mixed`),
+`device`, `auto-route` (прописать маршруты, чтобы трафик шёл в TUN),
+`auto-redirect`, `auto-detect-interface` (авто-определение выходного интерфейса),
+`dns-hijack` (например `["any:53"]`), `mtu`, `strict-route`, `inet4-address` /
+`inet4-route-address`, `endpoint-independent-nat`.
+
+**listeners** (доп. входящие): `http`, `socks`, `mixed`, `redir`, `tproxy`,
+`tunnel`, `tun`, а также серверные `shadowsocks`/`vmess`/`vless`/`trojan`/`tuic`.
+
+> zapret-gui **не генерирует и не настраивает** TUN/tproxy/redir для mihomo —
+> это делает сам YAML пользователя. Мы лишь детектим `/dev/net/tun`
+> (`mihomo_detector`) и сообщаем доступность TUN. Прозрачный режим через ОС у
+> нас исторически завязан на sing-box (`core/singbox_transparent*`) и
+> Selective routing (`core/routing`).
+
+---
+
+## 9. proxy-providers (подписки)
+
+Внешние источники прокси: `type` (`http`/`file`/`inline`), `url`, `path`,
+`interval`, `proxy` (через какой прокси качать), `header`, `health-check`
+(`enable`,`url`,`interval`,`lazy`,`expected-status`), `override`
+(`additional-prefix`/`-suffix`, `skip-cert-verify`, `udp`, …), `filter`,
+`exclude-filter`, `exclude-type`, `dialer-proxy`. Подключаются в группах через
+`use: [<provider>]` или `include-all-providers`.
+
+---
+
+## 10. Наш конвертер clash-YAML → sing-box (`core/clash_yaml.py`)
+
+Это **отдельная** функция (импорт clash-подписки в движок sing-box), не запуск
+mihomo. Мини-парсер YAML + реестр конвертеров `_CLASH_CONVERTERS`.
+
+**Конвертируются 6 типов** (clash-proxy → sing-box outbound):
+
+| clash `type` | → sing-box | Заметки маппинга |
+|--------------|-----------|------------------|
+| `ss` | `shadowsocks` | `cipher`/`method` → `method` (через `normalize_ss_method`), `password` |
+| `vless` | `vless` | `uuid`, `flow`; `network ws/grpc` → `transport`; `tls`/`security:reality` → `tls` c `reality`(`public-key`→`public_key`,`short-id`→`short_id`), `servername`/`sni`→`server_name`, `client-fingerprint`→`utls`. **Reality без fingerprint → utls `chrome`** автоматически |
+| `vmess` | `vmess` | `uuid`, `cipher`(`auto`)→`security`, `alterId`→`alter_id`, ws-transport, tls |
+| `trojan` | `trojan` | `password`, `sni`/`servername`→`server_name`, `skip-cert-verify`→`insecure`, ws |
+| `hysteria2`/`hy2` | `hysteria2` | `password`/`auth`, sni, `skip-cert-verify`→`insecure` |
+| `tuic` | `tuic` | `uuid`, `password`, sni |
+
+**НЕ конвертируются** (пропуск с причиной «неподдерживаемый тип»): `wireguard`,
+`snell`, `ssr`, `ssh`, `http`, `socks5`, `direct`, и т.п. — для них в sing-box
+другой путь или нет аналога.
+
+> Нюанс YAML: `short-id: 01` парсится как int `1` — конвертер обрабатывает это
+> best-effort, чтобы не потерять ведущий ноль. `proxy-groups`/`rules` при таком
+> импорте **не переносятся** — берутся только узлы. Тесты: `tests/test_clash_yaml.py`.
+
+---
+
+## 11. Менеджер: запуск / валидация / статус (`mihomo_manager`)
+
+- **Имя конфига** — regex `^[A-Za-z0-9_.\-]{1,32}$`; файл `<config_dir>/<name>.yaml`.
+- **Лёгкая проверка** (`validate_yaml`): валидный YAML-словарь + есть `proxies`
+  ИЛИ `proxy-providers`. Ошибки: «пустой конфиг», «неправильный YAML», «нет
+  секции proxies».
+- **Глубокая проверка** (`validate_via_binary`): `mihomo -t -f <path>` (timeout
+  15 c) → `{ok, stdout, stderr, returncode}`.
+- **up**: pre-flight `mihomo -t`; если не прошёл — не стартуем, отдаём stderr.
+  Старт (§2), через ~1 c проверяем, не упал ли процесс; если упал — хвост лога
+  (до 80 строк) в ошибку («mihomo упал при старте (exit=…)»).
+- **down**: SIGTERM → ждём 5 c → SIGKILL. **restart** = down → 0.5 c → up.
+- CRUD: `list_configs`/`get_config`/`save_config` (атомарно через `.tmp`+rename)/
+  `delete_config` (только если не запущен). `status(name)` → `{name, active, pid,
+  log_path}`.
+
+---
+
+## 12. Установка и детект (`mihomo_installer` / `mihomo_detector`)
+
+- **Источник** — GitHub-релизы **MetaCubeX/mihomo**. Ассет:
+  `mihomo-linux-<arch>-v?<ver>.gz` (gzip-распаковка в бинарь).
+- **Маппинг арх** (от общего детектора): `x86_64→amd64`, `aarch64→arm64`,
+  `armv7→armv7`, `mips-softfloat→mips-softfloat`, `mipsel-softfloat→mipsle-softfloat`.
+  **`amd64` — точное совпадение**, не `amd64-compatible`/`amd64-v3` (это
+  отдельные варианты под старые/новые CPU).
+- **Детект бинаря**: `platform.binary_path()`, затем PATH в `/opt/usr/{sbin,bin}`,
+  `/opt/{bin,sbin}`, `/usr/local/{sbin,bin}`, `/usr/{sbin,bin}`, `/{sbin,bin}`.
+  Имена: `mihomo`, `clash.meta`, `clash-meta`, `clash` (исторические). Версия —
+  `mihomo -v`, regex `v?(\d+\.\d+\.\d+)`.
+- Состояние установки — `mihomo-installed.json` (`{tag, version, binary,
+  installed_at}`).
+
+---
+
+## 13. Платформенные пути (`mihomo_platform`)
+
+| | Keenetic/Entware | OpenWrt | Generic Linux |
+|--|------------------|---------|---------------|
+| bin | `/opt/usr/sbin/mihomo` | `/usr/sbin/mihomo` | `/usr/local/bin/mihomo` |
+| config (= `-d` workdir) | `/opt/etc/mihomo` | `/etc/mihomo` | `/etc/mihomo` |
+| run | `/opt/var/run/mihomo` | `/var/run/mihomo` | `/var/run/mihomo` |
+| log | `/opt/var/log` | `/var/log` | `/var/log` |
+| init | `/opt/etc/init.d` (`S53mihomo-gui`) | `/etc/init.d` (`mihomo-gui`) | systemd (`mihomo-gui.service`) |
+
+Шаблоны: `config_path(name)=<config_dir>/<name>.yaml`,
+`pid_path=<run_dir>/mihomo-<name>.pid`, `log_path=<log_dir>/mihomo-<name>.log`.
+**`config_dir` = `-d`-workdir mihomo**, поэтому geo-базы и кэш fake-ip кладутся
+туда же.
+
+---
+
+## 14. Автозапуск (`mihomo_autostart`)
+
+Флаги в `settings.json` → `mihomo.autostart = {<name>: true}`. Init-скрипт:
+- **Entware/OpenWrt**: sh со `start_one`/`stop_one`, `ulimit -n 65536`,
+  `setsid <bin> -d <config_dir> -f <config> &` + ручной PID-файл; действия
+  `start|stop|restart|status`.
+- **systemd**: `.service` (`LimitNOFILE=65536`). ⚠️ текущая реализация systemd-юнита
+  поднимает **только первый** включённый конфиг — для нескольких нужен отдельный
+  юнит на конфиг.
+
+`regenerate()` пишет/ставит скрипт, `apply_now()` поднимает включённые сразу,
+`remove()` удаляет скрипт.
+
+---
+
+## 15. API (`api/mihomo.py`)
+
+`GET /api/mihomo/environment` (+`/refresh`), `GET /install/status`,
+`POST /install`, `POST /uninstall`, `GET /version` (проверка обновлений),
+`GET /configs`, `POST /configs` (`{name,text}`), `GET|PUT|DELETE /configs/<name>`,
+`POST /configs/<name>/up|down|restart`, `GET /configs/<name>/status`,
+`POST /configs/<name>/validate` (`mihomo -t`), `GET /autostart`,
+`POST /autostart/<name>` (`{enabled}`), `POST /autostart/{regenerate,remove,apply}`.
+
+---
+
+## 16. Диагностика «не работает» (чек-лист)
+
+1. **`mihomo -t -f <config>`** (или `/validate`) — первый шаг. Текст ошибки =
+   причина (неизвестный ключ/тип прокси, кривой YAML, опечатка в `rules`).
+2. **Процесс упал сразу после старта?** — `mihomo_manager` отдаёт хвост лога;
+   читать `log_path` (`<log_dir>/mihomo-<name>.log`). Частое: занятый порт
+   (`mixed-port`), нет прав на TUN, битый бинарь.
+3. **`GEOIP`/`GEOSITE`/`RULE-SET` не матчатся / ошибка загрузки** — **нет geo-баз**
+   в workdir, а исходящего доступа на роутере нет (мы базы не ставим, §3). Решение:
+   положить `geoip.dat`/`geosite.dat`/`*.mmdb` в `config_dir` вручную или задать
+   доступный `geox-url`.
+4. **Битый бинарь** (неверная арх, особенно `amd64` vs `amd64-compatible`,
+   endianness MIPS) — переустановить под верную арх (§12).
+5. **`external-controller` недоступен** — проверь адрес/`secret`; для роутера
+   слушать на LAN-адресе, не только `127.0.0.1`.
+6. **Прокси не ходит, хотя инстанс жив** — проверь сам узел (sni/uuid/cipher/
+   reality), `unified-delay`/задержки в группе `url-test`, `mode` (в `direct`
+   правила игнорируются), и доходит ли DNS до mihomo при fake-ip (§7).
+7. **Импорт clash-подписки в sing-box** (НЕ запуск mihomo) — если узел
+   пропал, его тип не из 6 поддерживаемых (§10): `wireguard`/`snell`/`ssr`/… не
+   конвертируются.
+
+---
+
+## 17. Layout (где что)
+
+- Менеджер (run/test/up/down/status, CRUD): `core/mihomo_manager.py`.
+- Пути/раскладка: `core/mihomo_platform.py`.
+- Установка/детект/арх: `core/mihomo_installer.py`, `core/mihomo_detector.py`.
+- Автозапуск: `core/mihomo_autostart.py`.
+- Конвертер clash-YAML → sing-box (импорт): `core/clash_yaml.py`.
+- API: `api/mihomo.py`. UI: `web/js/pages/mihomo.js`.
+- Тесты: `tests/test_mihomo.py`, `tests/test_clash_yaml.py`.

--- a/.claude/skills/singbox/SKILL.md
+++ b/.claude/skills/singbox/SKILL.md
@@ -9,8 +9,9 @@ description: >-
   uTLS/ECH, transport (ws/grpc/httpupgrade/h2/quic), multiplex, прозрачном
   проксировании (tproxy/redirect/tun), подписках и пуле серверов
   (server_pool, subscription_*), парсинге vless:// vmess:// ss:// trojan://
-  hysteria2:// tuic://, миграциях версий 1.11/1.12/1.13 (удалённые block/dns
-  outbounds, legacy inbound-поля, новый формат DNS), режиме отладки и
+  hysteria2:// tuic://, миграциях версий 1.11/1.12/1.13/1.14 (geoip/geosite
+  удалены в 1.12, block/dns outbounds + legacy inbound-поля + wireguard outbound
+  удалены в 1.13, новый формат DNS с 1.12 и удаление legacy-DNS в 1.14), отладке и
   диагностике «sing-box не запускается / конфиг не валиден / прокси не
   работает». Источник истины — sing-box.sagernet.org + sagernet/sing-box,
   привязка — наш код core/singbox_*.py, api/singbox.py, web/js/pages/singbox*.js.
@@ -191,7 +192,9 @@ debug ушёл. Просмотр лога: `GET /api/singbox/configs/<name>/log?
 
 ### 5.3 Endpoints (1.11+)
 `endpoints` (отдельно от outbounds): `wireguard`, `tailscale`. WireGuard как
-endpoint заменил старый `type:wireguard` outbound.
+endpoint заменил старый `type:wireguard` outbound (он deprecated в 1.11 и
+**удалён в 1.13.0** — на 1.13+ `{"type":"wireguard"}` в `outbounds` не парсится,
+нужен `endpoints`). Это встроенный WG sing-box; про AmneziaWG-туннели — skill `awg`.
 
 ### 5.4 TLS / Transport / Multiplex (вложенные объекты)
 - **tls**: `enabled`, `server_name`(SNI), `insecure`, `alpn`,
@@ -213,6 +216,10 @@ endpoint заменил старый `type:wireguard` outbound.
 `domain`/`domain_suffix`/`domain_keyword`/`domain_regex`, `ip_cidr`,
 `source_ip_cidr`, `port`/`port_range`, `network`(tcp/udp), `clash_mode`,
 `rule_set`, и т.д.
+
+> ⚠️ **`geoip`/`geosite` как матчеры route-правил УДАЛЕНЫ в 1.12.0** (deprecated
+> с 1.8). На 1.12+ конфиг с `{"geosite":...}`/`{"geoip":...}` в `route.rules` не
+> парсится — замена — `rule_set` (бинарные `.srs`) либо `ip_cidr`/`domain_suffix`.
 
 **Actions (это и есть «новая модель» 1.11+):**
 | action | смысл | ключевые параметры |
@@ -238,9 +245,10 @@ endpoint заменил старый `type:wireguard` outbound.
   `strategy`.
 - **С 1.12 (типизированный):** `dns.servers[].type` ∈ `udp | tcp | tls |
   https | quic | h3 | local | hosts | dhcp | fakeip | tailscale | resolved`,
-  плюс `type:legacy` для старого address-формата (старое всё ещё принимается
-  через `legacy`). Структура: `servers[]`, `rules[]`, `final`, `strategy`,
-  `independent_cache`, `client_subnet`.
+  плюс `type:legacy` для старого address-формата. Структура: `servers[]`,
+  `rules[]`, `final`, `strategy`, `independent_cache`, `client_subnet`.
+  ⚠️ **legacy address-формат (и `type:legacy`) УДАЛЁН в 1.14.0** — на 1.14+
+  конфиг с `dns.servers[].address` не запустится, только typed-серверы.
 
 > При генерации DNS-секции учитывай целевую версию: на 1.12+ предпочитай
 > типизированные серверы; legacy-`address` всё ещё валиден как `type:legacy`,
@@ -268,19 +276,23 @@ endpoint заменил старый `type:wireguard` outbound.
 
 ## 9. Миграции версий — таблица «что удалено» (ГЛАВНОЕ при «не работает»)
 
-| Версия | Удалено / изменено | Замена | Наш статус |
-|--------|--------------------|--------|-----------|
-| 1.8 | `geoip`, `geosite` (deprecated) | `rule_set` (бинарные `.srs`) | используем ipset/hostlist + rule-set при импорте |
-| 1.11 | спец-outbounds **`block`**, **`dns`** (deprecated) | `reject` / `hijack-dns` rule-actions | `block` убран из `make_minimal_config`; dns-hijack через route |
-| 1.11 | inbound-поля `sniff*`, `domain_strategy` (deprecated) | rule-actions `sniff` / `resolve` | `make_sniff_rule()` |
-| 1.12 | формат `dns` (типизированные серверы) | `type:...`/`type:legacy` | см. §7 |
-| **1.13** | **ФАКТИЧЕСКИ УДАЛЕНЫ** всё, что было deprecated в 1.11: `block`/`dns` outbounds и legacy inbound-поля | как выше | issue #149 — наш фикс; `validate()` оставляет block/dns в «известных типах» только для ЧТЕНИЯ чужих старых конфигов |
+Сверено с офиц. `sing-box.sagernet.org/deprecated` + `/migration`
+(deprecated ≠ removed — важно различать версию объявления и версию удаления):
 
-> Симптомы на 1.13: `FATAL ... legacy inbound fields ... removed in sing-box
-> 1.13.0` (legacy sniff) или падение на `{"type":"block"|"dns"}`. Лечится
-> переходом на rule-actions. Наш генератор уже чистый; импортированные/ручные
-> конфиги пользователя — нет, поэтому существует pre-flight `check` и режим
-> отладки.
+| Версия | Что произошло | Замена | Наш статус |
+|--------|---------------|--------|-----------|
+| 1.8 | deprecated: `geoip`, `geosite` | `rule_set` (бинарные `.srs`) | ipset/hostlist + rule-set при импорте |
+| 1.11 | deprecated: спец-outbounds **`block`**/**`dns`**; inbound-поля `sniff*`/`domain_strategy`; outbound `wireguard` | rule-actions `reject`/`hijack-dns`/`sniff`/`resolve`; `endpoints` для WG | `block` убран из `make_minimal_config`; sniff/dns-hijack через route |
+| **1.12** | **УДАЛЕНЫ `geoip`/`geosite`** (как route-матчеры); формат `dns` переписан на типизированные серверы (legacy-`address` пока принимается) | `rule_set`; `type:udp/tcp/tls/…` | geo — через ipset/rule-set; DNS см. §7 |
+| **1.13** | **УДАЛЕНЫ** `block`/`dns` outbounds, legacy inbound-поля (`sniff*`/`domain_strategy`), старый outbound `type:wireguard` | как deprecated в 1.11 | issue #149 — генератор чистый; `validate()` держит block/dns в «известных типах» только для ЧТЕНИЯ старых чужих конфигов |
+| **1.14** (latest — 1.14.0-alpha) | **УДАЛЁН legacy-формат `dns`** (address-серверы / `type:legacy`); deprecated: inline `tls.acme`, address-filter поля DNS-правил (→ action `evaluate`), `independent_cache` (убрано), `store_rdrc`→`store_dns` | typed DNS-серверы (§7) | на 1.14+ `dns.servers[].address` не запустится — генерить только typed |
+
+> Симптомы по версиям: на 1.12+ — падение на `{"geosite":…}`/`{"geoip":…}` в
+> route или на legacy-DNS уже на 1.14; на 1.13 — `FATAL ... legacy inbound
+> fields ... removed in sing-box 1.13.0` (legacy sniff) либо падение на
+> `{"type":"block"|"dns"|"wireguard"}`. Лечится переходом на rule-actions/
+> rule_set/endpoints/typed-DNS. Наш генератор уже чистый; импортированные/ручные
+> конфиги пользователя — нет, поэтому существует pre-flight `check` и режим отладки.
 
 ---
 


### PR DESCRIPTION
Новые справочники .claude/skills/ для AmneziaWG и mihomo по образцу singbox/nfqws2 (Источник истины → официальные источники + привязка к коду):

- awg/SKILL.md — AmneziaWG: параметры обфускации (Jc/Jmin/Jmax, S1-S4, H1-H4, I1-I5, J1-J3, Itime) и версии 1.0/1.5/2.0 по amneziawg-go + docs.amnezia.org; формат .conf и парсер (core/awg_config), жизненный цикл amneziawg-go + awg setconf + ip (core/awg_manager), WARP/WARP-in-WARP, нативный WG Keenetic (NDMS), watchdog/autostart, API, диагностика «handshake есть, трафика нет / 92 B in, 20 KB out».
- mihomo/SKILL.md — mihomo (Clash.Meta): clash-YAML (general/proxies/ proxy-groups/rules/dns-fakeip/tun/providers) по wiki.metacubex.one; CLI, менеджер/валидация (mihomo -t), установка/арх, пути, autostart, geo-базы, конвертер clash→sing-box (core/clash_yaml.py), диагностика.

Сверка singbox/SKILL.md с sing-box.sagernet.org/deprecated:
- geoip/geosite УДАЛЕНЫ в 1.12.0 (не только deprecated в 1.8)
- block/dns outbounds + legacy inbound-поля + type:wireguard outbound УДАЛЕНЫ в 1.13.0
- legacy address-формат DNS УДАЛЁН в 1.14.0
- добавлена строка 1.14 в таблицу миграций

https://claude.ai/code/session_01MMSerhTy2wefqFsG7jGYjD