### PR TITLE
mihomo: прокси-таблица и режим отладки (паритет с sing-box)

### DIFF
--- a/api/mihomo.py
+++ b/api/mihomo.py
@@ -34,6 +34,46 @@ from bottle import request, response
 INSTALL_API_WAIT = 8
 
 
+def _load_cfg(name):
+    """(mgr, res, cfg|None). res — ответ get_config; cfg — разобранный YAML."""
+    from core.mihomo_manager import get_mihomo_manager
+    from core.clash_yaml import parse_yaml
+    mgr = get_mihomo_manager()
+    res = mgr.get_config(name)
+    if not res.get("ok"):
+        return mgr, res, None
+    try:
+        cfg = parse_yaml(res.get("text") or "")
+    except Exception:
+        cfg = {}
+    return mgr, res, (cfg if isinstance(cfg, dict) else {})
+
+
+def _resolve_test_proxies(body):
+    """
+    Источник прокси для теста: имя конфига `config` (+ опц. `names`
+    — подмножество). Возвращает (proxies|None, controller_ep|None).
+    Полные proxy-dict'ы достаём из конфига (для одноразового движка);
+    если конфиг запущен — отдаём ещё и его external-controller (тест
+    идёт через уже поднятые узлы).
+    """
+    from core import mihomo_proxies as mp
+    name = (body.get("config") or "").strip()
+    if not name:
+        return None, None
+    mgr, res, cfg = _load_cfg(name)
+    if not res.get("ok"):
+        return [], None
+    proxies = mp.list_proxies(cfg or {})
+    names = body.get("names")
+    if isinstance(names, list) and names:
+        ns = {str(n) for n in names}
+        proxies = [p for p in proxies if str(p.get("name")) in ns]
+    ep = mp.external_controller_endpoint(cfg or {}) \
+        if mgr.is_running(name) else None
+    return proxies, ep
+
+
 def register(app):
 
     # ─────── environment / install ────────────────────────────────
@@ -197,6 +237,319 @@ def register(app):
         text = body.get("text") if isinstance(body, dict) else None
         from core.mihomo_manager import get_mihomo_manager
         return get_mihomo_manager().validate_via_binary(name, text=text)
+
+    @app.route("/api/mihomo/configs/<name>/log")
+    def mihomo_configs_log(name):
+        """Хвост лог-файла инстанса — «видно, почему не работает»."""
+        response.content_type = "application/json; charset=utf-8"
+        from core.mihomo_manager import get_mihomo_manager
+        try:
+            lines = int(request.query.get("lines") or 200)
+        except (TypeError, ValueError):
+            lines = 200
+        res = get_mihomo_manager().read_log(name, lines)
+        if not res.get("ok"):
+            response.status = 400
+        return res
+
+    # ─────── режим отладки ─────────────────────────────────────────
+
+    @app.route("/api/mihomo/debug")
+    def mihomo_debug_get():
+        response.content_type = "application/json; charset=utf-8"
+        from core.mihomo_manager import get_mihomo_manager
+        return get_mihomo_manager().get_debug()
+
+    @app.route("/api/mihomo/debug", method="POST")
+    def mihomo_debug_set():
+        """Вкл/выкл режим отладки (log-level=debug при следующем запуске)."""
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        from core.mihomo_manager import get_mihomo_manager
+        res = get_mihomo_manager().set_debug(bool(body.get("enabled")))
+        if not res.get("ok"):
+            response.status = 500
+        return res
+
+    # ─────── прокси-таблица ────────────────────────────────────────
+
+    @app.route("/api/mihomo/configs/<name>/proxies")
+    def mihomo_proxies_list(name):
+        """
+        Прокси конфига для таблицы: [{name,type,server,port}] + активный
+        узел/группы из запущенного external-controller (если доступен).
+        """
+        response.content_type = "application/json; charset=utf-8"
+        from core import mihomo_proxies as mp
+        mgr, res, cfg = _load_cfg(name)
+        if not res.get("ok"):
+            response.status = 404
+            return res
+        running = mgr.is_running(name)
+        ep = mp.external_controller_endpoint(cfg or {})
+        active, groups, controller_live = "", [], False
+        if running and ep:
+            live = mp.controller_proxies(ep)
+            if live.get("ok"):
+                controller_live = True
+                active = live.get("active") or ""
+                groups = live.get("groups") or []
+        return {"ok": True, "proxies": mp.proxy_rows(cfg or {}),
+                "active": active, "groups": groups, "running": running,
+                "controller": ep is not None,
+                "controller_live": controller_live,
+                "select_groups": mp.select_group_names(cfg or {})}
+
+    @app.route("/api/mihomo/configs/<name>/activate", method="POST")
+    def mihomo_configs_activate(name):
+        """
+        Пустить трафик через выбранный прокси: PUT /proxies/<group> на
+        external-controller (живое переключение, как metacubexd). Требует
+        запущенного инстанса с external-controller — у mihomo выбор узла
+        хранится в рантайме, не в YAML.
+        """
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        tag = (body.get("name") or body.get("tag") or "").strip()
+        if not tag:
+            response.status = 400
+            return {"ok": False, "error": "Не указан прокси (name)"}
+        from core import mihomo_proxies as mp
+        mgr, res, cfg = _load_cfg(name)
+        if not res.get("ok"):
+            response.status = 404
+            return res
+        if not mgr.is_running(name):
+            return {"ok": False, "needs_running": True, "error":
+                    "Запустите конфиг — у mihomo прокси переключается на "
+                    "лету через external-controller."}
+        ep = mp.external_controller_endpoint(cfg or {})
+        if not ep:
+            return {"ok": False, "needs_controller": True, "error":
+                    "У конфига нет external-controller — включите "
+                    "управление кнопкой и перезапустите конфиг."}
+        return mp.controller_activate(ep, tag)
+
+    @app.route("/api/mihomo/configs/<name>/enable-controller",
+               method="POST")
+    def mihomo_enable_controller(name):
+        """
+        Идемпотентно добавить `external-controller` + `secret` в конфиг
+        (нужно для учёта трафика, теста через движок и переключения).
+        Свободный порт на 127.0.0.1, secret генерим. Если запущен —
+        нужен перезапуск.
+        """
+        response.content_type = "application/json; charset=utf-8"
+        import secrets as _secrets
+        from core import mihomo_proxies as mp
+        from core.proxy_tester import _free_port
+        mgr, res, cfg = _load_cfg(name)
+        if not res.get("ok"):
+            response.status = 404
+            return res
+        ep = mp.external_controller_endpoint(cfg or {})
+        if ep:
+            return {"ok": True, "already": True, "port": ep["port"],
+                    "running": mgr.is_running(name)}
+        port = _free_port()
+        new_text = mp.enable_external_controller_text(
+            res.get("text") or "", "127.0.0.1", port, _secrets.token_hex(8))
+        save = mgr.save_config(name, text=new_text)
+        if not save.get("ok"):
+            response.status = 500
+            return save
+        return {"ok": True, "port": port, "running": mgr.is_running(name),
+                "needs_restart": mgr.is_running(name)}
+
+    @app.route("/api/mihomo/configs/<name>/proxies/delete-bulk",
+               method="POST")
+    def mihomo_proxies_delete_bulk(name):
+        """Удалить выбранные прокси (body: {names:[...]}). Round-trip —
+        требует PyYAML (иначе отказ, чтобы не повредить конфиг)."""
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        names = [str(n) for n in (body.get("names") or []) if n]
+        if not names:
+            response.status = 400
+            return {"ok": False, "error": "Не переданы names"}
+        from core import mihomo_proxies as mp
+        mgr, res, cfg = _load_cfg(name)
+        if not res.get("ok"):
+            response.status = 404
+            return res
+        present = set(mp.proxy_names(cfg or {}))
+        r = mp.safe_mutate(res.get("text") or "",
+                           lambda c: mp.remove_proxies(c, names))
+        if not r.get("ok"):
+            # needs_pyyaml — это не ошибка сервера: 200 с понятным телом,
+            # чтобы фронт показал подсказку (API.post бросает на не-2xx).
+            response.status = 200 if r.get("needs_pyyaml") else 400
+            return r
+        save = mgr.save_config(name, text=r["text"])
+        if not save.get("ok"):
+            response.status = 500
+            return save
+        deleted = sorted(present & set(names))
+        return {"ok": True, "deleted": deleted,
+                "skipped": sorted(set(names) - present)}
+
+    @app.route("/api/mihomo/configs/<name>/import-links", method="POST")
+    def mihomo_import_links(name):
+        """Вставка серверов из буфера (Ctrl+V): share-URI → clash-proxy,
+        дозапись в `proxies:` (аддитивно, работает и без PyYAML)."""
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        text_in = (body.get("text") or "").strip()
+        if not text_in:
+            response.status = 400
+            return {"ok": False, "error": "Пустой текст"}
+        from core.subscription_importer import extract_items
+        from core.clash_yaml import uri_to_clash_proxy
+        from core import mihomo_proxies as mp
+        mgr, res, cfg = _load_cfg(name)
+        if not res.get("ok"):
+            response.status = 404
+            return res
+        new, errors = [], 0
+        for it in extract_items(text_in):
+            if not isinstance(it, dict) or it.get("type") != "uri":
+                continue
+            uri = it.get("value")
+            if not uri:
+                continue
+            r = uri_to_clash_proxy(uri)
+            if r.get("ok") and r.get("proxy"):
+                new.append(r["proxy"])
+            else:
+                errors += 1
+        if not new:
+            return {"ok": False, "errors": errors,
+                    "error": "Не нашлось валидных серверов в тексте"}
+        existing = set(mp.proxy_names(cfg or {}))
+        added, renamed = 0, 0
+        for p in new:
+            nm = str(p.get("name") or "proxy")
+            if nm in existing:
+                base, n = nm, 2
+                while ("%s-%d" % (base, n)) in existing:
+                    n += 1
+                nm = "%s-%d" % (base, n)
+                p["name"] = nm
+                renamed += 1
+            existing.add(nm)
+            added += 1
+        new_text = mp.append_proxies_text(res.get("text") or "", new)
+        if new_text == (res.get("text") or ""):
+            return {"ok": False, "error":
+                    "Не удалось дописать прокси (нестандартный блок "
+                    "proxies). Отредактируйте YAML вручную."}
+        save = mgr.save_config(name, text=new_text)
+        if not save.get("ok"):
+            response.status = 500
+            return save
+        return {"ok": True, "added": added, "renamed": renamed,
+                "errors": errors}
+
+    @app.route("/api/mihomo/export-links", method="POST")
+    def mihomo_export_links():
+        """Копирование прокси в буфер (Ctrl+C): clash-proxy → share-URI.
+        body: {config, names?}."""
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        name = (body.get("config") or "").strip()
+        if not name:
+            response.status = 400
+            return {"ok": False, "error": "Укажите config"}
+        from core.clash_yaml import clash_proxy_to_uri
+        from core import mihomo_proxies as mp
+        _mgr, res, cfg = _load_cfg(name)
+        if not res.get("ok"):
+            response.status = 404
+            return res
+        proxies = mp.list_proxies(cfg or {})
+        names = body.get("names")
+        if isinstance(names, list) and names:
+            ns = {str(n) for n in names}
+            proxies = [p for p in proxies if str(p.get("name")) in ns]
+        links = [u for u in (clash_proxy_to_uri(p) for p in proxies) if u]
+        return {"ok": True, "text": "\n".join(links), "count": len(links)}
+
+    # ─────── tester / traffic ──────────────────────────────────────
+
+    @app.route("/api/mihomo/test", method="POST")
+    def mihomo_test_start():
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        proxies, ep = _resolve_test_proxies(body)
+        if proxies is None:
+            response.status = 400
+            return {"ok": False, "error": "Укажите config"}
+        if not proxies:
+            return {"ok": False, "error": "Не нашлось прокси для теста"}
+        target = (body.get("target") or "cloudflare").strip()
+        try:
+            timeout_ms = int(body.get("timeout_ms") or 5000)
+        except (TypeError, ValueError):
+            timeout_ms = 5000
+        from core.mihomo_proxy_tester import get_mihomo_test_job
+        from core.mihomo_detector import get_mihomo_detector
+        binary = get_mihomo_detector().detect_binary().get("path", "")
+        started = get_mihomo_test_job().start(
+            proxies, target=target, timeout_ms=timeout_ms,
+            controller=ep, binary=binary)
+        if not started:
+            return {"ok": False, "running": True,
+                    "error": "Тест уже выполняется"}
+        return {"ok": True, "started": True, "count": len(proxies)}
+
+    @app.route("/api/mihomo/test/status")
+    def mihomo_test_status():
+        response.content_type = "application/json; charset=utf-8"
+        from core.mihomo_proxy_tester import get_mihomo_test_job
+        from core.proxy_tester import TARGET_PRESETS
+        st = get_mihomo_test_job().status()
+        st["ok"] = True
+        st["targets"] = list(TARGET_PRESETS.keys())
+        return st
+
+    @app.route("/api/mihomo/traffic")
+    def mihomo_traffic():
+        """Кумулятивный трафик per-proxy {name:{up,down}} (?config=<name>
+        — фильтр по тегам конфига + сообщить про external-controller)."""
+        response.content_type = "application/json; charset=utf-8"
+        from core.proxy_traffic import get_mihomo_traffic_tracker
+        from core import mihomo_proxies as mp
+        tracker = get_mihomo_traffic_tracker()
+        tracker.ensure_running()
+        name = (request.query.get("config") or "").strip()
+        tags, controller, running = None, None, None
+        if name:
+            mgr, res, cfg = _load_cfg(name)
+            if res.get("ok"):
+                tags = mp.proxy_names(cfg or {})
+                controller = mp.external_controller_endpoint(
+                    cfg or {}) is not None
+                running = mgr.is_running(name)
+        return {"ok": True, "traffic": tracker.snapshot(tags),
+                "controller": controller, "running": running}
 
     # ─────── autostart ────────────────────────────────────────────
 

