### PR TITLE
AWG watchdog: ловить зависание «приём встал» и стартовать автономно

### DIFF
--- a/api/awg.py
+++ b/api/awg.py
@@ -545,7 +545,8 @@ def register(app):
         """
         Изменить настройки. Передавать любое подмножество полей:
           enabled, handshake_timeout_sec, check_interval_sec,
-          cooldown_sec, max_restarts_per_hour.
+          cooldown_sec, max_restarts_per_hour, probe_*,
+          rx_stall_enabled, rx_stall_timeout_sec, rx_stall_min_tx_bytes.
         """
         response.content_type = "application/json; charset=utf-8"
         try:
@@ -559,7 +560,9 @@ def register(app):
                 "check_interval_sec", "cooldown_sec",
                 "max_restarts_per_hour",
                 "probe_enabled", "probe_host", "probe_port",
-                "probe_timeout_sec", "probe_fail_threshold") if k in body})
+                "probe_timeout_sec", "probe_fail_threshold",
+                "rx_stall_enabled", "rx_stall_timeout_sec",
+                "rx_stall_min_tx_bytes") if k in body})
             return {"ok": True, "status": get_watchdog().get_status(),
                     "settings": new}
         except Exception as e:

--- a/app.py
+++ b/app.py
@@ -476,6 +476,16 @@ def create_app(config_dir: str = None) -> Bottle:
     except Exception:
         pass
 
+    # AWG-watchdog: автоперезапуск «зависших» туннелей (handshake устарел
+    # ИЛИ приём встал). Поднимаем при старте GUI, чтобы защита работала
+    # автономно после ребута роутера, а не только когда открыта страница
+    # AWG. Ничего не делает, если awg.watchdog.enabled = false (дефолт).
+    try:
+        from core.awg_watchdog import get_watchdog
+        get_watchdog().reconfigure()
+    except Exception as e:
+        log.warning("AWG-watchdog при boot: %s" % e, source="awg")
+
     # Healthcheck-демон (autocircular watchdog): ничего не делает, если
     # cfg.healthcheck.enabled = false (дефолт). Включается через GUI.
     try:

--- a/core/awg_watchdog.py
+++ b/core/awg_watchdog.py
@@ -40,11 +40,30 @@ DEFAULT_MAX_RESTARTS_PER_HOUR = 6     # защита от петли
 # handshake ещё «свежий», но трафик через туннель уже не идёт (сайты
 # тормозят → сеть отваливается; помогает рестарт). Проба делается с
 # привязкой к интерфейсу туннеля (SO_BINDTODEVICE), т.е. реально через него.
+#
+# ВАЖНО: на роутере SO_BINDTODEVICE может молча не сработать (нужен root/
+# capability, особенности musl/uclibc) — тогда проба уйдёт мимо туннеля по
+# обычному WAN и даст ложный «жив». Поэтому она НЕ главный сигнал; основной
+# детектор «данные не идут» — пассивный rx-stall ниже (счётчики самого
+# демона, обойти их нельзя).
 DEFAULT_PROBE_ENABLED       = False
 DEFAULT_PROBE_HOST          = "1.1.1.1"
 DEFAULT_PROBE_PORT          = 443
 DEFAULT_PROBE_TIMEOUT_SEC   = 4
 DEFAULT_PROBE_FAIL_THRESHOLD = 2      # подряд неудач → рестарт
