### PR TITLE
fix(gui): mihomo -t валидация, real-time логи (polling-фолбэк), async…

### DIFF
--- a/api/mihomo.py
+++ b/api/mihomo.py
@@ -188,8 +188,15 @@ def register(app):
     @app.route("/api/mihomo/configs/<name>/validate", method="POST")
     def mihomo_configs_validate(name):
         response.content_type = "application/json; charset=utf-8"
+        # Опциональный body {text}: проверить несохранённое содержимое
+        # редактора. Без него — проверяется сохранённый на диск конфиг.
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        text = body.get("text") if isinstance(body, dict) else None
         from core.mihomo_manager import get_mihomo_manager
-        return get_mihomo_manager().validate_via_binary(name)
+        return get_mihomo_manager().validate_via_binary(name, text=text)
 
     # ─────── autostart ────────────────────────────────────────────
 

--- a/core/mihomo_manager.py
+++ b/core/mihomo_manager.py
@@ -17,6 +17,7 @@ import os
 import re
 import signal
 import subprocess
+import tempfile
 import threading
 import time
 
@@ -216,16 +217,54 @@ class MihomoManager:
 
     # ─────── validate via binary ───────
 
-    def validate_via_binary(self, name: str) -> dict:
-        if not _valid_name(name):
-            return {"ok": False, "error": "Некорректное имя"}
+    def validate_via_binary(self, name: str, text: str = None) -> dict:
+        """
+        Проверка конфига бинарём: `mihomo -t -d <config_dir> -f <file>`.
+
+        `-d <config_dir>` ОБЯЗАТЕЛЕН и ставится таким же, как при реальном
+        запуске (_do_up). Без него mihomo ищет geoip/geosite-базы и
+        rule-/proxy-provider-файлы в текущем рабочем каталоге процесса GUI
+        и «ругается на конфиг», хотя при запуске (`-d config_dir`) всё на
+        месте — это и была причина ложных ошибок «Проверить (mihomo -t)».
+
+        Если передан `text`, проверяем именно его (несохранённое содержимое
+        редактора) через временный файл внутри config_dir — чтобы `-d`
+        находил geo-базы и провайдеры ровно как при сохранённом конфиге.
+        """
         binary = self._binary()
         if not binary:
             return {"ok": False, "error": "mihomo не установлен"}
-        path = self._platform().config_path(name)
-        if not os.path.isfile(path):
-            return {"ok": False, "error": "Конфиг не найден"}
-        rc, out, err = _run([binary, "-t", "-f", path], timeout=15)
+        platform = self._platform()
+        config_dir = platform.config_dir
+        self._ensure_dir(config_dir)
+
+        tmp_path = None
+        if text is not None:
+            try:
+                # tmp-файл вне списка конфигов (не *.yaml/*.yml).
+                fd, tmp_path = tempfile.mkstemp(
+                    prefix=".validate-", suffix=".tmp", dir=config_dir)
+                with os.fdopen(fd, "w") as f:
+                    f.write(text)
+            except OSError as e:
+                return {"ok": False, "error": "write tmp: %s" % e}
+            path = tmp_path
+        else:
+            if not _valid_name(name):
+                return {"ok": False, "error": "Некорректное имя"}
+            path = platform.config_path(name)
+            if not os.path.isfile(path):
+                return {"ok": False, "error": "Конфиг не найден"}
+
+        try:
+            rc, out, err = _run(
+                [binary, "-t", "-d", config_dir, "-f", path], timeout=15)
+        finally:
+            if tmp_path:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
         return {"ok": rc == 0, "stdout": out, "stderr": err,
                 "returncode": rc}
 
@@ -271,8 +310,11 @@ class MihomoManager:
         if self.is_running(name):
             return {"ok": True, "already_running": True}
 