--- a/core/clash_yaml.py
+++ b/core/clash_yaml.py
@@ -506,3 +506,275 @@ _CLASH_CONVERTERS = {
     "hy2":        _conv_hysteria2,
     "tuic":       _conv_tuic,
 }
+
+
+# ─────── YAML emitter (python-структура → clash-YAML) ───────
+#
+# Нужен, чтобы:
+#   1) собирать одноразовый конфиг для тестера прокси mihomo (§тестер);
+#   2) безопасно перезаписывать список прокси из таблицы (только когда
+#      доступен pyyaml — иначе самописный парсер теряет вложенность/rules
+#      на round-trip и редактирование запрещается, см. mihomo_proxies).
+#
+# Когда установлен pyyaml — используем `yaml.safe_dump` (точнее и безопаснее).
+# Иначе — минимальный рекурсивный эмиттер (dict/list/scalar) c корректным
+# квотированием. mihomo читает YAML своим полнофункциональным парсером,
+# поэтому даже глубоко вложенные структуры эмиттер выдаёт валидно.
+
+def has_pyyaml() -> bool:
+    """Доступен ли модуль pyyaml (определяет, можно ли безопасно
+    перезаписывать сложные конфиги round-trip'ом)."""
+    try:
+        import yaml  # type: ignore  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+_YAML_KEYWORDS = {"true", "false", "yes", "no", "on", "off", "null", "~",
+                  "none"}
+_QUOTE_CHARS_RE = re.compile(r"[:#\[\]{},&*!|>'\"%@`]")
+
+
+def _needs_quote(s: str) -> bool:
+    if s == "":
+        return True
+    low = s.lower()
+    if low in _YAML_KEYWORDS:
+        return True
+    if re.match(r"^-?\d+$", s) or re.match(r"^-?\d+\.\d+$", s):
+        return True
+    if s != s.strip():
+        return True
+    if _QUOTE_CHARS_RE.search(s):
+        return True
+    if s[0] in "-?:,[]{}#&*!|>'\"%@` ":
+        return True
+    return False
+
+
+def _yaml_scalar(v) -> str:
+    if v is None:
+        return "null"
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, float):
+        return repr(v)
+    s = str(v)
+    if _needs_quote(s):
+        return '"%s"' % s.replace("\\", "\\\\").replace('"', '\\"')
+    return s
+
+
+def _emit_kv(key, value, indent: int, out: list):
+    pad = " " * indent
+    ks = _yaml_scalar(key) if _needs_quote(str(key)) else str(key)
+    if isinstance(value, dict):
+        if not value:
+            out.append("%s%s: {}" % (pad, ks))
+            return
+        out.append("%s%s:" % (pad, ks))
+        for k, v in value.items():
+            _emit_kv(k, v, indent + 2, out)
+    elif isinstance(value, list):
+        if not value:
+            out.append("%s%s: []" % (pad, ks))
+            return
+        out.append("%s%s:" % (pad, ks))
+        _emit_seq(value, indent + 2, out)
+    else:
+        out.append("%s%s: %s" % (pad, ks, _yaml_scalar(value)))
+
+
+def _emit_seq(seq: list, indent: int, out: list):
+    pad = " " * indent
+    for item in seq:
+        if isinstance(item, dict) and item:
+            keys = list(item.items())
+            k0, v0 = keys[0]
+            if isinstance(v0, (dict, list)) and v0:
+                out.append("%s-" % pad)
+                _emit_kv(k0, v0, indent + 2, out)
+            else:
+                ks = _yaml_scalar(k0) if _needs_quote(str(k0)) else str(k0)
+                out.append("%s- %s: %s" % (pad, ks, _yaml_scalar(v0)))
+            for k, v in keys[1:]:
+                _emit_kv(k, v, indent + 2, out)
+        elif isinstance(item, dict):
+            out.append("%s- {}" % pad)
+        elif isinstance(item, list) and item:
+            out.append("%s-" % pad)
+            _emit_seq(item, indent + 2, out)
+        elif isinstance(item, list):
+            out.append("%s- []" % pad)
+        else:
+            out.append("%s- %s" % (pad, _yaml_scalar(item)))
+
+
+def dump_yaml(data) -> str:
+    """Python-структура → текст clash/mihomo-YAML."""
+    try:
+        import yaml  # type: ignore
+        return yaml.safe_dump(data, allow_unicode=True, sort_keys=False,
+                              default_flow_style=False)
+    except ImportError:
+        pass
+    out: list = []
+    if isinstance(data, dict):
+        for k, v in data.items():
+            _emit_kv(k, v, 0, out)
+    elif isinstance(data, list):
+        _emit_seq(data, 0, out)
+    else:
+        out.append(_yaml_scalar(data))
+    return "\n".join(out) + "\n"
+
+
+def dump_seq(seq: list, indent: int = 2) -> list:
+    """Список (обычно proxies) → строки YAML с отступом `indent` (для
+    текстовой вставки в существующий блок без полного round-trip)."""
+    out: list = []
+    _emit_seq(seq, indent, out)
+    return out
+
+
+# ─────── clash-proxy ↔ share-URI (copy/paste в таблице прокси) ───────
+#
+# Экспорт (Ctrl+C): clash-proxy → sing-box outbound (готовые конвертеры
+# выше) → share-URI (core.singbox_subscription.outbound_to_uri).
+# Импорт (Ctrl+V): share-URI → sing-box outbound (uri_to_outbound) →
+# clash-proxy (_singbox_outbound_to_clash). Это даёт переиспользование
+# уже протестированных парсеров, а не дубль логики.
+
+def clash_proxy_to_uri(p: dict) -> str:
+    """clash-proxy dict → share-URI (или '' для неподдержанного типа)."""
+    if not isinstance(p, dict):
+        return ""
+    conv = _CLASH_CONVERTERS.get(str(p.get("type", "")).lower())
+    if not conv:
+        return ""
+    try:
+        ob = conv(p)
+    except Exception:
+        ob = None
+    if not ob:
+        return ""
+    name = str(p.get("name") or ob.get("tag") or "")
+    if name:
+        ob = dict(ob)
+        ob["tag"] = name
+    from core.singbox_subscription import outbound_to_uri
+    return outbound_to_uri(ob)
+
+
+def _apply_transport_to_clash(tr, base: dict):
+    if not isinstance(tr, dict):
+        return
+    tt = tr.get("type")
+    if tt == "ws":
+        base["network"] = "ws"
+        ws: dict = {}
+        if tr.get("path"):
+            ws["path"] = tr["path"]
+        host = (tr.get("headers") or {}).get("Host")
+        if host:
+            ws["headers"] = {"Host": host}
+        if ws:
+            base["ws-opts"] = ws
+    elif tt == "grpc":
+        base["network"] = "grpc"
+        if tr.get("service_name"):
+            base["grpc-opts"] = {"grpc-service-name": tr["service_name"]}
+
+
+def _apply_tls_to_clash(tls, base: dict, reality: bool):
+    if not isinstance(tls, dict) or not tls.get("enabled"):
+        return
+    base["tls"] = True
+    if tls.get("server_name"):
+        base["servername"] = tls["server_name"]
+    fp = (tls.get("utls") or {}).get("fingerprint")
+    if fp:
+        base["client-fingerprint"] = fp
+    ro = tls.get("reality") or {}
+    if reality and isinstance(ro, dict) and ro.get("enabled"):
+        opts: dict = {}
+        if ro.get("public_key"):
+            opts["public-key"] = ro["public_key"]
+        if ro.get("short_id"):
+            opts["short-id"] = ro["short_id"]
+        base["reality-opts"] = opts
+
+
+def _singbox_outbound_to_clash(ob: dict):
+    """sing-box outbound → clash-proxy dict (для 6 поддержанных типов)."""
+    if not isinstance(ob, dict):
+        return None
+    t = ob.get("type")
+    server, port = ob.get("server"), ob.get("server_port")
+    if not server or not port:
+        return None
+    base = {"name": ob.get("tag") or str(t),
+            "server": str(server), "port": int(port)}
+    if t == "shadowsocks":
+        base.update({"type": "ss",
+                     "cipher": ob.get("method") or "aes-128-gcm",
+                     "password": ob.get("password") or ""})
+        return base
+    if t == "vless":
+        base.update({"type": "vless", "uuid": ob.get("uuid") or ""})
+        if ob.get("flow"):
+            base["flow"] = ob["flow"]
+        _apply_transport_to_clash(ob.get("transport"), base)
+        _apply_tls_to_clash(ob.get("tls"), base, reality=True)
+        return base
+    if t == "vmess":
+        base.update({"type": "vmess", "uuid": ob.get("uuid") or "",
+                     "alterId": int(ob.get("alter_id") or 0),
+                     "cipher": ob.get("security") or "auto"})
+        _apply_transport_to_clash(ob.get("transport"), base)
+        _apply_tls_to_clash(ob.get("tls"), base, reality=False)
+        return base
+    if t == "trojan":
+        base.update({"type": "trojan", "password": ob.get("password") or ""})
+        tls = ob.get("tls") or {}
+        if tls.get("server_name"):
+            base["sni"] = tls["server_name"]
+        if tls.get("insecure"):
+            base["skip-cert-verify"] = True
+        _apply_transport_to_clash(ob.get("transport"), base)
+        return base
+    if t == "hysteria2":
+        base.update({"type": "hysteria2",
+                     "password": ob.get("password") or ""})
+        tls = ob.get("tls") or {}
+        if tls.get("server_name"):
+            base["sni"] = tls["server_name"]
+        if tls.get("insecure"):
+            base["skip-cert-verify"] = True
+        return base
+    if t == "tuic":
+        base.update({"type": "tuic", "uuid": ob.get("uuid") or ""})
+        if ob.get("password"):
+            base["password"] = ob["password"]
+        tls = ob.get("tls") or {}
+        if tls.get("server_name"):
+            base["sni"] = tls["server_name"]
+        return base
+    return None
+
+
+def uri_to_clash_proxy(uri: str) -> dict:
+    """share-URI → {"ok": bool, "proxy": dict} либо {"ok": False, "error"}."""
+    from core.singbox_subscription import uri_to_outbound
+    r = uri_to_outbound(uri)
+    if not r.get("ok") or not r.get("outbound"):
+        return {"ok": False, "error": r.get("error") or "URI не распознан"}
+    p = _singbox_outbound_to_clash(r["outbound"])
+    if not p:
+        return {"ok": False, "error": "тип не конвертируется в clash-proxy"}
+    return {"ok": True, "proxy": p}

--- a/core/mihomo_manager.py
+++ b/core/mihomo_manager.py
@@ -40,6 +40,15 @@ def _valid_name(name: str) -> bool:
     return bool(name) and bool(_VALID_NAME_RE.match(name))
 
 
+def _inject_log_level(text: str, level: str = "debug") -> str:
+    """Подменить верхнеуровневый `log-level` (для режима отладки). Чисто
+    текстовая правка — не трогаем вложенные структуры/комментарии."""
+    out = [l for l in text.splitlines()
+           if not re.match(r"^log-level\s*:", l)]
+    out.insert(0, "log-level: %s" % level)
+    return "\n".join(out) + "\n"
+
+
 def _raise_nofile():
     if resource is None:
         return
@@ -140,6 +149,10 @@ class MihomoManager:
             return []
         out = []
         for fn in sorted(os.listdir(platform.config_dir)):
+            # Служебные dotfile'ы (debug-launch `.run-*.yaml`, временные
+            # `.validate-*`) не показываем как конфиги пользователя.
+            if fn.startswith("."):
+                continue
             if not (fn.endswith(".yaml") or fn.endswith(".yml")):
                 continue
             name = fn.rsplit(".", 1)[0]
@@ -214,6 +227,80 @@ class MihomoManager:
         except OSError as e:
             return {"ok": False, "error": "rm: %s" % e}
         return {"ok": True, "name": name}
+
+    # ─────── debug mode / log ───────
+    #
+    # «Режим отладки»: видно, ПОЧЕМУ прокси не работает. У mihomo нет merge
+    # нескольких `-f` (как `-c` у sing-box), поэтому при включённом debug
+    # запускаем из временного launch-конфига `.run-<name>.yaml` с
+    # подменённым `log-level: debug`. Сам пользовательский YAML не трогаем —
+    # выключил тумблер, перезапустил, debug ушёл.
+
+    def _debug_enabled(self) -> bool:
+        try:
+            from core.config_manager import get_config_manager
+            return bool(get_config_manager().get("mihomo", "debug_log",
+                                                  default=False))
+        except Exception:
+            return False
+
+    def get_debug(self) -> dict:
+        return {"ok": True, "enabled": self._debug_enabled()}
+
+    def set_debug(self, enabled: bool) -> dict:
+        try:
+            from core.config_manager import get_config_manager
+            cm = get_config_manager()
+            cm.set("mihomo", "debug_log", bool(enabled))
+            cm.save()
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+        log.info("mihomo: режим отладки %s" % ("включён" if enabled
+                                               else "выключен"),
+                 source="mihomo")
+        return {"ok": True, "enabled": bool(enabled)}
+
+    def _debug_launch_path(self, name: str) -> str:
+        return os.path.join(self._platform().config_dir,
+                            ".run-%s.yaml" % name)
+
+    def _write_debug_launch(self, name: str, config: str):
+        """Записать launch-конфиг с debug-логом, вернуть путь или None."""
+        try:
+            with open(config, "r") as f:
+                text = f.read()
+        except OSError:
+            return None
+        path = self._debug_launch_path(name)
+        try:
+            tmp = path + ".tmp"
+            with open(tmp, "w") as f:
+                f.write(_inject_log_level(text, "debug"))
+            os.replace(tmp, path)
+            return path
+        except OSError:
+            return None
+
+    def _cleanup_debug_launch(self, name: str):
+        try:
+            os.remove(self._debug_launch_path(name))
+        except OSError:
+            pass
+
+    def read_log(self, name: str, lines: int = 200) -> dict:
+        """Хвост лог-файла инстанса (для просмотра в UI)."""
+        if not _valid_name(name):
+            return {"ok": False, "error": "Некорректное имя"}
+        path = self._platform().log_path(name)
+        try:
+            lines = max(1, min(2000, int(lines)))
+        except (TypeError, ValueError):
+            lines = 200
+        if not os.path.isfile(path):
+            return {"ok": True, "name": name, "path": path,
+                    "exists": False, "log": ""}
+        return {"ok": True, "name": name, "path": path, "exists": True,
+                "log": _tail_file(path, lines), "debug": self._debug_enabled()}
 
     # ─────── validate via binary ───────
 