+
+# Пассивный детектор застоя приёма. Туннель ШЛЁТ (tx растёт), но НИЧЕГО не
+# ПРИНИМАЕТ (rx стоит) дольше порога — классическое «92 B in / 20 KB out»:
+# handshake может оставаться свежим (control-plane жив), а данные сервер
+# дропает. Считаем по счётчикам `awg show` (rx_bytes/tx_bytes) — это правда
+# от самого демона, без лишнего трафика и без обхода туннеля. Включён по
+# умолчанию: на простое (tx тоже стоит) не срабатывает, а keepalive-шум
+# отсекается порогом min_tx, поэтому ложных рестартов не даёт.
+DEFAULT_RX_STALL_ENABLED      = True
+DEFAULT_RX_STALL_TIMEOUT_SEC  = 120   # сек без единого принятого байта → рестарт
+DEFAULT_RX_STALL_MIN_TX_BYTES = 4096  # столько надо отправить «в пустоту»,
+                                      # чтобы это считалось застоем, а не
+                                      # тишиной keepalive (~десятки байт/мин)
 
 
 def probe_via_iface(host: str, port: int = 443, iface: str = "",
@@ -78,19 +97,65 @@ def probe_via_iface(host: str, port: int = 443, iface: str = "",
             pass
 
 
+def eval_rx_stall(state, rx_bytes, tx_bytes, now: float, *,
+                  timeout: int, min_tx: int) -> tuple:
+    """
+    Пассивный детектор «приём встал»: туннель ШЛЁТ (tx растёт), но НИЧЕГО
+    не ПРИНИМАЕТ (rx стоит) дольше `timeout`, отправив при этом не меньше
+    `min_tx` байт «в пустоту». Это ровно картина зависания (handshake может
+    быть свежим, а data-пакеты сервер дропает).
+
+    Чистая функция: состояние НЕ хранит, принимает и возвращает его явно
+    (удобно для юнит-тестов). Возвращает (new_state, stalled: bool).
+
+      state — {"rx", "tx_at_rx", "rx_ts"} с прошлого замера или None.
+      now   — текущее время (сек).
+
+    Логика без ложных срабатываний:
+      * первый замер или сброс счётчиков (после рестарта rx/tx обнуляются)
+        — ре-базируемся, решения не принимаем;
+      * любой прирост rx → что-то приняли, туннель жив → сброс отсчёта;
+      * rx стоит → считаем, сколько отправили и сколько ждём С МОМЕНТА
+        последнего приёма; застой = (tx_since >= min_tx) И (age >= timeout).
+        На простое (tx тоже стоит) tx_since=0 < min_tx → не срабатывает;
+        keepalive-шум (десятки байт) ниже min_tx → тоже не срабатывает.
+    """
+    rx = int(rx_bytes or 0)
+    tx = int(tx_bytes or 0)
+    prev_rx = int((state or {}).get("rx", 0))
+    prev_tx_at_rx = int((state or {}).get("tx_at_rx", 0))
+    # Первый замер / сброс счётчиков (rx или tx «откатились» — рестарт демона).
+    if state is None or rx < prev_rx or tx < prev_tx_at_rx:
+        return ({"rx": rx, "tx_at_rx": tx, "rx_ts": now}, False)
+    # Приняли новые байты — туннель жив, перезапускаем отсчёт от текущего tx.
+    if rx > prev_rx:
+        return ({"rx": rx, "tx_at_rx": tx, "rx_ts": now}, False)
+    # rx стоит: сохраняем точку последнего приёма (tx_at_rx/rx_ts), копим.
+    rx_ts = float((state or {}).get("rx_ts", now))
+    new_state = {"rx": rx, "tx_at_rx": prev_tx_at_rx, "rx_ts": rx_ts}
+    tx_since = tx - prev_tx_at_rx
+    age = now - rx_ts
+    stalled = (tx_since >= max(0, min_tx)) and (age >= timeout)
+    return (new_state, stalled)
+
+
 def decide_restart(*, handshake_age, handshake_timeout: int,
                    probe_enabled: bool, probe_consecutive_fails: int,
-                   probe_threshold: int) -> tuple:
+                   probe_threshold: int, rx_stalled: bool = False) -> tuple:
     """
     Чистое решение «рестартить ли туннель». Возвращает (bool, reason).
 
       handshake_age — секунд с последнего handshake (или None, если его
                       ещё не было / нет peer'ов);
-      probe_* — активная проба через туннель.
+      probe_*    — активная проба через туннель (опц., может обходить туннель);
+      rx_stalled — пассивный детектор «приём встал» (главный сигнал «данные
+                   не идут», см. eval_rx_stall).
     """
     if probe_enabled and probe_consecutive_fails >= max(1, probe_threshold):
         return (True, "проба через туннель не прошла %d раз подряд"
                 % probe_consecutive_fails)
+    if rx_stalled:
+        return (True, "туннель шлёт, но не принимает (данные не идут)")
     if handshake_age is not None and handshake_age >= handshake_timeout:
         return (True, "handshake %dс назад (>%dс)"
                 % (handshake_age, handshake_timeout))
@@ -136,6 +201,12 @@ def _get_settings() -> dict:
             "probe_timeout_sec", DEFAULT_PROBE_TIMEOUT_SEC)),
         "probe_fail_threshold":     int(wd.get(
             "probe_fail_threshold", DEFAULT_PROBE_FAIL_THRESHOLD)),