-        # Pre-flight: mihomo -t.
-        chk_rc, _o, chk_err = _run([binary, "-t", "-f", config], timeout=15)
+        # Pre-flight: mihomo -t (с тем же -d, что и при запуске, иначе
+        # geoip/geosite/провайдеры ищутся не там и проверка ложно падает).
+        chk_rc, _o, chk_err = _run(
+            [binary, "-t", "-d", platform.config_dir, "-f", config],
+            timeout=15)
         if chk_rc != 0:
             return {"ok": False, "error":
                     "mihomo -t %s: %s" % (name, (chk_err or "").strip())}

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -629,6 +629,16 @@ input:focus, textarea:focus, select:focus {
     to { transform: rotate(360deg); }
 }
 
+/* Маленький спиннер для строк/кнопок (рядом с текстом) */
+.spinner-inline {
+    width: 12px;
+    height: 12px;
+    border-width: 2px;
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 4px;
+}
+
 /* ===== Toast Notifications ===== */
 .toast-container {
     position: fixed;
@@ -2537,6 +2547,13 @@ input:focus, textarea:focus, select:focus {
 
 .logs-conn-error .logs-conn-dot { background: var(--error); }
 .logs-conn-error .logs-conn-text { color: var(--error); }
+
+/* polling-фолбэк: данные идут (опросом), не алармим — мягкий зелёный пульс */
+.logs-conn-polling .logs-conn-dot {
+    background: var(--success);
+    animation: pulse-dot 1.6s ease infinite;
+}
+.logs-conn-polling .logs-conn-text { color: var(--success); }
 
 @keyframes pulse-dot {
     0%, 100% { opacity: 1; }

--- a/web/js/pages/logs.js
+++ b/web/js/pages/logs.js
@@ -29,6 +29,14 @@ const LogsPage = (() => {
     let statsTimer = null;
     let maxDisplayEntries = 500;
 
+    // Polling-фолбэк: когда SSE недоступен (часто на Keenetic за
+    // KeenDNS/прокси, которые буферизуют поток) — добираем новые записи
+    // обычным опросом /api/logs?since=<lastTs>, чтобы лог всё равно
+    // обновлялся «вживую», а не висел до ручного refresh.
+    let pollFallbackTimer = null;
+    let pollInFlight = false;
+    let lastTs = 0;                 // курсор: timestamp последней записи
+
     // Цветовая карта уровней
     const LEVEL_CONFIG = {
         DEBUG:   { color: '#6b7280', bg: 'rgba(107, 114, 128, 0.1)', label: 'DEBUG',   icon: '🔍' },
@@ -206,6 +214,9 @@ const LogsPage = (() => {
             const data = await API.get('/api/logs?n=500');
             if (data.ok && data.entries) {
                 entries = data.entries;
+                // Курсор для polling-фолбэка: самый свежий timestamp.
+                lastTs = entries.reduce((m, e) => Math.max(m, e.timestamp || 0), 0)
+                         || (Date.now() / 1000);
                 applyFilters();
                 renderEntries();
                 updateCounts();
@@ -224,19 +235,14 @@ const LogsPage = (() => {
             eventSource = null;
         }
 
-        // Защита от спама переподключений: если слишком много попыток
-        // подряд — останавливаемся и показываем ошибку
-        if (reconnectAttempts > 10) {
-            updateConnectionStatus('error');
-            return;
-        }
-
         try {
             eventSource = new EventSource('/api/logs/stream');
 
             eventSource.onopen = () => {
                 isConnected = true;
                 reconnectAttempts = 0;
+                // SSE снова живой — polling-фолбэк больше не нужен.
+                stopPollFallback();
                 updateConnectionStatus('connected');
             };
 
@@ -267,7 +273,6 @@ const LogsPage = (() => {
 
             eventSource.onerror = () => {
                 isConnected = false;
-                updateConnectionStatus('disconnected');
 
                 // Закрываем текущий EventSource
                 if (eventSource) {
@@ -275,11 +280,14 @@ const LogsPage = (() => {
                     eventSource = null;
                 }
 
+                // Включаем polling-фолбэк, чтобы лог продолжал наполняться,
+                // пока SSE недоступен, и продолжаем пытаться поднять SSE.
+                startPollFallback();
                 scheduleReconnect();
             };
         } catch (err) {
             isConnected = false;
-            updateConnectionStatus('error');
+            startPollFallback();
             scheduleReconnect();
         }
     }
@@ -288,15 +296,65 @@ const LogsPage = (() => {
         if (reconnectTimer) return;
 
         reconnectAttempts++;
-        // Экспоненциальная задержка: 1s, 2s, 4s, 8s, max 30s
+        // Экспоненциальная задержка: 1s, 2s, 4s, 8s, max 30s.
+        // Не сдаёмся «навсегда»: SSE дёшево пытать раз в 30с, а данные
+        // тем временем идут через polling-фолбэк.
         const delay = Math.min(1000 * Math.pow(2, reconnectAttempts - 1), 30000);
 
-        updateConnectionStatus('reconnecting', delay);
+        // Если фолбэк активен и данные текут — не пугаем «Ошибкой соединения».
+        if (pollFallbackTimer) {
+            updateConnectionStatus('polling');
+        } else {
+            updateConnectionStatus('reconnecting', delay);
+        }
 
         reconnectTimer = setTimeout(() => {
             reconnectTimer = null;
             connectSSE();
         }, delay);
+    }
+
+    // ── polling-фолбэк ──────────────────────────────────────────────
+
+    async function startPollFallback() {
+        if (pollFallbackTimer) return;
+        // Без курсора рискуем задвоить с loadInitialLogs — сперва убедимся,
+        // что начальная загрузка прошла (она и выставит lastTs).
+        if (lastTs === 0) {
+            await loadInitialLogs();
+        }
+        if (pollFallbackTimer) return;      // мог стартовать, пока ждали
+        pollFallbackTimer = setInterval(pollOnce, 3000);
+        if (!isConnected) updateConnectionStatus('polling');
+        pollOnce();                          // первый опрос сразу
+    }
+
+    function stopPollFallback() {
+        if (pollFallbackTimer) {
+            clearInterval(pollFallbackTimer);
+            pollFallbackTimer = null;
+        }
+        pollInFlight = false;
+    }
+
+    async function pollOnce() {
+        if (pollInFlight) return;
+        pollInFlight = true;
+        try {
+            if (lastTs === 0) lastTs = Math.floor(Date.now() / 1000) - 1;
+            const data = await API.get(
+                '/api/logs?since=' + encodeURIComponent(lastTs));
+            if (data && data.ok && Array.isArray(data.entries)) {
+                data.entries.forEach(e => {
+                    if (e && e.timestamp > lastTs) lastTs = e.timestamp;
+                    if (!isPaused) addEntry(e);
+                });
+            }
+        } catch (_) {
+            // сетевой сбой — продолжаем пытаться на следующем тике
+        } finally {
+            pollInFlight = false;
+        }
     }
 
     function disconnectSSE() {
@@ -308,12 +366,18 @@ const LogsPage = (() => {
             clearTimeout(reconnectTimer);
             reconnectTimer = null;
         }
+        stopPollFallback();
         isConnected = false;
     }
 
     // ══════════════════ Entry Management ══════════════════
 
     function addEntry(entry) {
+        // Двигаем курсор и для SSE-пути: если SSE затем оборвётся,
+        // polling-фолбэк продолжит ровно с последней показанной записи.
+        if (entry && entry.timestamp && entry.timestamp > lastTs) {
+            lastTs = entry.timestamp;
+        }
         entries.push(entry);
 
         // Ограничиваем буфер
@@ -653,6 +717,9 @@ const LogsPage = (() => {
             case 'reconnecting':
                 if (text) text.textContent = 'Переподключение... (' + Math.round(delay / 1000) + 'с)';
                 break;
+            case 'polling':
+                if (text) text.textContent = 'Обновление опросом';
+                break;
             case 'error':
                 if (text) text.textContent = 'Ошибка соединения';
                 break;
@@ -734,6 +801,10 @@ const LogsPage = (() => {
         entries = [];
         filteredEntries = [];
         newMessageCount = 0;
+        // Сбрасываем курсор/счётчики, чтобы повторный вход на страницу
+        // стартовал «с чистого листа».
+        reconnectAttempts = 0;
+        lastTs = 0;
     }
 
     // ══════════════════ Public API ══════════════════

--- a/web/js/pages/mihomo.js
+++ b/web/js/pages/mihomo.js
@@ -267,8 +267,8 @@ rules:
                                  font-size:12px; white-space:pre; overflow:auto;">${escapeHtml(editing.text)}</textarea>
                 <div style="display:flex; gap:8px; margin-top:8px;">
                     <button class="btn btn-primary btn-sm" onclick="MihomoPage.save()">Сохранить</button>
-                    ${!isNew ? `<button class="btn btn-ghost btn-sm"
-                        onclick="MihomoPage.validate()">Проверить (mihomo -t)</button>` : ''}
+                    <button class="btn btn-ghost btn-sm"
+                        onclick="MihomoPage.validate()">Проверить (mihomo -t)</button>
                 </div>
             </div>
         `;
@@ -328,9 +328,20 @@ rules:
     }
 
     async function validate() {
-        if (!editing || editing.isNew) return;
+        if (!editing) return;
+        // Проверяем то, что СЕЙЧАС в редакторе (а не сохранённое на диск) —
+        // иначе кнопка вводит в заблуждение после правок без «Сохранить».
+        const ta = document.getElementById('mh-edit-text');
+        const text = ta ? ta.value : undefined;
+        let name = editing.name;
+        if (editing.isNew) {
+            const ni = document.getElementById('mh-edit-name');
+            name = ((ni && ni.value) || '').trim() || '_editor';
+        }
         try {
-            const r = await API.post(`/api/mihomo/configs/${encodeURIComponent(editing.name)}/validate`);
+            const r = await API.post(
+                `/api/mihomo/configs/${encodeURIComponent(name)}/validate`,
+                { text });
             if (r && r.ok) Toast.success('Конфиг валиден');
             else Toast.error('mihomo -t: ' + ((r && (r.stderr || r.error)) || 'ошибка'));
         } catch (e) { Toast.error(e.message); }

--- a/web/js/pages/singbox_setup.js
+++ b/web/js/pages/singbox_setup.js
@@ -12,6 +12,7 @@ const SingboxSetupPage = (() => {
     let manifest = null;
     let manifestError = '';
     let version = null;        // /api/singbox/version (installed + latest)
+    let latestState = 'idle';  // 'idle'|'loading'|'done' — проверка релиза (GitHub)
     let installState = { status: 'idle', progress: 0, message: '' };
 
     let pollTimer = null;
@@ -50,33 +51,48 @@ const SingboxSetupPage = (() => {
     // ══════════════ data ══════════════
 
     async function refresh() {
+        // Шаг 1 — БЫСТРАЯ локальная часть (платформа/TUN/установленная
+        // версия). Без сети, поэтому рисуем сразу и страница не «висит».
         try {
-            const [envResp, verResp] = await Promise.all([
-                API.post('/api/singbox/environment/refresh').catch(() => null),
-                API.get('/api/singbox/version').catch(() => null),
-            ]);
-            env     = envResp || null;
-            version = verResp || null;
+            env = await API.post('/api/singbox/environment/refresh')
+                           .catch(() => null);
         } catch (e) {
             // ignore
         }
+        renderContent();
 
-        // Manifest опционально — если нет интернета или нет релиза
+        // Шаг 2 — МЕДЛЕННАЯ часть (GitHub: версия в релизе + manifest).
+        // Грузим в фоне и перерисовываем, когда придёт, чтобы запрос к
+        // сети (на роутере он может тянуться десятки секунд) не блокировал
+        // открытие раздела.
+        loadLatest();
+    }
+
+    // Проверка «что в нашем релизе» — отдельно и асинхронно (см. refresh).
+    async function loadLatest() {
+        latestState = 'loading';
+        renderContent();
         try {
-            const r = await API.get('/api/singbox/manifest');
-            if (r && r.ok) {
-                manifest = r.manifest;
+            const [verResp, manResp] = await Promise.all([
+                API.get('/api/singbox/version').catch(() => null),
+                API.get('/api/singbox/manifest').catch(() => null),
+            ]);
+            version = verResp || null;
+            if (manResp && manResp.ok) {
+                manifest = manResp.manifest;
                 manifestError = '';
             } else {
                 manifest = null;
-                manifestError = (r && r.error) || 'Не удалось получить manifest';
+                manifestError = (manResp && manResp.error)
+                                || 'Не удалось получить manifest (нет сети/релиза)';
             }
         } catch (e) {
             manifest = null;
             manifestError = e.message;
+        } finally {
+            latestState = 'done';
+            renderContent();
         }
-
-        renderContent();
     }
 
     // ══════════════ poll install progress ══════════════
@@ -197,7 +213,12 @@ const SingboxSetupPage = (() => {
                         <div class="text-muted" style="font-size:11px;">
                             ${escapeHtml(bin.path || '')}
                         </div>` : ''}
-                    ${latestVersion ? `
+                    ${latestState === 'loading' ? `
+                        <div style="margin-top:4px;" class="text-muted">
+                            В нашем релизе: проверяю…
+                            <span class="spinner spinner-inline"></span>
+                        </div>`
+                      : latestVersion ? `
                         <div style="margin-top:4px;">
                             В нашем релизе: <strong>${escapeHtml(latestVersion)}</strong>
                             ${hasUpdate ? '<span style="color:#fb8;">— доступно обновление</span>' : ''}


### PR DESCRIPTION
…-установка sing-box

Три исправления из бэклога, каждое — отдельная жалоба пользователя.

1) mihomo «Проверить (mihomo -t)» ругался на конфиг
   - validate_via_binary/_do_up теперь запускают `mihomo -t -d <config_dir> -f <file>` с тем же `-d`, что и реальный запуск. Без `-d` mihomo искал geoip/geosite и rule-/proxy-провайдеры в рабочем каталоге процесса GUI и ложно падал, хотя при `up` (с `-d config_dir`) всё на месте.
   - validate принимает несохранённый текст редактора (через временный файл в config_dir) — проверяется то, что пользователь видит, а не диск.
   - кнопка «Проверить» доступна и для новых (ещё не сохранённых) конфигов.

2) Раздел ЛОГИ не наполнялся в реальном времени, висела «Ошибка соединения»
   - добавлен polling-фолбэк: когда SSE недоступен (частый случай на Keenetic за KeenDNS/прокси, буферизующими поток), лог добирается опросом /api/logs?since=<cursor> и продолжает обновляться «вживую».
   - SSE больше не сдаётся «навсегда» после 10 попыток — пытается раз в 30с, данные тем временем идут опросом; статус «Обновление опросом» вместо алармящей «Ошибки соединения».

3) Раздел установки sing-box долго висел при открытии
   - быстрая локальная часть (платформа/TUN/установленная версия) рисуется сразу; проверка «что в нашем релизе» (GitHub: версия + manifest) ушла в фон с индикатором «проверяю…», чтобы сетевой запрос (на роутере — десятки секунд) не блокировал открытие раздела.

Тесты: tests/test_mihomo (23) и tests/test_log_buffer, test_awg_watchdog — зелёные. https://claude.ai/code/session_018Uua5QhSHRsDJBZPFQQvoW