@@ -310,12 +397,24 @@ class MihomoManager:
         if self.is_running(name):
             return {"ok": True, "already_running": True}
 
+        # Режим отладки: запускаем из launch-конфига с log-level=debug
+        # (пользовательский YAML не трогаем). При любой ошибке — обычный.
+        run_config = config
+        debug_used = False
+        if self._debug_enabled():
+            dp = self._write_debug_launch(name, config)
+            if dp:
+                run_config = dp
+                debug_used = True
+
         # Pre-flight: mihomo -t (с тем же -d, что и при запуске, иначе
         # geoip/geosite/провайдеры ищутся не там и проверка ложно падает).
         chk_rc, _o, chk_err = _run(
-            [binary, "-t", "-d", platform.config_dir, "-f", config],
+            [binary, "-t", "-d", platform.config_dir, "-f", run_config],
             timeout=15)
         if chk_rc != 0:
+            if debug_used:
+                self._cleanup_debug_launch(name)
             return {"ok": False, "error":
                     "mihomo -t %s: %s" % (name, (chk_err or "").strip())}
 
@@ -329,7 +428,7 @@ class MihomoManager:
 
         try:
             popen = subprocess.Popen(
-                [binary, "-d", platform.config_dir, "-f", config],
+                [binary, "-d", platform.config_dir, "-f", run_config],
                 stdin=subprocess.DEVNULL,
                 stdout=log_fh, stderr=log_fh,
                 close_fds=True,
@@ -349,14 +448,17 @@ class MihomoManager:
         time.sleep(1.0)
         if popen.poll() is not None:
             tail = _tail_file(log_file, 80)
+            if debug_used:
+                self._cleanup_debug_launch(name)
             return {"ok": False,
                     "error": "mihomo упал при старте (exit=%s)"
                              % popen.returncode,
                     "log_tail": tail}
-        log.info("mihomo: запущен '%s' (pid=%d)" % (name, popen.pid),
+        log.info("mihomo: запущен '%s' (pid=%d)%s" % (
+            name, popen.pid, " [debug]" if debug_used else ""),
                  source="mihomo")
         return {"ok": True, "pid": popen.pid, "config": config,
-                "log_path": log_file}
+                "log_path": log_file, "debug": debug_used}
 
     def _do_down(self, name: str) -> dict:
         platform = self._platform()
@@ -383,6 +485,7 @@ class MihomoManager:
             os.remove(pid_file)
         except OSError:
             pass
+        self._cleanup_debug_launch(name)
         log.info("mihomo: остановлен '%s' (pid=%d)" % (name, pid),
                  source="mihomo")
         return {"ok": True, "pid": pid}

--- a/core/mihomo_proxies.py
+++ b/core/mihomo_proxies.py
@@ -1,0 +1,296 @@
+# core/mihomo_proxies.py
+"""
+Прокси-таблица mihomo (паритет с sing-box `singbox_proxies`).
+
+Здесь — серверная логика для страницы «mihomo → Прокси»:
+  - разбор секции `proxies` clash-YAML в строки таблицы (имя/тип/адрес);
+  - доступ к запущенному инстансу через external-controller (RESTful
+    Clash API): список групп/активный узел, переключение активного,
+    замер задержки (тест) и трафик (см. core/proxy_traffic.py);
+  - безопасное редактирование списка прокси из таблицы:
+      * импорт share-ссылок (Ctrl+V) — текстовая дозапись в блок
+        `proxies:` (работает и без pyyaml — операция аддитивная);
+      * удаление выбранных — round-trip через pyyaml (parse→mutate→dump);
+        без pyyaml самописный парсер теряет вложенность/rules, поэтому
+        удаление в таком окружении честно отклоняется (не портим конфиг);
+      * включение external-controller — текстовая дозапись двух скаляров.
+
+mihomo сам по себе и есть эталонная реализация Clash, поэтому управление
+активным прокси/замеры идут его родным API, а не нашей конвертацией.
+"""
+
+import json
+import re
+import urllib.error
+import urllib.request
+
+from core.clash_yaml import parse_yaml, dump_yaml, dump_seq, has_pyyaml
+
+
+_SELECT_TYPE = "Selector"   # как Clash API называет group типа select
+
+
+# ─────── чтение конфига ───────
+
+def list_proxies(cfg: dict) -> list:
+    """Список proxy-dict'ов из секции `proxies` (только валидные записи)."""
+    if not isinstance(cfg, dict):
+        return []
+    out = []
+    for p in (cfg.get("proxies") or []):
+        if isinstance(p, dict) and p.get("name") and p.get("type"):
+            out.append(p)
+    return out
+
+
+def proxy_names(cfg: dict) -> list:
+    """Имена всех прокси (ключ для трафика/снапшота)."""
+    return [str(p["name"]) for p in list_proxies(cfg)]
+
+
+def proxy_rows(cfg: dict) -> list:
+    """Строки таблицы: {name, type, server, port}."""
+    rows = []
+    for p in list_proxies(cfg):
+        port = p.get("port")
+        rows.append({
+            "name":   str(p.get("name")),
+            "type":   str(p.get("type") or ""),
+            "server": str(p.get("server") or ""),
+            "port":   port if isinstance(port, int) else (
+                int(port) if str(port).isdigit() else port),
+        })
+    return rows
+
+
+def select_group_names(cfg: dict) -> list:
+    """Имена proxy-groups типа select (через них переключают активный)."""
+    out = []
+    for g in (cfg.get("proxy-groups") or []):
+        if isinstance(g, dict) and str(g.get("type") or "").lower() == "select" \
+                and g.get("name"):
+            out.append(str(g["name"]))
+    return out
+
+
+def external_controller_endpoint(cfg: dict):
+    """
+    {"host","port","secret"} из `external-controller`/`secret`, либо None.
+    `:9090` / `0.0.0.0:9090` → опрашиваем через 127.0.0.1.
+    """
+    if not isinstance(cfg, dict):
+        return None
+    ctrl = cfg.get("external-controller")
+    if not ctrl or ":" not in str(ctrl):
+        return None
+    host, _, port = str(ctrl).rpartition(":")
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        return None
+    if not host or host in ("0.0.0.0", "::", "[::]"):
+        host = "127.0.0.1"
+    host = host.strip("[]")
+    return {"host": host, "port": port, "secret": cfg.get("secret") or ""}
+
+
+# ─────── RESTful Clash API (запущенный инстанс) ───────
+
+def _request(ep: dict, path: str, method: str = "GET", data=None,
+             timeout: float = 3.0) -> tuple:
+    """(status, body). 0 — сеть/таймаут. Поддерживает GET/PUT с JSON."""
+    url = "http://%s:%d%s" % (ep["host"], int(ep["port"]), path)
+    headers = {}
+    if ep.get("secret"):
+        headers["Authorization"] = "Bearer %s" % ep["secret"]
+    body = None
+    if data is not None:
+        body = json.dumps(data).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=body, headers=headers,
+                                 method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.getcode(), r.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        try:
+            b = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            b = ""
+        return e.code, b
+    except (urllib.error.URLError, OSError, TimeoutError, ValueError):
+        return 0, ""
+
+
+def controller_proxies(ep: dict) -> dict:
+    """
+    GET /proxies → {"ok", "active", "groups": [{name, now, all}]}.
+    `active` — текущий узел первой select-группы (для отметки в таблице).
+    """
+    st, body = _request(ep, "/proxies")
+    if st != 200 or not body:
+        return {"ok": False}
+    try:
+        data = json.loads(body)
+    except ValueError:
+        return {"ok": False}
+    proxies = data.get("proxies") if isinstance(data, dict) else None
+    if not isinstance(proxies, dict):
+        return {"ok": False}
+    groups = []
+    for nm, info in proxies.items():
+        if isinstance(info, dict) and info.get("type") == _SELECT_TYPE:
+            groups.append({"name": nm,
+                           "now": info.get("now") or "",
+                           "all": info.get("all") or []})
+    active = groups[0]["now"] if groups else ""
+    return {"ok": True, "active": active, "groups": groups}
+
+
+def controller_activate(ep: dict, tag: str) -> dict:
+    """
+    Переключить активный прокси вживую: PUT /proxies/<group> {"name": tag}.
+    Группа — первая select, содержащая tag (иначе первая select).
+    """
+    info = controller_proxies(ep)
+    if not info.get("ok"):
+        return {"ok": False, "error": "external-controller недоступен"}
+    groups = info.get("groups") or []
+    if not groups:
+        return {"ok": False,
+                "error": "В конфиге нет proxy-group типа select"}
+    grp = next((g for g in groups if tag in (g.get("all") or [])), groups[0])
+    st, _body = _request(
+        ep, "/proxies/%s" % urllib.request.quote(grp["name"], safe=""),
+        method="PUT", data={"name": tag}, timeout=3.0)
+    if st in (200, 204):
+        return {"ok": True, "group": grp["name"], "active": tag, "live": True}
+    return {"ok": False, "group": grp["name"],
+            "error": "mihomo отклонил переключение (HTTP %s)" % st}
+
+
+# ─────── текстовые правки (без pyyaml) ───────
+
+def _find_top_key(lines: list, key: str):
+    """Индекс строки верхнеуровневого ключа `key:` (col 0), иначе None."""
+    pat = re.compile(r"^%s\s*:" % re.escape(key))
+    for i, l in enumerate(lines):
+        if pat.match(l):
+            return i
+    return None
+
+
+def _proxies_block_end(lines: list, start: int) -> int:
+    """Индекс конца блока `proxies:` — первый следующий ключ col 0."""
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        l = lines[j]
+        if not l.strip():
+            continue
+        if not l[0].isspace() and not l.lstrip().startswith("#"):
+            return j
+        end = j + 1
+    return end
+
+
+def append_proxies_text(text: str, new_proxies: list) -> str:
+    """
+    Дозаписать прокси в блок `proxies:` текстово (аддитивно, без полного
+    round-trip — поэтому безопасно и без pyyaml). Если блока нет —
+    добавить его в конец.
+    """
+    if not new_proxies:
+        return text
+    item_lines = dump_seq(new_proxies, indent=2)
+    had_nl = text.endswith("\n") or text == ""
+    lines = text.splitlines()
+    idx = _find_top_key(lines, "proxies")
+    if idx is None:
+        block = ["proxies:"] + item_lines
+        base = "\n".join(lines)
+        if base and not base.endswith("\n"):
+            base += "\n"
+        return base + "\n".join(block) + "\n"
+    # Если `proxies:` имеет inline-значение (напр. `proxies: []`) —
+    # текстовая дозапись блока сломала бы YAML; пусть caller использует
+    # round-trip. Считаем такой случай неподдержанным здесь.
+    inline = lines[idx].split(":", 1)[1].strip()
+    if inline and inline not in ("[]", "~", "null"):
+        return text
+    if inline in ("[]", "~", "null"):
+        lines[idx] = "proxies:"
+    end = _proxies_block_end(lines, idx)
+    new_lines = lines[:end] + item_lines + lines[end:]
+    out = "\n".join(new_lines)
+    return out + "\n" if had_nl else out
+
+
+def enable_external_controller_text(text: str, host: str, port: int,
+                                    secret: str = "") -> str:
+    """Дозаписать `external-controller`/`secret` (если их нет) — два
+    верхнеуровневых скаляра, безопасно текстом."""
+    lines = text.splitlines()
+    has_ctrl = any(re.match(r"^external-controller\s*:", l) for l in lines)
+    has_secret = any(re.match(r"^secret\s*:", l) for l in lines)
+    prepend = []
+    if not has_ctrl:
+        prepend.append("external-controller: %s:%d" % (host, int(port)))
+    if secret and not has_secret:
+        prepend.append("secret: %s" % secret)
+    if not prepend:
+        return text
+    return "\n".join(prepend) + "\n" + text
+
+
+# ─────── мутации dict (для round-trip через pyyaml) ───────
+
+def remove_proxies(cfg: dict, names) -> dict:
+    """Удалить прокси по именам + вычистить ссылки в proxy-groups."""
+    nameset = {str(n) for n in (names or [])}
+    if not nameset:
+        return cfg
+    proxies = cfg.get("proxies")
+    if isinstance(proxies, list):
+        cfg["proxies"] = [p for p in proxies
+                          if not (isinstance(p, dict)
+                                  and str(p.get("name")) in nameset)]
+    clean_group_refs(cfg, nameset)
+    return cfg
+
+
+def clean_group_refs(cfg: dict, removed: set):
+    """Убрать удалённые имена из `proxies:` каждой proxy-group, поправить
+    висячие default/now-подобные поля."""
+    for g in (cfg.get("proxy-groups") or []):
+        if not isinstance(g, dict):
+            continue
+        plist = g.get("proxies")
+        if isinstance(plist, list):
+            g["proxies"] = [x for x in plist if str(x) not in removed]
+
+
+def safe_mutate(text: str, mutate_fn) -> dict:
+    """
+    Round-trip правка конфига: parse → mutate(cfg) → dump.
+
+    Доступно только при наличии pyyaml: самописный fallback-парсер теряет
+    вложенные структуры/скалярные списки (rules) на round-trip, и
+    перезапись повредила бы конфиг. В таком окружении возвращаем
+    {"ok": False, "needs_pyyaml": True} — операция честно отклоняется.
+    """
+    if not has_pyyaml():
+        return {"ok": False, "needs_pyyaml": True, "error":
+                "Удаление прокси из таблицы требует модуля PyYAML "
+                "(иначе сложный конфиг будет повреждён при перезаписи). "
+                "Установите PyYAML (python3-yaml) или правьте список прокси "
+                "в YAML на странице mihomo."}
+    try:
+        cfg = parse_yaml(text)
+    except Exception as e:
+        return {"ok": False, "error": "не удалось разобрать YAML: %s" % e}
+    if not isinstance(cfg, dict):
+        return {"ok": False, "error": "корень YAML не является объектом"}
+    new_cfg = mutate_fn(cfg)
+    if new_cfg is None:
+        new_cfg = cfg
+    return {"ok": True, "text": dump_yaml(new_cfg)}

--- a/core/mihomo_proxy_tester.py
+++ b/core/mihomo_proxy_tester.py
@@ -1,0 +1,356 @@
+# core/mihomo_proxy_tester.py
+"""
+Тестер доступности прокси mihomo (паритет с core/proxy_tester.py).
+
+Две фазы, как у sing-box:
+  Фаза 1 — TCP-отсев (переиспользуем `proxy_tester.tcp_prefilter`):
+    параллельный TCP-connect до server:port каждого прокси.
+  Фаза 2 — e2e-замер задержки через движок mihomo (Clash API
+    `GET /proxies/<name>/delay?url=<target>&timeout=<ms>`):
+      * если конфиг ЗАПУЩЕН и доступен его external-controller —
+        опрашиваем его напрямую (полная достоверность, узлы уже подняты);
+      * иначе поднимаем одноразовый `mihomo -d <tmp> -f <cfg.yaml>` со
+        всеми выжившими + external-controller и замеряем, батчами по 40
+        (битый узел роняет только свой батч), затем гасим.
+
+Без бинаря mihomo и без запущенного controller — остаётся только TCP-
+отсев (graceful degrade), как у sing-box.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from core.log_buffer import log
+from core.proxy_tester import (
+    resolve_target, tcp_prefilter, parse_delay, _free_port,
+)
+
+
+_BATCH = 40
+_E2E_WORKERS = 16
+_BOOT_WAIT = 12.0
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _get(host: str, port: int, secret: str, path: str,
+         timeout: float) -> tuple:
+    url = "http://%s:%d%s" % (host, int(port), path)
+    headers = {"Authorization": "Bearer %s" % secret} if secret else {}
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.getcode(), r.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        try:
+            b = e.read().decode("utf-8", errors="replace")
+        except Exception:
+            b = ""
+        return e.code, b
+    except (urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
+        return 0, str(e)
+
+
+def _wait_ready(host: str, port: int, secret: str, deadline: float,
+                popen=None) -> bool:
+    while time.time() < deadline:
+        if popen is not None and popen.poll() is not None:
+            return False
+        st, _ = _get(host, port, secret, "/version", 1.5)
+        if st == 200:
+            return True
+        time.sleep(0.3)
+    return False
+
+
+def _tail(path: str, limit: int = 600) -> str:
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+    except OSError:
+        return ""
+    text = _ANSI_RE.sub("", data.decode("utf-8", errors="replace")).strip()
+    return " ".join(text.split())[-limit:]
+
+
+# ─────── фаза 2: через запущенный external-controller ───────
+
+def _controller_delays(ep: dict, names: list, target_url: str,
+                       timeout_ms: int, on_done=None) -> dict:
+    out: dict = {}
+    total = len(names)
+    done = 0
+    q = urllib.request.quote(target_url, safe="")
+    http_to = (timeout_ms / 1000.0) + 3.0
+
+    def _job(nm):
+        path = "/proxies/%s/delay?timeout=%d&url=%s" % (
+            urllib.request.quote(nm, safe=""), timeout_ms, q)
+        st, body = _get(ep["host"], ep["port"], ep.get("secret", ""),
+                        path, http_to)
+        return nm, parse_delay(st, body)
+
+    with ThreadPoolExecutor(max_workers=min(_E2E_WORKERS, total)) as ex:
+        futs = [ex.submit(_job, n) for n in names]
+        for fut in as_completed(futs):
+            nm, res = fut.result()
+            out[nm] = res
+            done += 1
+            if on_done:
+                try:
+                    on_done(done, total)
+                except Exception:
+                    pass
+    return out
+
+
+# ─────── фаза 2: одноразовый mihomo ───────
+
+def _throwaway_delays(proxies: list, target_url: str, timeout_ms: int,
+                      binary: str, on_done=None) -> dict:
+    total = len(proxies)
+    out: dict = {}
+    done = 0
+    for start in range(0, total, _BATCH):
+        batch = proxies[start:start + _BATCH]
+        names = [p["name"] for p in batch]
+        try:
+            res = _throwaway_batch(batch, target_url, timeout_ms, binary)
+        except RuntimeError as e:
+            res = {n: {"ok": False, "engine_fail": True, "error": str(e)}
+                   for n in names}
+        out.update(res)
+        done += len(batch)
+        if on_done:
+            try:
+                on_done(done, total)
+            except Exception:
+                pass
+    return out
+
+
+def _throwaway_batch(proxies: list, target_url: str, timeout_ms: int,
+                     binary: str) -> dict:
+    from core.clash_yaml import dump_yaml
+    names = [p["name"] for p in proxies]
+    ctrl_port = _free_port()
+    mixed_port = _free_port()
+    secret = secrets.token_hex(8)
+    cfg = {
+        "log-level": "silent",
+        "mixed-port": mixed_port,
+        "mode": "rule",
+        "external-controller": "127.0.0.1:%d" % ctrl_port,
+        "secret": secret,
+        "proxies": proxies,
+        "proxy-groups": [
+            {"name": "GLOBAL", "type": "select", "proxies": names}],
+        "rules": ["MATCH,GLOBAL"],
+    }
+    tmp_dir = tempfile.mkdtemp(prefix="zapret-mihomo-test-")
+    cfg_path = os.path.join(tmp_dir, "test.yaml")
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        f.write(dump_yaml(cfg))
+
+    out: dict = {}
+    popen = None
+    err_path = os.path.join(tmp_dir, "stderr.log")
+    err_f = None
+    try:
+        err_f = open(err_path, "wb")
+        popen = subprocess.Popen(
+            [binary, "-d", tmp_dir, "-f", cfg_path],
+            stdout=subprocess.DEVNULL, stderr=err_f)
+        if not _wait_ready("127.0.0.1", ctrl_port, secret,
+                           time.time() + _BOOT_WAIT, popen):
+            try:
+                err_f.flush()
+            except Exception:
+                pass
+            tail = _tail(err_path, 600)
+            log.warning("mihomo tester: движок не запустился (батч %d)"
+                        % len(names) + (": %s" % tail if tail else ""),
+                        source="mihomo")
+            raise RuntimeError("mihomo не запустился"
+                               + (": %s" % tail if tail else ""))
+
+        q = urllib.request.quote(target_url, safe="")
+        http_to = (timeout_ms / 1000.0) + 3.0
+
+        def _job(nm):
+            path = "/proxies/%s/delay?timeout=%d&url=%s" % (
+                urllib.request.quote(nm, safe=""), timeout_ms, q)
+            st, body = _get("127.0.0.1", ctrl_port, secret, path, http_to)
+            return nm, parse_delay(st, body)
+
+        with ThreadPoolExecutor(
+                max_workers=min(_E2E_WORKERS, len(names))) as ex:
+            futs = [ex.submit(_job, n) for n in names]
+            for fut in as_completed(futs):
+                nm, res = fut.result()
+                out[nm] = res
+    finally:
+        if popen is not None:
+            try:
+                popen.terminate()
+                popen.wait(timeout=3)
+            except Exception:
+                try:
+                    popen.kill()
+                except Exception:
+                    pass
+        if err_f is not None:
+            try:
+                err_f.close()
+            except Exception:
+                pass
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    return out
+
+
+# ─────── public ───────
+
+def test_proxies(proxies: list, *, target: str = "cloudflare",
+                 timeout_ms: int = 5000, controller: dict = None,
+                 binary: str = None, progress_cb=None) -> dict:
+    """
+    Протестировать clash-proxy dict'ы. Результат как у proxy_tester:
+      {"ok", "target", "engine_used", "results": [{tag, server, port,
+        type, alive, latency_ms, stage, error}], "summary"}.
+    """
+    obs = [p for p in (proxies or []) if isinstance(p, dict)
+           and p.get("name") and p.get("server") and p.get("port")]
+    target_url = resolve_target(target)
+    if not obs:
+        return {"ok": True, "target": target_url, "engine_used": False,
+                "results": [], "summary": {"total": 0, "alive": 0, "dead": 0}}
+
+    meta = {str(p["name"]): p for p in obs}
+    tcp_models = [{"tag": str(p["name"]), "server": p.get("server"),
+                   "server_port": p.get("port")} for p in obs]
+
+    def _rep(phase, d, t):
+        if progress_cb:
+            try:
+                progress_cb(phase, d, t)
+            except Exception:
+                pass
+
+    _rep("tcp", 0, len(obs))
+    tcp = tcp_prefilter(tcp_models, on_done=lambda d, t: _rep("tcp", d, t))
+    survivors = [n for n, (ok, _ms) in tcp.items() if ok]
+
+    e2e: dict = {}
+    engine_used = False
+    if survivors:
+        if controller:
+            _rep("e2e", 0, len(survivors))
+            e2e = _controller_delays(
+                controller, survivors, target_url, timeout_ms,
+                on_done=lambda d, t: _rep("e2e", d, t))
+            engine_used = bool(e2e)
+        elif binary:
+            _rep("e2e", 0, len(survivors))
+            try:
+                e2e = _throwaway_delays(
+                    [meta[n] for n in survivors], target_url, timeout_ms,
+                    binary, on_done=lambda d, t: _rep("e2e", d, t))
+                engine_used = True
+            except Exception as e:
+                log.warning("mihomo tester e2e: %s" % e, source="mihomo")
+                e2e = {}
+
+    results = []
+    for nm, p in meta.items():
+        tcp_ok, tcp_ms = tcp.get(nm, (False, None))
+        row = {"tag": nm, "server": p.get("server"),
+               "port": p.get("port"), "type": p.get("type")}
+        if not tcp_ok:
+            row.update({"alive": False, "latency_ms": None, "stage": "tcp",
+                        "error": "сервер не отвечает (TCP)"})
+        elif engine_used and nm in e2e and not e2e[nm].get("engine_fail"):
+            r = e2e[nm]
+            row.update({"alive": bool(r.get("ok")),
+                        "latency_ms": r.get("latency_ms"), "stage": "e2e",
+                        "error": "" if r.get("ok") else
+                        (r.get("error") or "недоступно")})
+        else:
+            row.update({"alive": True, "latency_ms": tcp_ms, "stage": "tcp",
+                        "error": ""})
+        results.append(row)
+
+    results.sort(key=lambda r: (
+        not r["alive"],
+        r["latency_ms"] if r["latency_ms"] is not None else 1 << 30))
+    alive = sum(1 for r in results if r["alive"])
+    return {"ok": True, "target": target_url, "engine_used": engine_used,
+            "results": results,
+            "summary": {"total": len(results), "alive": alive,
+                        "dead": len(results) - alive}}
+
+
+# ─────── async job ───────
+
+class _MihomoTestJob:
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._running = False
+        self._result: dict = {}
+        self._started_at = 0.0
+        self._progress = {"phase": "", "done": 0, "total": 0}
+
+    def running(self) -> bool:
+        with self._lock:
+            return self._running
+
+    def start(self, proxies: list, **kw) -> bool:
+        with self._lock:
+            if self._running:
+                return False
+            self._running = True
+            self._result = {}
+            self._started_at = time.time()
+            self._progress = {"phase": "tcp", "done": 0,
+                              "total": len(proxies or [])}
+
+        def _cb(phase, done, total):
+            with self._lock:
+                self._progress = {"phase": phase, "done": done,
+                                  "total": total}
+
+        def _run():
+            try:
+                res = test_proxies(proxies, progress_cb=_cb, **kw)
+            except Exception as e:
+                res = {"ok": False, "error": str(e)}
+            with self._lock:
+                self._result = res
+                self._running = False
+
+        threading.Thread(target=_run, name="mihomo-tester",
+                         daemon=True).start()
+        return True
+
+    def status(self) -> dict:
+        with self._lock:
+            return {"running": self._running, "result": self._result,
+                    "started_at": self._started_at,
+                    "progress": dict(self._progress)}
+
+
+_job = _MihomoTestJob()
+
+
+def get_mihomo_test_job() -> _MihomoTestJob:
+    return _job

--- a/core/proxy_traffic.py
+++ b/core/proxy_traffic.py
@@ -68,7 +68,7 @@ def _clash_get(host: str, port: int, secret: str, path: str,
 
 def running_clash_targets() -> list:
     """
-    Запущенные конфиги с настроенным clash_api. Для каждого:
+    Запущенные конфиги sing-box с настроенным clash_api. Для каждого:
       {"config", "host", "port", "secret", "tags": [<real outbound tags>]}.
     Только read-only чтение конфигов — путь запуска не затрагивается.
     """
@@ -97,6 +97,47 @@ def running_clash_targets() -> list:
     return out
 
 
+def running_mihomo_clash_targets() -> list:
+    """
+    Запущенные конфиги mihomo с external-controller. mihomo — эталонная
+    реализация Clash, его `/connections` отдаёт тот же формат, что и
+    sing-box clash_api, поэтому трекер общий (см. get_mihomo_traffic_tracker).
+    """
+    out = []
+    try:
+        from core.mihomo_manager import get_mihomo_manager
+        from core.clash_yaml import parse_yaml
+        from core.mihomo_proxies import (
+            external_controller_endpoint, proxy_names)
+        mgr = get_mihomo_manager()
+        for c in mgr.list_configs():
+            if not c.get("running"):
+                continue
+            res = mgr.get_config(c["name"])
+            if not res.get("ok"):
+                continue
+            try:
+                cfg = parse_yaml(res.get("text") or "")
+            except Exception:
+                continue
+            ep = external_controller_endpoint(cfg)
+            if not ep:
+                continue
+            ep = dict(ep)
+            ep["config"] = c["name"]
+            ep["tags"] = proxy_names(cfg)
+            out.append(ep)
+    except Exception as e:
+        log.warning("proxy_traffic(mihomo): не удалось перечислить "
+                    "инстансы: %s" % e, source="mihomo")
+    return out
+
+
+def _mihomo_state_path() -> str:
+    from core.mihomo_platform import detect_mihomo_platform
+    return os.path.join(detect_mihomo_platform().run_dir, "proxy_traffic.json")
+
+
 def _pick_tag(chains) -> str:
     """Тег реального узла из chains (первый не служебный, обычно chains[0])."""
     if not isinstance(chains, list):
@@ -108,21 +149,28 @@ def _pick_tag(chains) -> str:
 
 
 class TrafficTracker:
-    """Фоновый накопитель трафика по тегам outbound'ов."""
+    """Фоновый накопитель трафика по тегам outbound'ов.
 
-    def __init__(self):
+    Параметризуется источником целей и путём состояния — один и тот же
+    класс обслуживает и sing-box (clash_api), и mihomo (external-
+    controller): формат `/connections` у них совпадает.
+    """
+
+    def __init__(self, targets_fn=None, state_path_fn=None):
         self._lock = threading.Lock()
         self._totals: dict = {}    # tag -> {"up","down","seen"}
         self._conn: dict = {}      # endpoint_key -> {conn_id: (up, down)}
         self._thread = None
         self._running = False
+        self._targets_fn = targets_fn or running_clash_targets
+        self._state_path_fn = state_path_fn or _state_path
         self._load()
 
     # ─────── persistence ───────
 
     def _load(self):
         try:
-            with open(_state_path(), "r") as f:
+            with open(self._state_path_fn(), "r") as f:
                 data = json.load(f)
         except (OSError, ValueError):
             return
@@ -138,7 +186,7 @@ class TrafficTracker:
                 }
 
     def _save(self):