+        "rx_stall_enabled":         bool(wd.get(
+            "rx_stall_enabled", DEFAULT_RX_STALL_ENABLED)),
+        "rx_stall_timeout_sec":     int(wd.get(
+            "rx_stall_timeout_sec", DEFAULT_RX_STALL_TIMEOUT_SEC)),
+        "rx_stall_min_tx_bytes":    int(wd.get(
+            "rx_stall_min_tx_bytes", DEFAULT_RX_STALL_MIN_TX_BYTES)),
     }
 
 
@@ -173,6 +244,8 @@ class AwgWatchdog:
         self._last_restart = {}
         # Счётчик подряд-неудачных проб: {iface: int}
         self._probe_fails  = {}
+        # Состояние пассивного rx-stall детектора: {iface: {rx, tx_at_rx, rx_ts}}
+        self._rx_state     = {}
 
     # ─── lifecycle ───
 
@@ -260,15 +333,35 @@ class AwgWatchdog:
             return
 
         # Возраст самого свежего handshake по peer'ам (None — если ещё
-        # не было / нет peer'ов: на первом подъёме не нервничаем).
+        # не было / нет peer'ов: на первом подъёме не нервничаем). Заодно
+        # копим суммарные счётчики rx/tx для пассивного детектора застоя.
         peers = status.get("peers") or []
         latest = 0
+        rx_total = 0
+        tx_total = 0
         for p in peers:
             try:
                 latest = max(latest, int(p.get("latest_handshake") or 0))
             except (TypeError, ValueError):
-                continue
+                pass
+            try:
+                rx_total += int(p.get("rx_bytes") or 0)
+                tx_total += int(p.get("tx_bytes") or 0)
+            except (TypeError, ValueError):
+                pass
         age = (int(now) - latest) if latest > 0 else None
+
+        # Пассивный детектор «приём встал» (главный сигнал «данные не идут»;
+        # ловит зависание даже при свежем handshake, без лишнего трафика).
+        rx_stalled = False
+        if settings.get("rx_stall_enabled", DEFAULT_RX_STALL_ENABLED) and peers:
+            new_rx_state, rx_stalled = eval_rx_stall(
+                self._rx_state.get(iface), rx_total, tx_total, now,
+                timeout=settings.get("rx_stall_timeout_sec",
+                                     DEFAULT_RX_STALL_TIMEOUT_SEC),
+                min_tx=settings.get("rx_stall_min_tx_bytes",
+                                    DEFAULT_RX_STALL_MIN_TX_BYTES))
+            self._rx_state[iface] = new_rx_state
 
         # Активная проба через туннель (если включена).
         probe_enabled = bool(settings.get("probe_enabled", False))
@@ -287,7 +380,8 @@ class AwgWatchdog:
             probe_enabled=probe_enabled,
             probe_consecutive_fails=probe_fails,
             probe_threshold=settings.get("probe_fail_threshold",
-                                         DEFAULT_PROBE_FAIL_THRESHOLD))
+                                         DEFAULT_PROBE_FAIL_THRESHOLD),
+            rx_stalled=rx_stalled)
         if not should:
             return
 
@@ -314,6 +408,9 @@ class AwgWatchdog:
             return
         self._last_restart[iface] = now
         self._probe_fails[iface] = 0
+        # После рестарта счётчики обнулятся — забываем прошлый rx-snapshot,
+        # чтобы следующий тик ре-базировался, а не считал «откат» застоем.
+        self._rx_state.pop(iface, None)
         history.append(now)
 
     # ─── status (для UI) ───

--- a/tests/test_awg_watchdog.py
+++ b/tests/test_awg_watchdog.py
@@ -201,3 +201,169 @@ class TestProbeSettings(unittest.TestCase):
         self.assertEqual(s["probe_enabled"], False)
         self.assertIn("probe_host", s)
         self.assertIn("probe_fail_threshold", s)