-        path = _state_path()
+        path = self._state_path_fn()
         try:
             os.makedirs(os.path.dirname(path), exist_ok=True)
             tmp = path + ".tmp"
@@ -169,7 +217,7 @@ class TrafficTracker:
             time.sleep(_POLL_INTERVAL)
 
     def _poll_all(self):
-        targets = running_clash_targets()
+        targets = self._targets_fn()
         active_keys = set()
         changed = False
         for t in targets:
@@ -247,13 +295,28 @@ class TrafficTracker:
 
 
 _tracker = None
+_mihomo_tracker = None
 _tracker_lock = threading.Lock()
 
 
 def get_traffic_tracker() -> TrafficTracker:
+    """Трекер трафика sing-box (clash_api)."""
     global _tracker
     if _tracker is None:
         with _tracker_lock:
             if _tracker is None:
                 _tracker = TrafficTracker()
     return _tracker
+
+
+def get_mihomo_traffic_tracker() -> TrafficTracker:
+    """Трекер трафика mihomo (external-controller). Отдельный экземпляр и
+    отдельный файл состояния (в run_dir mihomo)."""
+    global _mihomo_tracker
+    if _mihomo_tracker is None:
+        with _tracker_lock:
+            if _mihomo_tracker is None:
+                _mihomo_tracker = TrafficTracker(
+                    targets_fn=running_mihomo_clash_targets,
+                    state_path_fn=_mihomo_state_path)
+    return _mihomo_tracker