+
+
+class TestRxStallSettings(unittest.TestCase):
+
+    def test_rx_stall_defaults(self):
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=FakeConfigManager({})):
+            s = awg_watchdog._get_settings()
+        # rx-stall детектор включён по умолчанию — это главный сигнал.
+        self.assertTrue(s["rx_stall_enabled"])
+        self.assertEqual(s["rx_stall_timeout_sec"],
+                         awg_watchdog.DEFAULT_RX_STALL_TIMEOUT_SEC)
+        self.assertEqual(s["rx_stall_min_tx_bytes"],
+                         awg_watchdog.DEFAULT_RX_STALL_MIN_TX_BYTES)
+
+
+class TestEvalRxStall(unittest.TestCase):
+    """Пассивный детектор «приём встал» (чистая функция)."""
+
+    def _eval(self, state, rx, tx, now, timeout=120, min_tx=4096):
+        return awg_watchdog.eval_rx_stall(
+            state, rx, tx, now, timeout=timeout, min_tx=min_tx)
+
+    def test_first_sample_rebaselines(self):
+        state, stalled = self._eval(None, 1000, 2000, now=100.0)
+        self.assertFalse(stalled)
+        self.assertEqual(state["rx"], 1000)
+        self.assertEqual(state["tx_at_rx"], 2000)
+        self.assertEqual(state["rx_ts"], 100.0)
+
+    def test_rx_progress_resets(self):
+        prev = {"rx": 1000, "tx_at_rx": 2000, "rx_ts": 0.0}
+        # rx вырос → приняли данные → не застой, отсчёт от текущего tx/now.
+        state, stalled = self._eval(prev, 1500, 9000, now=300.0)
+        self.assertFalse(stalled)
+        self.assertEqual(state["rx"], 1500)
+        self.assertEqual(state["tx_at_rx"], 9000)
+        self.assertEqual(state["rx_ts"], 300.0)
+
+    def test_idle_does_not_stall(self):
+        # rx и tx стоят (нет трафика вообще) — это простой, не зависание.
+        prev = {"rx": 1000, "tx_at_rx": 2000, "rx_ts": 0.0}
+        _state, stalled = self._eval(prev, 1000, 2000, now=10_000.0)
+        self.assertFalse(stalled)
+
+    def test_keepalive_noise_does_not_stall(self):
+        # rx стоит, но отправлено всего ~300 байт (keepalive) < min_tx=4096.
+        prev = {"rx": 1000, "tx_at_rx": 2000, "rx_ts": 0.0}
+        _state, stalled = self._eval(prev, 1000, 2300, now=10_000.0)
+        self.assertFalse(stalled)
+
+    def test_stall_fires_when_sending_but_silent(self):
+        # rx стоит, отправлено > min_tx, прошло > timeout → застой.
+        prev = {"rx": 1000, "tx_at_rx": 2000, "rx_ts": 0.0}
+        _state, stalled = self._eval(prev, 1000, 2000 + 5000, now=200.0,
+                                     timeout=120, min_tx=4096)
+        self.assertTrue(stalled)
+
+    def test_no_stall_before_timeout(self):
+        # Отправили много, но времени с последнего приёма мало.
+        prev = {"rx": 1000, "tx_at_rx": 2000, "rx_ts": 100.0}
+        _state, stalled = self._eval(prev, 1000, 2000 + 50_000, now=150.0,
+                                     timeout=120, min_tx=4096)
+        self.assertFalse(stalled)
+
+    def test_counter_reset_rebaselines(self):
+        # После рестарта демона счётчики обнулились (rx/tx меньше прежних) —
+        # не считаем это застоем, ре-базируемся.
+        prev = {"rx": 50_000, "tx_at_rx": 80_000, "rx_ts": 0.0}
+        state, stalled = self._eval(prev, 100, 200, now=9999.0)
+        self.assertFalse(stalled)
+        self.assertEqual(state["rx"], 100)
+        self.assertEqual(state["tx_at_rx"], 200)
+        self.assertEqual(state["rx_ts"], 9999.0)
+
+    def test_stall_accumulates_across_flat_ticks(self):
+        # Несколько тиков подряд rx стоит — момент последнего приёма
+        # (rx_ts/tx_at_rx) сохраняется, возраст копится до срабатывания.
+        prev = {"rx": 1000, "tx_at_rx": 2000, "rx_ts": 1000.0}
+        s1, st1 = self._eval(prev, 1000, 4000, now=1030.0)   # +30с
+        self.assertFalse(st1)
+        self.assertEqual(s1["rx_ts"], 1000.0)        # точка приёма не сдвинулась
+        self.assertEqual(s1["tx_at_rx"], 2000)
+        s2, st2 = self._eval(s1, 1000, 8000, now=1130.0)     # +130с, tx>min
+        self.assertTrue(st2)
+
+
+class TestDecideRestartRxStall(unittest.TestCase):
+
+    def test_rx_stall_restarts_with_fresh_handshake(self):
+        should, reason = awg_watchdog.decide_restart(
+            handshake_age=5, handshake_timeout=180,
+            probe_enabled=False, probe_consecutive_fails=0, probe_threshold=2,
+            rx_stalled=True)
+        self.assertTrue(should)
+        self.assertIn("не принимает", reason)
+
+    def test_rx_stall_false_holds(self):
+        should, _ = awg_watchdog.decide_restart(
+            handshake_age=5, handshake_timeout=180,
+            probe_enabled=False, probe_consecutive_fails=0, probe_threshold=2,
+            rx_stalled=False)
+        self.assertFalse(should)
+
+    def test_default_rx_stalled_is_false(self):
+        # Обратная совместимость: без kwarg ведёт себя как раньше.
+        should, _ = awg_watchdog.decide_restart(
+            handshake_age=5, handshake_timeout=180,
+            probe_enabled=False, probe_consecutive_fails=0, probe_threshold=2)
+        self.assertFalse(should)
+
+
+class TestMaybeRestartRxStall(unittest.TestCase):
+    """Интеграция rx-stall в _maybe_restart (без фонового потока)."""
+
+    def _settings(self, **over):
+        base = {
+            "handshake_timeout_sec": 180,
+            "check_interval_sec":    30,
+            "cooldown_sec":          300,
+            "max_restarts_per_hour": 6,
+            "enabled": True,
+            "rx_stall_enabled": True,
+            "rx_stall_timeout_sec": 120,
+            "rx_stall_min_tx_bytes": 4096,
+        }
+        base.update(over)
+        return base
+
+    def test_restarts_on_rx_stall_even_if_handshake_fresh(self):
+        wd  = awg_watchdog.AwgWatchdog()
+        mgr = mock.MagicMock()
+        now = time.time()
+        # Затравка: последний приём давно (>timeout назад), tx тогда был 2000.
+        wd._rx_state["awg0"] = {"rx": 1000, "tx_at_rx": 2000,
+                                "rx_ts": now - 200}
+        # handshake свежий (не сработал бы старый триггер), rx стоит,
+        # tx вырос на 5000 (> min_tx) → застой приёма.
+        status = {"peers": [{"latest_handshake": int(now) - 5,
+                             "rx_bytes": 1000, "tx_bytes": 7000}]}
+        wd._maybe_restart(mgr, "awg0", status, self._settings(), now=now)
+        mgr.restart.assert_called_once_with("awg0")
+
+    def test_no_restart_when_rx_progresses(self):
+        wd  = awg_watchdog.AwgWatchdog()
+        mgr = mock.MagicMock()
+        now = time.time()
+        wd._rx_state["awg0"] = {"rx": 1000, "tx_at_rx": 2000,
+                                "rx_ts": now - 200}
+        # rx ВЫРОС (приняли данные) → туннель жив, рестарта нет.
+        status = {"peers": [{"latest_handshake": int(now) - 5,
+                             "rx_bytes": 5000, "tx_bytes": 7000}]}
+        wd._maybe_restart(mgr, "awg0", status, self._settings(), now=now)
+        mgr.restart.assert_not_called()
+
+    def test_rx_stall_disabled_holds(self):
+        wd  = awg_watchdog.AwgWatchdog()
+        mgr = mock.MagicMock()
+        now = time.time()
+        wd._rx_state["awg0"] = {"rx": 1000, "tx_at_rx": 2000,
+                                "rx_ts": now - 200}
+        status = {"peers": [{"latest_handshake": int(now) - 5,
+                             "rx_bytes": 1000, "tx_bytes": 7000}]}
+        wd._maybe_restart(mgr, "awg0", status,
+                          self._settings(rx_stall_enabled=False), now=now)
+        mgr.restart.assert_not_called()