--- a/docs/NEXT-SESSION-ROADMAP.md
+++ b/docs/NEXT-SESSION-ROADMAP.md
@@ -98,6 +98,21 @@ latest с нормализацией версии).
   `tests/test_singbox_debug.py`, `core/singbox_manager.py`).
 **Приёмка.** Прокси mihomo видны и управляются таблицей без правки YAML; есть
 тест и debug-режим.
+**✅ Сделано (эта сессия).** Страница `web/js/pages/mihomo_proxies.js` (таблица
+имя/тип/адрес/задержка/трафик, мультивыбор, сортировка, copy/paste ссылок,
+активация выбранного), пункт «Прокси» в `sidebar.js`. Бэкенд: новые эндпоинты в
+`api/mihomo.py` (`/configs/<n>/proxies`, `/activate`, `/enable-controller`,
+`/proxies/delete-bulk`, `/import-links`, `/export-links`, `/test`+`/test/status`,
+`/traffic`, `/debug`, `/configs/<n>/log`); `core/mihomo_proxies.py` (разбор
+proxies, RESTful Clash API: список групп/активный/переключение, текстовые
+правки), `core/mihomo_proxy_tester.py` (TCP-отсев + e2e через external-controller
+запущенного инстанса или одноразовый mihomo, как у sing-box),
+`core/proxy_traffic.py` обобщён под mihomo-трекер (`get_mihomo_traffic_tracker`),
+YAML-эмиттер + clash↔URI-конвертеры в `core/clash_yaml.py`, режим отладки
+(`log-level=debug` launch-конфиг) и хвост лога в `core/mihomo_manager.py`. Тесты:
+`tests/test_mihomo_proxies.py`. NB: round-trip-удаление прокси из таблицы требует
+PyYAML (без него — честный отказ, чтобы не повредить сложный конфиг); импорт/
+экспорт/тест/трафик/переключение работают и без PyYAML.
 
 ### 3. Полная унификация интерфейса awg / mihomo / sing-box / маршрутизации
 **Цель.** Единый стиль и логика разделов; общие компоненты вместо копипасты;

--- a/tests/test_mihomo_proxies.py
+++ b/tests/test_mihomo_proxies.py
@@ -1,0 +1,341 @@
+# tests/test_mihomo_proxies.py
+"""
+Тесты прокси-таблицы mihomo (задача №2):
+  - YAML-эмиттер clash_yaml.dump_yaml + round-trip;
+  - clash-proxy ↔ share-URI (copy/paste);
+  - чтение/мутации mihomo_proxies (rows/groups/controller/append/remove);
+  - тестер mihomo (TCP-degrade без бинаря/контроллера);
+  - режим отладки и лог менеджера mihomo.
+
+Тесты не требуют ни bottle, ни pyyaml (round-trip-операции гейтятся
+на has_pyyaml() и проверяются для обоих окружений).
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+from core.clash_yaml import (
+    parse_yaml, dump_yaml, dump_seq, has_pyyaml,
+    clash_proxy_to_uri, uri_to_clash_proxy,
+)
+from core import mihomo_proxies as mp
+from core.mihomo_proxy_tester import test_proxies
+from core import mihomo_manager
+from core.mihomo_manager import _inject_log_level
+from core.mihomo_platform import MihomoPlatform
+
+
+# ─────── YAML emitter ───────
+
+class TestDumpYaml(unittest.TestCase):
+
+    def test_roundtrip_pure_proxies(self):
+        cfg = {"proxies": [
+            {"name": "a", "type": "ss", "server": "1.2.3.4", "port": 8388,
+             "cipher": "aes-128-gcm", "password": "p"},
+            {"name": "My Node", "type": "vless", "server": "ex.com",
+             "port": 443, "uuid": "u-1"},
+        ]}
+        text = dump_yaml(cfg)
+        back = parse_yaml(text)
+        self.assertIn("proxies", back)
+        self.assertEqual(len(back["proxies"]), 2)
+        self.assertEqual(back["proxies"][0]["name"], "a")
+        self.assertEqual(back["proxies"][0]["port"], 8388)
+        self.assertEqual(back["proxies"][1]["name"], "My Node")
+
+    def test_quotes_special_values(self):
+        # значение с ':' должно быть заквочено и распарситься обратно.
+        text = dump_yaml({"external-controller": "127.0.0.1:9090"})
+        back = parse_yaml(text)
+        self.assertEqual(back["external-controller"], "127.0.0.1:9090")
+
+    def test_dump_seq_indent(self):
+        lines = dump_seq([{"name": "x", "type": "ss"}], indent=2)
+        self.assertTrue(lines[0].startswith("  - "))
+
+
+# ─────── clash-proxy ↔ URI ───────
+
+class TestClashUriRoundtrip(unittest.TestCase):
+
+    def _roundtrip(self, proxy):
+        uri = clash_proxy_to_uri(proxy)
+        self.assertTrue(uri, "пустой URI для %s" % proxy.get("type"))
+        r = uri_to_clash_proxy(uri)
+        self.assertTrue(r.get("ok"), r)
+        return r["proxy"]
+
+    def test_ss(self):
+        p = self._roundtrip({
+            "name": "ss1", "type": "ss", "server": "1.2.3.4", "port": 8388,
+            "cipher": "aes-128-gcm", "password": "pw"})
+        self.assertEqual(p["type"], "ss")
+        self.assertEqual(p["server"], "1.2.3.4")
+        self.assertEqual(p["port"], 8388)
+        self.assertEqual(p["cipher"], "aes-128-gcm")
+        self.assertEqual(p["password"], "pw")
+        self.assertEqual(p["name"], "ss1")
+
+    def test_vless_tls(self):
+        p = self._roundtrip({
+            "name": "v1", "type": "vless", "server": "ex.com", "port": 443,
+            "uuid": "uu", "tls": True, "servername": "sni.com",
+            "client-fingerprint": "chrome"})
+        self.assertEqual(p["type"], "vless")
+        self.assertEqual(p["uuid"], "uu")
+        self.assertTrue(p["tls"])
+        self.assertEqual(p["servername"], "sni.com")
+
+    def test_vless_reality(self):
+        p = self._roundtrip({
+            "name": "r1", "type": "vless", "server": "ex.com", "port": 443,
+            "uuid": "uu", "tls": True, "servername": "sni.com",
+            "client-fingerprint": "chrome",
+            "reality-opts": {"public-key": "0" * 64, "short-id": "ab"}})
+        self.assertEqual(p["reality-opts"]["public-key"], "0" * 64)
+        self.assertEqual(p["reality-opts"]["short-id"], "ab")
+
+    def test_trojan(self):
+        p = self._roundtrip({
+            "name": "t1", "type": "trojan", "server": "t.com", "port": 443,
+            "password": "pp", "sni": "s.com"})
+        self.assertEqual(p["type"], "trojan")
+        self.assertEqual(p["password"], "pp")
+        self.assertEqual(p["sni"], "s.com")
+
+    def test_unsupported_type_empty(self):
+        self.assertEqual(clash_proxy_to_uri(
+            {"name": "x", "type": "wireguard", "server": "h", "port": 1}), "")
+
+
+# ─────── чтение конфига ───────
+
+SAMPLE = """\
+mixed-port: 7890
+proxies:
+  - name: A
+    type: ss
+    server: 1.1.1.1
+    port: 8388
+    cipher: aes-128-gcm
+    password: p
+  - name: B
+    type: trojan
+    server: 2.2.2.2
+    port: 443
+    password: q
+proxy-groups:
+  - name: PROXY
+    type: select
+    proxies:
+      - A
+      - B
+rules:
+  - MATCH,PROXY
+"""
+
+
+class TestReadConfig(unittest.TestCase):
+
+    def setUp(self):
+        self.cfg = parse_yaml(SAMPLE)
+
+    def test_proxy_rows(self):
+        rows = mp.proxy_rows(self.cfg)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["name"], "A")
+        self.assertEqual(rows[0]["type"], "ss")
+        self.assertEqual(rows[0]["server"], "1.1.1.1")
+        self.assertEqual(rows[0]["port"], 8388)
+
+    def test_proxy_names(self):
+        self.assertEqual(mp.proxy_names(self.cfg), ["A", "B"])
+
+    def test_select_groups(self):
+        self.assertEqual(mp.select_group_names(self.cfg), ["PROXY"])
+
+    def test_external_controller_endpoint(self):
+        self.assertIsNone(mp.external_controller_endpoint(self.cfg))
+        ep = mp.external_controller_endpoint(
+            {"external-controller": "127.0.0.1:9090", "secret": "s"})
+        self.assertEqual(ep, {"host": "127.0.0.1", "port": 9090,
+                              "secret": "s"})
+        ep2 = mp.external_controller_endpoint(
+            {"external-controller": "0.0.0.0:9091"})
+        self.assertEqual(ep2["host"], "127.0.0.1")
+        self.assertEqual(ep2["port"], 9091)
+
+
+# ─────── мутации ───────
+
+class TestMutations(unittest.TestCase):
+
+    def test_remove_proxies_and_clean_groups(self):
+        cfg = parse_yaml(SAMPLE)
+        mp.remove_proxies(cfg, ["A"])
+        self.assertEqual([p["name"] for p in cfg["proxies"]], ["B"])
+        # ссылка на A удалена из группы
+        grp = cfg["proxy-groups"][0]
+        self.assertEqual(grp["proxies"], ["B"])
+
+    def test_append_proxies_text(self):
+        new = [{"name": "C", "type": "ss", "server": "3.3.3.3", "port": 9000,
+                "cipher": "aes-128-gcm", "password": "z"}]
+        out = mp.append_proxies_text(SAMPLE, new)
+        back = parse_yaml(out)
+        names = [p["name"] for p in back["proxies"]]
+        self.assertIn("A", names)
+        self.assertIn("C", names)
+        # остальные секции (rules) сохранены текстово
+        self.assertIn("rules:", out)
+        self.assertIn("MATCH,PROXY", out)
+
+    def test_append_no_proxies_section(self):
+        out = mp.append_proxies_text("mixed-port: 7890\n", [
+            {"name": "C", "type": "ss", "server": "3.3.3.3", "port": 1,
+             "cipher": "aes-128-gcm", "password": "z"}])
+        back = parse_yaml(out)
+        self.assertEqual([p["name"] for p in back["proxies"]], ["C"])
+
+    def test_enable_external_controller_text(self):
+        out = mp.enable_external_controller_text(
+            "mixed-port: 7890\nproxies:\n  - name: a\n",
+            "127.0.0.1", 9090, "sec")
+        self.assertTrue(out.startswith("external-controller: 127.0.0.1:9090\n"))
+        self.assertIn("secret: sec", out)
+        self.assertIn("mixed-port: 7890", out)
+        # идемпотентность
+        self.assertEqual(
+            mp.enable_external_controller_text(out, "127.0.0.1", 1, "x"), out)
+
+    def test_safe_mutate_delete(self):
+        r = mp.safe_mutate(SAMPLE, lambda c: mp.remove_proxies(c, ["A"]))
+        if has_pyyaml():
+            self.assertTrue(r["ok"], r)
+            back = parse_yaml(r["text"])
+            self.assertEqual([p["name"] for p in back["proxies"]], ["B"])
+        else:
+            self.assertFalse(r["ok"])
+            self.assertTrue(r.get("needs_pyyaml"))
+
+
+# ─────── тестер ───────
+
+class TestTester(unittest.TestCase):
+
+    def test_empty(self):
+        res = test_proxies([], binary=None)
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["summary"]["total"], 0)
+
+    def test_tcp_only_dead(self):
+        # 127.0.0.1:1 — порт закрыт → connection refused (быстро) → мёртв.
+        res = test_proxies(
+            [{"name": "dead", "type": "ss", "server": "127.0.0.1", "port": 1}],
+            controller=None, binary=None)
+        self.assertEqual(res["summary"]["total"], 1)
+        row = res["results"][0]
+        self.assertEqual(row["tag"], "dead")
+        self.assertFalse(row["alive"])
+        self.assertEqual(row["stage"], "tcp")
+
+    def test_filters_missing_server(self):
+        res = test_proxies([{"name": "x", "type": "ss"}], binary=None)
+        self.assertEqual(res["summary"]["total"], 0)
+
+
+# ─────── менеджер: debug / log / dotfiles ───────
+
+class _FakePlatform(MihomoPlatform):
+    name = "test"
+
+    def __init__(self, base):
+        self.binary_dir = os.path.join(base, "bin")
+        self.config_dir = os.path.join(base, "config")
+        self.run_dir = os.path.join(base, "run")
+        self.log_dir = os.path.join(base, "log")
+        for d in (self.binary_dir, self.config_dir, self.run_dir,
+                  self.log_dir):
+            os.makedirs(d, exist_ok=True)
+
+
+class _FakeCM:
+    def __init__(self):
+        self.d = {}
+
+    def get(self, sect, key, default=None):
+        return self.d.get((sect, key), default)
+
+    def set(self, sect, key, val):
+        self.d[(sect, key)] = val
+
+    def save(self):
+        pass
+
+
+class TestManagerDebug(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="mihomo-px-")
+        self.platform = _FakePlatform(self.tmp)
+        self.mgr = mihomo_manager.MihomoManager()
+        self._pp = mock.patch.object(self.mgr, "_platform",
+                                     return_value=self.platform)
+        self._pp.start()
+
+    def tearDown(self):
+        self._pp.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_inject_log_level(self):
+        out = _inject_log_level(
+            "mixed-port: 7890\nlog-level: info\nproxies:\n  - name: a\n",
+            "debug")
+        self.assertTrue(out.startswith("log-level: debug\n"))
+        self.assertNotIn("log-level: info", out)
+        self.assertIn("mixed-port: 7890", out)
+
+    def test_get_set_debug(self):
+        cm = _FakeCM()
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=cm):
+            self.assertFalse(self.mgr.get_debug()["enabled"])
+            self.assertTrue(self.mgr.set_debug(True)["enabled"])
+            self.assertTrue(self.mgr.get_debug()["enabled"])
+
+    def test_list_configs_skips_dotfiles(self):
+        cfg_dir = self.platform.config_dir
+        with open(os.path.join(cfg_dir, "vpn.yaml"), "w") as f:
+            f.write("proxies:\n  - name: a\n    type: ss\n"
+                    "    server: 1.1.1.1\n    port: 1\n")
+        with open(os.path.join(cfg_dir, ".run-vpn.yaml"), "w") as f:
+            f.write("log-level: debug\nproxies: []\n")
+        names = [c["name"] for c in self.mgr.list_configs()]
+        self.assertIn("vpn", names)
+        self.assertNotIn(".run-vpn", names)
+
+    def test_read_log(self):
+        with open(self.platform.log_path("inst"), "w") as f:
+            for i in range(300):
+                f.write("line %d\n" % i)
+        r = self.mgr.read_log("inst", lines=10)
+        self.assertTrue(r["ok"])
+        self.assertTrue(r["exists"])
+        self.assertIn("line 299", r["log"])
+        self.assertNotIn("line 100", r["log"])
+
+    def test_read_log_missing(self):
+        r = self.mgr.read_log("nope")
+        self.assertTrue(r["ok"])
+        self.assertFalse(r["exists"])
+
+    def test_read_log_bad_name(self):
+        self.assertFalse(self.mgr.read_log("../etc/passwd")["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/index.html
+++ b/web/index.html
@@ -110,6 +110,7 @@
     <script src="/js/pages/singbox_proxies.js"></script>
     <script src="/js/pages/singbox_setup.js"></script>
     <script src="/js/pages/mihomo.js"></script>
+    <script src="/js/pages/mihomo_proxies.js"></script>
     <script src="/js/pages/mihomo_setup.js"></script>
     <script src="/js/pages/lists.js"></script>
     <script src="/js/pages/routing_unified.js"></script>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -33,6 +33,7 @@ const App = (() => {
         'singbox-proxies': SingboxProxiesPage,
         'singbox-setup':   SingboxSetupPage,
         mihomo:            MihomoPage,
+        'mihomo-proxies':  MihomoProxiesPage,
         'mihomo-setup':    MihomoSetupPage,
         lists:       ListsPage,
         routing:     RoutingUnifiedPage,

--- a/web/js/components/sidebar.js
+++ b/web/js/components/sidebar.js
@@ -65,7 +65,8 @@ const Sidebar = (() => {
                     { id: 'singbox-setup',   label: 'Установка', icon: 'settings' },
                 ] },
                 { id: 'mihomo', label: 'mihomo', icon: 'awg', children: [
-                    { id: 'mihomo-setup', label: 'Установка', icon: 'settings' },
+                    { id: 'mihomo-proxies', label: 'Прокси',   icon: 'globe' },
+                    { id: 'mihomo-setup',   label: 'Установка', icon: 'settings' },
                 ] },
             ]
         },

--- a/web/js/pages/mihomo_proxies.js
+++ b/web/js/pages/mihomo_proxies.js
@@ -1,0 +1,797 @@
+/**
+ * mihomo_proxies.js — таблица проксей mihomo (паритет с singbox_proxies.js).
+ *
+ * Единое окно-таблица над секцией `proxies` выбранного clash-конфига:
+ * Имя | Тип | Адрес | Задержка/статус | Трафик ↑/↓.
+ *
+ *   - выбор строк (клик / Ctrl+клик / Shift-диапазон / чекбоксы);
+ *   - сортируемые заголовки (доступность/задержка/трафик/имя/тип);
+ *   - тест выделенных/всех (TCP-отсев + e2e через движок mihomo);
+ *   - copy/paste share-ссылок (Ctrl+C / Ctrl+V);
+ *   - активация выбранного — живое переключение через external-controller;
+ *   - учёт трафика per-proxy (Clash API /connections);
+ *   - режим отладки (log-level=debug) + просмотр лога инстанса.
+ *
+ * Отличия от sing-box: tag = имя прокси (может содержать пробелы/эмодзи),
+ * поэтому обработчики строк используют индекс, а не имя в inline-onclick.
+ * Переключение/трафик/тест требуют запущенного инстанса с external-
+ * controller — у mihomo выбор узла живёт в рантайме, не в YAML.
+ */
+
+const MihomoProxiesPage = (() => {
+
+    let configs = [];
+    let configName = '';
+    let proxies = [];                   // [{name,type,server,port}]
+    let activeName = '';                // активный узел (now первой select-группы)
+    let running = false;
+    let hasController = false;          // в конфиге есть external-controller
+    let controllerLive = false;         // controller отвечает
+    let selectGroups = [];
+
+    let testResults = {};               // name -> {alive, latency_ms, stage, error}
+    let traffic = {};                   // name -> {up, down}
+
+    let selected = new Set();           // выбранные имена
+    let lastClickedIdx = -1;
+    let sortKey = 'avail';
+    let sortDir = 'desc';
+
+    let target = 'cloudflare';
+    let testState = { running: false, progress: { phase: '', done: 0, total: 0 } };
+    let testTimer = null;
+    let trafficTimer = null;
+    let showPasteBox = false;
+    let busy = false;
+    let debugEnabled = false;
+    let logText = null;                 // строка лога или null (панель скрыта)
+
+    let keyHandler = null;
+    let pasteHandler = null;
+
+    // ══════════════ lifecycle ══════════════
+
+    function render(container) {
+        container.innerHTML = `
+            <div class="page-header">
+                <div>
+                    <h1 class="page-title">Прокси mihomo</h1>
+                    <p class="page-description">
+                        Серверы clash-конфига: тест задержки через движок,
+                        учёт трафика, переключение активного узла на лету,
+                        copy/paste ссылок (Ctrl+C / Ctrl+V).
+                    </p>
+                </div>
+                <div style="display:flex; gap:8px;">
+                    <button class="btn btn-ghost btn-sm" onclick="window.location.hash='mihomo'">
+                        Инстансы
+                    </button>
+                    <button class="btn btn-ghost btn-sm" onclick="MihomoProxiesPage.refreshAll()">
+                        Обновить
+                    </button>
+                </div>
+            </div>
+            <div id="mpx-body"></div>
+        `;
+        attachGlobalHandlers();
+        loadDebug();
+        loadConfigs();
+        startTrafficPolling();
+    }
+
+    function destroy() {
+        if (testTimer) { clearTimeout(testTimer); testTimer = null; }
+        if (trafficTimer) { clearTimeout(trafficTimer); trafficTimer = null; }
+        detachGlobalHandlers();
+    }
+
+    // ══════════════ data ══════════════
+
+    async function loadDebug() {
+        try {
+            const r = await API.get('/api/mihomo/debug');
+            debugEnabled = !!(r && r.enabled);
+        } catch (_) { /* не критично */ }
+    }
+
+    async function loadConfigs() {
+        try {
+            const r = await API.get('/api/mihomo/configs');
+            configs = (r && r.configs) || [];
+        } catch (e) { Toast.error(e.message); configs = []; }
+
+        if (!configName || !configs.some(c => c.name === configName)) {
+            configName = (configs[0] || {}).name || '';
+        }
+        await loadProxies();
+        await loadTraffic();
+        renderBody();
+    }
+
+    async function loadProxies() {
+        proxies = []; activeName = ''; running = false;
+        hasController = false; controllerLive = false; selectGroups = [];
+        if (!configName) return;
+        try {
+            const r = await API.get(
+                `/api/mihomo/configs/${encodeURIComponent(configName)}/proxies`);
+            if (r && r.ok) {
+                proxies = r.proxies || [];
+                activeName = r.active || '';
+                running = !!r.running;
+                hasController = !!r.controller;
+                controllerLive = !!r.controller_live;
+                selectGroups = r.select_groups || [];
+            } else {
+                Toast.error((r && r.error) || 'не удалось получить прокси');
+            }
+        } catch (e) { Toast.error(e.message); }
+        // Чистим выбор от исчезнувших имён.
+        const present = new Set(proxies.map(p => p.name));
+        selected = new Set([...selected].filter(n => present.has(n)));
+    }
+
+    async function loadTraffic() {
+        if (!configName) { traffic = {}; return; }
+        try {
+            const r = await API.get(
+                `/api/mihomo/traffic?config=${encodeURIComponent(configName)}`);
+            if (r && r.ok) traffic = r.traffic || {};
+        } catch (_) { /* трафик не критичен */ }
+    }
+
+    function startTrafficPolling() {
+        if (trafficTimer) clearTimeout(trafficTimer);
+        trafficTimer = setTimeout(async () => {
+            await loadTraffic();
+            if (document.getElementById('mpx-body')) updateTrafficCells();
+            startTrafficPolling();
+        }, 3000);
+    }
+
+    function updateTrafficCells() {
+        const body = document.getElementById('mpx-body');
+        if (!body) return;
+        body.querySelectorAll('tr[data-name]').forEach(tr => {
+            const cell = tr.querySelector('.mpx-traffic');
+            if (cell) cell.innerHTML = trafficCellHtml(tr.getAttribute('data-name'));
+        });
+    }
+
+    async function refreshAll() { await loadConfigs(); }
+
+    function switchConfig(name) {
+        configName = name;
+        selected = new Set();
+        lastClickedIdx = -1;
+        testResults = {};
+        logText = null;
+        loadProxies().then(loadTraffic).then(renderBody);
+    }
+
+    // ══════════════ render ══════════════
+
+    function renderBody() {
+        const box = document.getElementById('mpx-body');
+        if (!box) return;
+
+        if (!configs.length) {
+            box.innerHTML = `<div class="card"><div class="text-muted">
+                Конфигов нет. Создайте конфиг на странице
+                <a href="#mihomo" style="text-decoration:underline;">Инстансы</a>
+                и вставьте clash-YAML, либо вставьте ссылки сюда (Ctrl+V).
+            </div></div>`;
+            return;
+        }
+
+        const cfgOpts = configs.map(c =>
+            `<option value="${escapeAttr(c.name)}" ${c.name === configName ? 'selected' : ''}>
+                ${escapeHtml(c.name)}${c.running ? ' ●' : ''}
+            </option>`).join('');
+
+        const selCount = selected.size;
+        box.innerHTML = `
+            <div class="card" style="margin-bottom:12px;">
+                <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+                    <label class="text-muted" style="margin:0;">Конфиг:</label>
+                    <select class="form-input" style="width:auto;"
+                            onchange="MihomoProxiesPage.switchConfig(this.value)">
+                        ${cfgOpts}
+                    </select>
+                    <span class="text-muted" style="font-size:12px;">
+                        прокси: ${proxies.length}${selCount ? ` · выбрано: ${selCount}` : ''}
+                        ${running ? ' · <span style="color:#39c45e;">running</span>'
+                                  : ' · <span style="color:#e58;">stopped</span>'}
+                    </span>
+                    <div style="margin-left:auto; display:flex; gap:6px; flex-wrap:wrap;">
+                        <label class="text-muted" style="display:flex; align-items:center; gap:4px; font-size:12px;">
+                            цель
+                            <select class="form-input" style="width:auto;"
+                                    onchange="MihomoProxiesPage.setTarget(this.value)">
+                                ${['cloudflare', 'amazon', 'google'].map(t =>
+                                    `<option value="${t}" ${t === target ? 'selected' : ''}>${t}</option>`).join('')}
+                            </select>
+                        </label>
+                        <button class="btn btn-primary btn-sm" ${testState.running || busy ? 'disabled' : ''}
+                                onclick="MihomoProxiesPage.test(false)">
+                            ${testState.running ? 'Тест идёт…' : 'Тест всех'}
+                        </button>
+                        <button class="btn btn-ghost btn-sm" ${testState.running || busy || !selCount ? 'disabled' : ''}
+                                onclick="MihomoProxiesPage.test(true)">
+                            Тест выделенных
+                        </button>
+                        <button class="btn btn-primary btn-sm" ${busy || selCount !== 1 ? 'disabled' : ''}
+                                onclick="MihomoProxiesPage.activateSelected()"
+                                title="Пустить трафик через выделенный узел (двойной клик по строке)">
+                            ▶ Через эту
+                        </button>
+                        <button class="btn btn-ghost btn-sm" ${!selCount ? 'disabled' : ''}
+                                onclick="MihomoProxiesPage.copySelected()" title="Ctrl+C">
+                            Копировать
+                        </button>
+                        <button class="btn btn-ghost btn-sm"
+                                onclick="MihomoProxiesPage.togglePasteBox()" title="Ctrl+V">
+                            Вставить
+                        </button>
+                        <button class="btn btn-ghost btn-sm" ${!selCount || busy ? 'disabled' : ''}
+                                onclick="MihomoProxiesPage.deleteSelected()" title="Delete">
+                            Удалить
+                        </button>
+                    </div>
+                </div>
+                <div style="display:flex; gap:14px; align-items:center; flex-wrap:wrap; margin-top:10px;">
+                    <label class="text-muted" style="display:flex; align-items:center; gap:5px; font-size:12px;">
+                        <input type="checkbox" ${debugEnabled ? 'checked' : ''}
+                               onchange="MihomoProxiesPage.toggleDebug(this.checked)">
+                        режим отладки (log-level=debug)
+                    </label>
+                    <button class="btn btn-ghost btn-sm" onclick="MihomoProxiesPage.toggleLog()">
+                        ${logText !== null ? 'Скрыть лог' : 'Показать лог'}
+                    </button>
+                </div>
+                ${renderControllerBanner()}
+                ${showPasteBox ? renderPasteBox() : ''}
+                ${renderTestProgress()}
+                ${logText !== null ? renderLogPanel() : ''}
+            </div>
+
+            ${renderTable()}
+        `;
+    }
+
+    function renderControllerBanner() {
+        if (hasController && (controllerLive || !running)) return '';
+        if (!hasController) {
+            return `
+                <div class="alert alert-warning" style="margin-top:10px; display:flex; justify-content:space-between; align-items:center; gap:12px; flex-wrap:wrap;">
+                    <div style="font-size:12px;">
+                        У конфига <strong>${escapeHtml(configName)}</strong> нет
+                        <code>external-controller</code> — без него недоступны учёт
+                        трафика, тест через движок и переключение узла на лету.
+                    </div>
+                    <button class="btn btn-primary btn-sm" ${busy ? 'disabled' : ''}
+                            onclick="MihomoProxiesPage.enableController()">
+                        Включить управление и учёт трафика
+                    </button>
+                </div>`;
+        }
+        // есть controller, но running и не отвечает
+        return `
+            <div class="alert alert-warning" style="margin-top:10px; font-size:12px;">
+                external-controller настроен, но не отвечает. Проверьте порт/secret
+                и что конфиг перезапущен после изменения.
+            </div>`;
+    }
+
+    function renderPasteBox() {
+        return `
+            <div style="margin-top:10px;">
+                <label class="form-label">Вставьте ссылки (vless:// / vmess:// / trojan:// / ss:// / hy2:// / tuic://), по одной в строке:</label>
+                <textarea id="mpx-paste" class="form-textarea" spellcheck="false"
+                          style="width:100%; min-height:90px; font-family:monospace; font-size:12px;"
+                          placeholder="vless://...&#10;ss://..."></textarea>
+                <div style="margin-top:6px; display:flex; gap:6px;">
+                    <button class="btn btn-primary btn-sm" onclick="MihomoProxiesPage.importPasteBox()">
+                        Импортировать
+                    </button>
+                    <button class="btn btn-ghost btn-sm" onclick="MihomoProxiesPage.togglePasteBox()">
+                        Отмена
+                    </button>
+                </div>
+            </div>`;
+    }
+
+    function renderLogPanel() {
+        return `
+            <div style="margin-top:12px;">
+                <div class="text-muted" style="font-size:11px; margin-bottom:4px;">
+                    Лог инстанса «${escapeHtml(configName)}» (хвост):
+                </div>
+                <pre style="max-height:240px; overflow:auto; background:var(--bg-input);
+                            padding:8px; border-radius:6px; font-size:11px; white-space:pre-wrap;
+                            margin:0;">${escapeHtml(logText || '(пусто)')}</pre>
+            </div>`;
+    }
+
+    function renderTestProgress() {
+        if (!testState.running) return '';
+        const p = testState.progress || { phase: '', done: 0, total: 0 };
+        const label = p.phase === 'e2e' ? 'Проверка через движок до облака' : 'TCP-отсев живых';
+        const total = p.total || 0, done = p.done || 0;
+        const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+        return `
+            <div style="margin-top:12px;">
+                <div style="display:flex; justify-content:space-between; font-size:12px;">
+                    <span class="text-muted">${label}…</span>
+                    <span class="text-muted">${done} / ${total}${total ? ` (${pct}%)` : ''}</span>
+                </div>
+                <div style="height:6px; background:var(--bg-input); border-radius:4px; overflow:hidden; margin-top:6px;">
+                    <div style="height:100%; width:${pct}%; background:var(--accent); transition:width .3s;"></div>
+                </div>
+            </div>`;
+    }
+
+    function renderTable() {
+        if (!proxies.length) {
+            return `<div class="card"><div class="text-muted">
+                В конфиге «${escapeHtml(configName)}» нет прокси. Вставьте ссылки
+                (Ctrl+V / кнопка «Вставить») или добавьте их в YAML на странице
+                «Инстансы».
+            </div></div>`;
+        }
+
+        const rows = sortedRows();
+        const allSel = rows.length && rows.every(r => selected.has(r.name));
+
+        const head = (key, label, alignRight) => {
+            const active = sortKey === key;
+            const arrow = active ? (sortDir === 'desc' ? ' ▼' : ' ▲') : '';
+            return `<th style="text-align:${alignRight ? 'right' : 'left'}; cursor:pointer; user-select:none; ${active ? 'color:var(--accent);' : ''}"
+                        onclick="MihomoProxiesPage.sortBy('${key}')">${label}${arrow}</th>`;
+        };
+
+        const body = rows.map((r, idx) => {
+            const sel = selected.has(r.name);
+            const isActive = r.name === activeName;
+            return `
+                <tr data-name="${escapeAttr(r.name)}" style="cursor:pointer; ${sel ? 'background:var(--bg-hover, rgba(120,140,255,.12));' : ''}"
+                    title="Двойной клик — пустить трафик через этот узел"
+                    onclick="MihomoProxiesPage.onRowClick(${idx}, event)"
+                    ondblclick="MihomoProxiesPage.activateIdx(${idx})">
+                    <td style="width:28px; text-align:center;">
+                        <input type="checkbox" ${sel ? 'checked' : ''}
+                               onclick="event.stopPropagation(); MihomoProxiesPage.toggleRow(${idx})">
+                    </td>
+                    <td>
+                        ${isActive ? '<span style="color:#39c45e;" title="активный узел">▶</span> ' : ''}
+                        <span style="font-weight:600;">${escapeHtml(r.name)}</span>
+                    </td>
+                    <td class="text-muted" style="font-size:11px;">${escapeHtml(r.type)}</td>
+                    <td class="text-muted" style="font-size:11px;">${escapeHtml(addressOf(r))}</td>
+                    <td>${renderTestCell(r.name)}</td>
+                    <td class="mpx-traffic" style="text-align:right; white-space:nowrap; font-size:12px;">
+                        ${trafficCellHtml(r.name)}
+                    </td>
+                </tr>`;
+        }).join('');
+
+        return `
+            <div class="card">
+                <div style="overflow-x:auto;">
+                    <table style="width:100%; border-collapse:collapse; font-size:13px;">
+                        <thead><tr style="border-bottom:1px solid var(--border,#333);">
+                            <th style="width:28px; text-align:center;">
+                                <input type="checkbox" ${allSel ? 'checked' : ''}
+                                       title="Выделить всё (Ctrl+A)"
+                                       onclick="MihomoProxiesPage.toggleAll(this.checked)">
+                            </th>
+                            ${head('name', 'Имя')}
+                            ${head('type', 'Тип')}
+                            ${head('address', 'Адрес')}
+                            ${head('avail', 'Задержка / статус')}
+                            ${head('traffic', 'Трафик', true)}
+                        </tr></thead>
+                        <tbody>${body}</tbody>
+                    </table>
+                </div>
+            </div>`;
+    }
+
+    function addressOf(r) {
+        return (r.server != null ? String(r.server) : '')
+             + (r.port != null && r.port !== '' ? ':' + r.port : '');
+    }
+
+    function trafficCellHtml(name) {
+        const tr = traffic[name] || {};
+        const tt = (Number(tr.up) || 0) + (Number(tr.down) || 0);
+        if (tt <= 0) return '<span class="text-muted">—</span>';
+        return `<span class="text-muted">↑</span> ${humanBytes(tr.up)} `
+             + `<span class="text-muted">↓</span> ${humanBytes(tr.down)}`;
+    }
+
+    function renderTestCell(name) {
+        const r = testResults[name];
+        if (!r) return '<span class="text-muted">—</span>';
+        const dot = r.alive ? '#39c45e' : '#e58';
+        if (r.alive) {
+            const lat = r.latency_ms != null ? `${r.latency_ms} ms` : 'жив';
+            const stage = r.stage === 'e2e' ? 'e2e' : 'tcp';
+            return `<span style="color:${dot};">●</span> ${lat}
+                    <span class="text-muted" style="font-size:10px;">${stage}</span>`;
+        }
+        return `<span style="color:${dot};">●</span> <span style="color:#e58;">мёртв</span>
+                ${r.error ? `<span class="text-muted" style="font-size:10px;">${escapeHtml(r.error)}</span>` : ''}`;
+    }
+
+    // ══════════════ rows / sorting / selection ══════════════
+
+    function sortedRows() {
+        const rows = proxies.slice();
+        const dir = sortDir === 'desc' ? -1 : 1;
+        const lat = n => {
+            const r = testResults[n];
+            return (r && r.alive && r.latency_ms != null) ? r.latency_ms : null;
+        };
+        const aliveRank = n => {
+            const r = testResults[n];
+            if (!r) return 0;
+            return r.alive ? 1 : -1;
+        };
+        const traf = n => {
+            const v = traffic[n] || {};
+            return (Number(v.up) || 0) + (Number(v.down) || 0);
+        };
+        const cmp = (a, b) => {
+            let x = 0;
+            if (sortKey === 'name') x = String(a.name).localeCompare(String(b.name));
+            else if (sortKey === 'type') x = String(a.type).localeCompare(String(b.type)) || String(a.name).localeCompare(String(b.name));
+            else if (sortKey === 'address') x = addressOf(a).localeCompare(addressOf(b));
+            else if (sortKey === 'traffic') x = traf(a.name) - traf(b.name);
+            else if (sortKey === 'avail') {
+                x = aliveRank(a.name) - aliveRank(b.name);
+                if (x === 0) {
+                    const la = lat(a.name), lb = lat(b.name);
+                    if (la == null && lb == null) x = 0;
+                    else if (la == null) x = -1;
+                    else if (lb == null) x = 1;
+                    else x = lb - la;
+                }
+            }
+            return x * dir;
+        };
+        return rows.sort(cmp);
+    }
+
+    function sortBy(key) {
+        if (sortKey === key) {
+            sortDir = sortDir === 'desc' ? 'asc' : 'desc';
+        } else {
+            sortKey = key;
+            sortDir = (key === 'name' || key === 'type' || key === 'address') ? 'asc' : 'desc';
+        }
+        lastClickedIdx = -1;
+        renderBody();
+    }
+
+    function onRowClick(idx, event) {
+        const rows = sortedRows();
+        const r = rows[idx];
+        if (!r) return;
+        if (event && event.shiftKey && lastClickedIdx >= 0) {
+            const [a, b] = [lastClickedIdx, idx].sort((x, y) => x - y);
+            for (let i = a; i <= b && i < rows.length; i++) selected.add(rows[i].name);
+        } else if (event && (event.ctrlKey || event.metaKey)) {
+            if (selected.has(r.name)) selected.delete(r.name); else selected.add(r.name);
+            lastClickedIdx = idx;
+        } else {
+            selected = new Set([r.name]);
+            lastClickedIdx = idx;
+        }
+        renderBody();
+    }
+
+    function toggleRow(idx) {
+        const r = sortedRows()[idx];
+        if (!r) return;
+        if (selected.has(r.name)) selected.delete(r.name); else selected.add(r.name);
+        lastClickedIdx = idx;
+        renderBody();
+    }
+
+    function toggleAll(on) {
+        selected = on ? new Set(proxies.map(p => p.name)) : new Set();
+        renderBody();
+    }
+
+    function setTarget(t) { target = t; }
+
+    // ══════════════ test ══════════════
+
+    async function test(selectedOnly) {
+        if (!configName) { Toast.error('Сначала выберите конфиг'); return; }
+        const payload = { config: configName, target };
+        if (selectedOnly) {
+            if (!selected.size) { Toast.error('Ничего не выбрано'); return; }
+            payload.names = [...selected];
+        }
+        try {
+            const r = await API.post('/api/mihomo/test', payload);
+            if (!r || !r.ok) { Toast.error((r && r.error) || 'не удалось запустить тест'); return; }
+            Toast.info(`Тестируем ${r.count} прокси…`);
+            testState.running = true;
+            testState.progress = { phase: 'tcp', done: 0, total: r.count || 0 };
+            renderBody();
+            pollTest();
+        } catch (e) { Toast.error(e.message); }
+    }
+
+    function pollTest() {
+        if (testTimer) clearTimeout(testTimer);
+        testTimer = setTimeout(async () => {
+            try {
+                const st = await API.get('/api/mihomo/test/status');
+                testState.running = !!st.running;
+                if (st.progress) testState.progress = st.progress;
+                if (!st.running && st.result && st.result.results) {
+                    mergeResults(st.result.results);
+                    const sum = st.result.summary || {};
+                    const eng = st.result.engine_used ? '' : ' (только TCP — запустите конфиг для теста через движок)';
+                    Toast.success(`Готово: живых ${sum.alive || 0} / ${sum.total || 0}${eng}`);
+                    renderBody();
+                    return;
+                }
+                renderBody();
+                if (st.running) pollTest();
+            } catch (e) {
+                testState.running = false; renderBody();
+            }
+        }, 1000);
+    }
+
+    function mergeResults(results) {
+        (results || []).forEach(r => {
+            testResults[r.tag] = {
+                alive: !!r.alive, latency_ms: r.latency_ms,
+                stage: r.stage, error: r.error || '',
+            };
+        });
+    }
+
+    // ══════════════ copy / paste / delete ══════════════
+
+    async function copySelected() {
+        if (!selected.size) { Toast.error('Ничего не выбрано'); return; }
+        try {
+            const r = await API.post('/api/mihomo/export-links',
+                { config: configName, names: [...selected] });
+            if (!r || !r.ok || !r.text) { Toast.error('Нет ссылок для копирования (тип не экспортируется)'); return; }
+            const ok = await copyText(r.text);
+            if (ok) Toast.success(`Скопировано ссылок: ${r.count}`);
+            else Toast.error('Не удалось записать в буфер — выделите и скопируйте вручную');
+        } catch (e) { Toast.error(e.message); }
+    }
+
+    async function importText(text) {
+        text = (text || '').trim();
+        if (!text) return;
+        if (!configName) { Toast.error('Сначала выберите конфиг'); return; }
+        busy = true; renderBody();
+        try {
+            const r = await API.post(
+                `/api/mihomo/configs/${encodeURIComponent(configName)}/import-links`,
+                { text });
+            if (r && r.ok) {
+                Toast.success(`Добавлено: ${r.added}${r.renamed ? `, переименовано: ${r.renamed}` : ''}${r.errors ? `, ошибок: ${r.errors}` : ''}`);
+                showPasteBox = false;
+                await loadProxies();
+            } else {
+                Toast.error((r && r.error) || 'не удалось импортировать');
+            }
+        } catch (e) { Toast.error(e.message); }
+        finally { busy = false; renderBody(); }
+    }
+
+    function togglePasteBox() {
+        showPasteBox = !showPasteBox;
+        renderBody();
+        if (showPasteBox) {
+            const ta = document.getElementById('mpx-paste');
+            if (ta) ta.focus();
+        }
+    }
+
+    function importPasteBox() {
+        const ta = document.getElementById('mpx-paste');
+        importText(ta ? ta.value : '');
+    }
+
+    async function deleteSelected() {
+        if (!selected.size) return;
+        const names = [...selected];
+        if (!confirm(`Удалить выбранные прокси (${names.length}) из конфига «${configName}»?`)) return;
+        busy = true; renderBody();
+        try {
+            const r = await API.post(
+                `/api/mihomo/configs/${encodeURIComponent(configName)}/proxies/delete-bulk`,
+                { names });
+            if (r && r.ok) {
+                Toast.success(`Удалено: ${(r.deleted || []).length}${(r.skipped || []).length ? `, пропущено: ${r.skipped.length}` : ''}`);
+                selected = new Set();
+                await loadProxies();
+            } else if (r && r.needs_pyyaml) {
+                Toast.error(r.error || 'для удаления нужен PyYAML');
+            } else {
+                Toast.error((r && r.error) || 'не удалось удалить');
+            }
+        } catch (e) { Toast.error(e.message); }
+        finally { busy = false; renderBody(); }
+    }
+
+    // ══════════════ activate ══════════════
+
+    function activateSelected() {
+        if (selected.size !== 1) { Toast.error('Выберите один узел'); return; }
+        activate([...selected][0]);
+    }
+
+    function activateIdx(idx) {
+        const r = sortedRows()[idx];
+        if (r) activate(r.name);
+    }
+
+    async function activate(name) {
+        if (!configName) return;
+        busy = true; renderBody();
+        try {
+            const r = await API.post(
+                `/api/mihomo/configs/${encodeURIComponent(configName)}/activate`,
+                { name });
+            if (r && r.ok) {
+                Toast.success(`Трафик идёт через «${name}» (группа ${r.group || '?'})`);
+                await loadProxies();
+            } else if (r && r.needs_running) {
+                Toast.error('Запустите конфиг — переключение у mihomo делается на лету.');
+            } else if (r && r.needs_controller) {
+                Toast.error('Нет external-controller — включите управление кнопкой и перезапустите конфиг.');
+            } else {
+                Toast.error((r && r.error) || 'не удалось переключить');
+            }
+        } catch (e) { Toast.error(e.message); }
+        finally { busy = false; renderBody(); }
+    }
+
+    async function enableController() {
+        busy = true; renderBody();
+        try {
+            const r = await API.post(
+                `/api/mihomo/configs/${encodeURIComponent(configName)}/enable-controller`);
+            if (r && r.ok) {
+                if (r.needs_restart) {
+                    Toast.success(`external-controller добавлен (порт ${r.port}). Перезапустите конфиг, чтобы заработало.`);
+                } else {
+                    Toast.success(`external-controller добавлен (порт ${r.port}).`);
+                }
+                await loadProxies();
+            } else {
+                Toast.error((r && r.error) || 'не удалось включить');
+            }
+        } catch (e) { Toast.error(e.message); }
+        finally { busy = false; renderBody(); }
+    }
+
+    // ══════════════ debug / log ══════════════
+
+    async function toggleDebug(on) {
+        try {
+            const r = await API.post('/api/mihomo/debug', { enabled: on });
+            if (r && r.ok) {
+                debugEnabled = !!r.enabled;
+                Toast.success(`Режим отладки ${debugEnabled ? 'включён' : 'выключен'} — применится при перезапуске инстанса`);
+            } else {
+                Toast.error((r && r.error) || 'не удалось');
+            }
+        } catch (e) { Toast.error(e.message); }
+        finally { renderBody(); }
+    }
+
+    async function toggleLog() {
+        if (logText !== null) { logText = null; renderBody(); return; }
+        if (!configName) { Toast.error('Сначала выберите конфиг'); return; }
+        try {
+            const r = await API.get(
+                `/api/mihomo/configs/${encodeURIComponent(configName)}/log?lines=200`);
+            if (r && r.ok) {
+                logText = r.exists ? (r.log || '(пусто)') : '(лог ещё не создан — запустите конфиг)';
+            } else {
+                logText = (r && r.error) || '(ошибка чтения лога)';
+            }
+        } catch (e) { logText = e.message; }
+        renderBody();
+    }
+
+    // ══════════════ hotkeys / clipboard ══════════════
+
+    function isEditable(el) {
+        if (!el) return false;
+        const tag = (el.tagName || '').toLowerCase();
+        return tag === 'input' || tag === 'textarea' || tag === 'select'
+               || el.isContentEditable;
+    }
+
+    function attachGlobalHandlers() {
+        keyHandler = (e) => {
+            if (isEditable(e.target)) return;
+            const mod = e.ctrlKey || e.metaKey;
+            if (mod && (e.key === 'c' || e.key === 'C')) {
+                if (selected.size) { e.preventDefault(); copySelected(); }
+            } else if (mod && (e.key === 'a' || e.key === 'A')) {
+                if (proxies.length) { e.preventDefault(); toggleAll(true); }
+            } else if (e.key === 'Delete') {
+                if (selected.size) { e.preventDefault(); deleteSelected(); }
+            }
+        };
+        pasteHandler = (e) => {
+            if (isEditable(e.target)) return;
+            const text = (e.clipboardData || window.clipboardData)?.getData('text') || '';
+            if (text && /(vless|vmess|trojan|ss|hysteria2|hy2|tuic):\/\//i.test(text)) {
+                e.preventDefault();
+                importText(text);
+            }
+        };
+        document.addEventListener('keydown', keyHandler);
+        document.addEventListener('paste', pasteHandler);
+    }
+
+    function detachGlobalHandlers() {
+        if (keyHandler) document.removeEventListener('keydown', keyHandler);
+        if (pasteHandler) document.removeEventListener('paste', pasteHandler);
+        keyHandler = pasteHandler = null;
+    }
+
+    async function copyText(text) {
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(text);
+                return true;
+            }
+        } catch (_) { /* fallback ниже */ }
+        try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.focus(); ta.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            return ok;
+        } catch (_) { return false; }
+    }
+
+    // ══════════════ helpers ══════════════
+
+    function humanBytes(n) {
+        n = Number(n) || 0;
+        if (n < 1024) return n + ' B';
+        const u = ['KB', 'MB', 'GB', 'TB']; let i = -1;
+        do { n /= 1024; i++; } while (n >= 1024 && i < u.length - 1);
+        return (n < 10 ? n.toFixed(2) : n.toFixed(1)) + ' ' + u[i];
+    }
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+    function escapeAttr(s) {
+        return escapeHtml(s).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    return {
+        render, destroy, refreshAll, switchConfig, setTarget,
+        sortBy, onRowClick, toggleRow, toggleAll,
+        test, copySelected, togglePasteBox, importPasteBox,
+        deleteSelected, activate, activateSelected, activateIdx,
+        enableController, toggleDebug, toggleLog,
+    };
+})();


### PR DESCRIPTION
Задача №2 из NEXT-SESSION-ROADMAP: сделать таблицу прокси mihomo как в singbox_proxies.js + тест прокси + режим отладки, чтобы прокси правились без сырого YAML.

Фронтенд:
- web/js/pages/mihomo_proxies.js — таблица (имя/тип/адрес/задержка/трафик), мультивыбор (клик/Ctrl/Shift/чекбоксы), сортировка, тест всех/выделенных, copy/paste share-ссылок (Ctrl+C/Ctrl+V), активация выбранного, учёт трафика, чекбокс режима отладки и просмотр лога инстанса.
- sidebar.js: mihomo → «Прокси»; регистрация в app.js и index.html.

Бэкенд (api/mihomo.py):
- GET /configs/<n>/proxies, POST /activate, /enable-controller, /proxies/delete-bulk, /import-links, /export-links, /test, /test/status, /traffic, GET/POST /debug, GET /configs/<n>/log.

core:
- mihomo_proxies.py — разбор секции proxies, RESTful Clash API (список групп/активный/живое переключение), текстовые правки (дозапись прокси, включение external-controller) и round-trip удаление через PyYAML с честным отказом при его отсутствии.
- mihomo_proxy_tester.py — TCP-отсев + e2e-замер задержки через external-controller запущенного инстанса либо одноразовый mihomo (батчами), graceful degrade до TCP, как у sing-box.
- proxy_traffic.py — TrafficTracker обобщён (targets/state-path), добавлен get_mihomo_traffic_tracker (external-controller mihomo).
- clash_yaml.py — YAML-эмиттер (dump_yaml/dump_seq) и конвертеры clash-proxy ↔ share-URI (переиспользуют sing-box парсеры).
- mihomo_manager.py — режим отладки (log-level=debug в launch-конфиге, не трогая YAML пользователя), хвост лога, скрытие служебных dotfile'ов.

Тесты: tests/test_mihomo_proxies.py (эмиттер/round-trip, clash↔URI, чтение/мутации, тестер TCP-degrade, debug/log менеджера). Не требуют bottle/pyyaml.