--- a/web/js/pages/awg_dashboard.js
+++ b/web/js/pages/awg_dashboard.js
@@ -775,13 +775,20 @@ const AwgDashboardPage = (() => {
                 <span>Переподключать при плохом соединении</span>
             </label>
             <p class="text-muted" style="font-size:12px; margin:6px 0 0;">
-                Периодически проверяет связь через туннель и автоматически
-                перезапускает его, если соединение деградировало (handshake
-                устарел или проба не проходит). Помогает, когда AmneziaWG
-                «зависает»: сайты тормозят, потом сеть отваливается.
+                Следит за туннелем и автоматически перезапускает его при
+                зависании. Ловит три случая: handshake устарел; туннель
+                <b>шлёт, но не принимает</b> (данные встали, хотя handshake
+                ещё «свежий» — частая причина «сайты тормозят, потом сеть
+                отваливается»); активная проба не проходит. Детектор «приём
+                встал» работает по счётчикам самого демона — без лишнего
+                трафика. Совет: задайте в конфиге PersistentKeepalive&nbsp;=&nbsp;25,
+                чтобы зависание ловилось и в простое.
             </p>
             <div id="wd-advanced" style="margin-top:10px; ${reconnectOn ? '' : 'display:none;'}">
                 <div style="display:grid; grid-template-columns:200px 1fr; gap:6px 12px; max-width:560px; align-items:center;">
+                    <label class="text-muted" style="font-size:12px;">Нет приёма данных, с → рестарт</label>
+                    <input type="number" id="wd-rxstall" class="form-control" style="max-width:100px;"
+                           min="30" max="3600" value="${escapeAttr(s.rx_stall_timeout_sec || 120)}">
                     <label class="text-muted" style="font-size:12px;">Хост для проверки</label>
                     <input type="text" id="wd-probe-host" class="form-control" style="max-width:200px;"
                            value="${escapeAttr(s.probe_host || '1.1.1.1')}">
@@ -804,10 +811,12 @@ const AwgDashboardPage = (() => {
         const host = (document.getElementById('wd-probe-host') || {}).value;
         const thr = (document.getElementById('wd-probe-thr') || {}).value;
         const hs = (document.getElementById('wd-hs') || {}).value;
+        const rx = (document.getElementById('wd-rxstall') || {}).value;
         const payload = { enabled: on, probe_enabled: on };
         if (host) payload.probe_host = String(host).trim();
         if (thr) payload.probe_fail_threshold = parseInt(thr, 10) || 2;
         if (hs) payload.handshake_timeout_sec = parseInt(hs, 10) || 180;
+        if (rx) payload.rx_stall_timeout_sec = parseInt(rx, 10) || 120;
         try {
             const r = await API.post('/api/awg/watchdog', payload);
             if (r && r.ok) {


### PR DESCRIPTION
Туннель раз в несколько часов «подвисает» (данные не идут), и watchdog с включённой галкой это не ловил. Две причины:

1. Единственный боевой триггер — возраст handshake >=180с. Но при зависании handshake часто остаётся свежим (control-plane жив, сервер дропает только data — классика «92 B in / 20 KB out»). Активная проба, которая это ловила бы, по умолчанию выключена И может молча уходить мимо туннеля (SO_BINDTODEVICE без root → проба по WAN → ложный «жив»).

2. Watchdog стартовал только из API (когда открыта страница AWG). После ребута роутера защиты не было, пока не зайдёшь в UI.

Что сделано:
- Пассивный детектор «приём встал» (eval_rx_stall): туннель шлёт (tx растёт), но не принимает (rx стоит) дольше порога — рестарт. Считаем по счётчикам самого демона (awg show rx/tx) — обойти нельзя, без лишнего трафика. Включён по умолчанию; на простое и на keepalive-шуме (порог min_tx) не срабатывает. Главный сигнал, не зависит от SO_BINDTODEVICE.
- Watchdog поднимается при старте GUI (app.py), а не только из API.
- Новые настройки rx_stall_* (API + UI: поле «нет приёма данных, с»), уточнён текст карточки + совет про PersistentKeepalive=25.
- Тесты на eval_rx_stall, decide_restart(rx_stalled) и интеграцию.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb