### PR TITLE
sing-box: TUN+DNS по умолчанию для маршрутизации + проверка соединения

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -355,6 +355,77 @@ def _clash_select(ep: dict, selector: str, name: str) -> bool:
         return False
 
 
+def _has_transparent_inbound(cfg: dict) -> bool:
+    """Есть ли уже TUN / tproxy / redirect inbound (их не трогаем)."""
+    for ib in ((cfg or {}).get("inbounds") or []):
+        if isinstance(ib, dict) and ib.get("type") in (
+                "tun", "tproxy", "redirect"):
+            return True
+    return False
+
+
+def _should_auto_route(cfg: dict) -> bool:
+    """
+    Стоит ли автоматически делать конфиг «готовым к маршрутизации»
+    (TUN + DNS): да, если есть хотя бы один пользовательский outbound и
+    ещё нет ни TUN, ни transparent-inbound'ов (их трогать нельзя).
+    """
+    from core.singbox_config import list_user_outbound_tags
+    if not isinstance(cfg, dict) or _has_transparent_inbound(cfg):
+        return False
+    return bool(list_user_outbound_tags(cfg))
+
+
+def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
+                           address=None, mtu=9000, stack="system",
+                           auto_route=False, sniff=True, hijack_dns=True):
+    """
+    Сделать конфиг «готовым к умной маршрутизации» и сохранить:
+      • TUN-inbound (цель для device/domain/cidr-правил «Маршрутизации»);
+      • перехват DNS + локальный резолвер (hijack_dns) — чтобы у устройства,
+        целиком завёрнутого в TUN, резолвились имена (иначе «инета нет», хотя
+        прокси живой);
+      • clash_api (нужен health-watchdog'у и учёту трафика).
+    Формат DNS подбираем под версию движка через `sing-box check`
+    (legacy → typed 1.12+). Без бинаря оставляем legacy (валиден 1.8–1.13).
+    Возвращает save-dict (+ interface_name, dns_format).
+    """
+    import secrets as _secrets
+    from core.singbox_config import (
+        set_tun_inbound, ensure_clash_api, clash_api_endpoint, render_conf)
+    from core.proxy_tester import _free_port
+
+    if clash_api_endpoint(cfg) is None:
+        try:
+            ensure_clash_api(cfg, port=_free_port(),
+                             secret=_secrets.token_hex(8))
+        except Exception:
+            pass
+
+    dns_format = "none"
+    if not hijack_dns:
+        set_tun_inbound(cfg, interface_name=iface, address=address, mtu=mtu,
+                        stack=stack, auto_route=auto_route, sniff=sniff,
+                        hijack_dns=False)
+    else:
+        chosen = None
+        for typed in (False, True):
+            set_tun_inbound(cfg, interface_name=iface, address=address,
+                            mtu=mtu, stack=stack, auto_route=auto_route,
+                            sniff=sniff, hijack_dns=True, typed_dns=typed)
+            chk = mgr.check_text(render_conf(cfg))
+            if chk.get("ok") or chk.get("no_binary"):
+                chosen = "typed" if typed else "legacy"
+                break
+        dns_format = chosen or "typed"
+
+    save = mgr.save_config(name, text=render_conf(cfg))
+    if isinstance(save, dict):
+        save["interface_name"] = iface
+        save["dns_format"] = dns_format
+    return save
+
+
 def _resolve_test_outbounds(body: dict):
     """
     Источник серверов для теста (по приоритету):
@@ -533,8 +604,24 @@ def register(app):
             response.status = 400
             return {"ok": False, "error": "Поле 'name' обязательно"}
         from core.singbox_manager import get_singbox_manager
-        return get_singbox_manager().save_config(
-            name, text=text, parsed=parsed)
+        mgr = get_singbox_manager()
+        save = mgr.save_config(name, text=text, parsed=parsed)
+        if not (isinstance(save, dict) and save.get("ok")):
+            return save
+        # TUN создаём по умолчанию: «обычный» (локальный SOCKS) прокси почти
+        # не нужен — основной сценарий это умная маршрутизация. routing=false
+        # в body отключает. Авто-применяем только если в конфиге есть прокси
+        # и ещё нет TUN/transparent-inbound'ов (см. _should_auto_route).
+        if body.get("routing", True):
+            cfg_resp = mgr.get_config(name)
+            cfg = (cfg_resp.get("parsed") or {}) \
+                if isinstance(cfg_resp, dict) else {}
+            if _should_auto_route(cfg):
+                routed = _apply_singbox_routing(mgr, name, cfg)
+                if isinstance(routed, dict) and routed.get("ok"):
+                    routed["routing_ready"] = True
+                    return routed
+        return save
 
     @app.route("/api/singbox/configs/<name>")
     def singbox_configs_get(name):
@@ -927,6 +1014,21 @@ def register(app):
         res = _modify_outbounds(name, _mut)
         if isinstance(res, dict) and res.get("ok"):
             res.update(report)
+            # После первой вставки прокси делаем конфиг готовым к
+            # маршрутизации (TUN+DNS), если он ещё не настроен.
+            try:
+                from core.singbox_manager import get_singbox_manager
+                mgr = get_singbox_manager()
+                cfg_resp = mgr.get_config(name)
+                cfg = (cfg_resp.get("parsed") or {}) \
+                    if isinstance(cfg_resp, dict) else {}
+                if _should_auto_route(cfg):
+                    routed = _apply_singbox_routing(mgr, name, cfg)
+                    if isinstance(routed, dict) and routed.get("ok"):
+                        res["routing_ready"] = True
+                        res["interface_name"] = routed.get("interface_name")
+            except Exception:
+                pass
         return res
 
     @app.route("/api/singbox/export-links", method="POST")
@@ -1168,7 +1270,6 @@ def register(app):
         except Exception:
             body = {}
         from core.singbox_manager import get_singbox_manager
-        from core.singbox_config import set_tun_inbound, render_conf
         mgr = get_singbox_manager()
         cfg_resp = mgr.get_config(name)
         if not cfg_resp.get("ok"):
@@ -1179,19 +1280,20 @@ def register(app):
         if isinstance(addr, str):
             addr = [a.strip() for a in addr.split(",") if a.strip()]
         iface = (body.get("interface_name") or "singbox-tun").strip()
-        set_tun_inbound(
-            cfg,
-            interface_name=iface,
+        # hijack_dns=True по умолчанию: для маршрутизации устройства целиком
+        # нужен перехват DNS, иначе у него не резолвятся имена.
+        save = _apply_singbox_routing(
+            mgr, name, cfg,
+            iface=iface,
             address=addr or None,
             mtu=int(body.get("mtu") or 9000),
             stack=(body.get("stack") or "system"),
             auto_route=bool(body.get("auto_route", False)),
-            sniff=bool(body.get("sniff", True)))
-        save = mgr.save_config(name, text=render_conf(cfg))
-        if not save.get("ok"):
+            sniff=bool(body.get("sniff", True)),
+            hijack_dns=bool(body.get("hijack_dns", True)))
+        if not (isinstance(save, dict) and save.get("ok")):
             response.status = 500
             return save
-        save["interface_name"] = iface
         return save
 
     @app.route("/api/singbox/transparent/apply", method="POST")
@@ -1456,6 +1558,42 @@ def register(app):
         st = sp.get_refresh_job().status()
         st["ok"] = True
         return st
+
+    # ─────── watchdog (авто-перезапуск при зависании прокси) ────────
+
+    @app.route("/api/singbox/watchdog")
+    def singbox_watchdog_get():
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            from core.singbox_watchdog import get_watchdog
+            return {"ok": True, "status": get_watchdog().get_status()}
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
+    @app.route("/api/singbox/watchdog", method="POST")
+    def singbox_watchdog_set():
+        """
+        Изменить настройки. Любое подмножество полей: enabled,
+        check_interval_sec, cooldown_sec, max_restarts_per_hour,
+        probe_target, probe_timeout_ms, probe_fail_threshold.
+        """
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+        try:
+            from core.singbox_watchdog import set_settings, get_watchdog
+            new = set_settings(**{k: body.get(k) for k in (
+                "enabled", "check_interval_sec", "cooldown_sec",
+                "max_restarts_per_hour", "probe_target",
+                "probe_timeout_ms", "probe_fail_threshold") if k in body})
+            return {"ok": True, "status": get_watchdog().get_status(),
+                    "settings": new}
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
 
     # ─────── proxy tester ──────────────────────────────────────────
 

--- a/app.py
+++ b/app.py
@@ -486,6 +486,15 @@ def create_app(config_dir: str = None) -> Bottle:
     except Exception as e:
         log.warning("AWG-watchdog при boot: %s" % e, source="awg")
 
+    # sing-box watchdog: авто-перезапуск инстанса, если прокси «завис»
+    # (проба через Clash API не проходит). Ничего не делает, если
+    # singbox.watchdog.enabled = false (дефолт).
+    try:
+        from core.singbox_watchdog import get_watchdog as _sb_watchdog
+        _sb_watchdog().reconfigure()
+    except Exception as e:
+        log.warning("sing-box watchdog при boot: %s" % e, source="singbox")
+
     # Healthcheck-демон (autocircular watchdog): ничего не делает, если
     # cfg.healthcheck.enabled = false (дефолт). Включается через GUI.
     try:

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -383,7 +383,8 @@ def make_tun_inbound(*, interface_name: str = "singbox-tun",
 def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
                     address=None, mtu: int = 9000, stack: str = "system",
                     auto_route: bool = False, strict_route: bool = False,
-                    sniff: bool = True, route_to_proxy: bool = True) -> dict:
+                    sniff: bool = True, route_to_proxy: bool = True,
+                    hijack_dns: bool = False, typed_dns: bool = False) -> dict:
     """
     Вставить/заменить TUN-inbound в конфиге (cfg мутируется и
     возвращается). Прежний наш `tun-in` убирается, остальные inbound'ы
@@ -395,6 +396,16 @@ def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
     доменные route-правила Selective routing срабатывали).
     route_to_proxy=True направляет весь попавший в TUN трафик в основной
     прокси-outbound конфига (route.final → selector/первый сервер).
+
+    hijack_dns=True (нужно для маршрутизации УСТРОЙСТВА целиком) — добавляет
+    перехват DNS (`{"protocol":"dns","action":"hijack-dns"}`) и DNS-секцию с
+    локальным резолвером. Без этого у устройства, чей трафик целиком завёрнут
+    в TUN, DNS-запросы (UDP:53) уходят в туннель, но движок их не обрабатывает
+    → имена не резолвятся → «интернета нет», хотя прокси живой. Резолвим через
+    `local` (резолвер роутера): имена открываются, а трафик к полученным IP всё
+    равно идёт в прокси; bootstrap-петли (резолв самого прокси-сервера) нет.
+    Приватные адреса (LAN) пускаем мимо прокси (`ip_is_private → direct`).
+    typed_dns=True — DNS-секция в формате sing-box 1.12+ (иначе legacy).
     """
     existing = [ib for ib in (cfg.get("inbounds") or [])
                 if not (isinstance(ib, dict) and ib.get("tag") == _TUN_TAG)]
@@ -402,12 +413,73 @@ def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
         interface_name=interface_name, address=address, mtu=mtu,
         stack=stack, auto_route=auto_route, strict_route=strict_route)
     cfg["inbounds"] = [tun] + existing
-    _set_managed_route_rules(cfg, sniff=sniff, hijack_dns=False)
+    _set_managed_route_rules(cfg, sniff=(sniff or hijack_dns),
+                             hijack_dns=hijack_dns)
     if route_to_proxy:
         proxy = pick_proxy_outbound(cfg)
         if proxy:
             cfg.setdefault("route", {})["final"] = proxy
+    if hijack_dns:
+        # Локальный резолвер для перехваченного DNS (fakeip=False → только
+        # direct-сервер, см. make_fakeip_dns). LAN — мимо прокси.
+        cfg["dns"] = make_fakeip_dns(proxied_domains=None, direct_dns="local",
+                                     typed=typed_dns, fakeip=False)
+        _ensure_private_direct_rule(cfg)
     return cfg
+
+
+def _ensure_private_direct_rule(cfg: dict) -> None:
+    """
+    Гарантировать правило «приватные адреса (LAN/loopback) → direct» и
+    наличие самого `direct`-outbound'а. Чтобы устройство, целиком
+    завёрнутое в TUN, ходило в локальную сеть (роутер, принтеры, NAS)
+    напрямую, а не через прокси. Правило ставится после служебных
+    (sniff/hijack-dns), но перед доменными/final.
+    """
+    outs = cfg.setdefault("outbounds", [])
+    if not any(isinstance(o, dict) and o.get("type") == "direct" for o in outs):
+        outs.append({"type": "direct", "tag": "direct"})
+    direct_tag = next((o.get("tag") for o in outs if isinstance(o, dict)
+                       and o.get("type") == "direct"), "direct")
+    rule = {"ip_is_private": True, "outbound": direct_tag}
+    route = cfg.setdefault("route", {})
+    rules = route.setdefault("rules", [])
+    if not isinstance(rules, list):
+        rules = []
+        route["rules"] = rules
+    if rule in rules:
+        return
+    # Вставляем сразу после блока служебных правил (sniff/hijack-dns),
+    # которые _set_managed_route_rules держит в начале.
+    insert_at = 0
+    for i, r in enumerate(rules):
+        if isinstance(r, dict) and r.get("action") in ("sniff", "hijack-dns"):
+            insert_at = i + 1
+    rules.insert(insert_at, rule)
+
+
+def active_outbound_tag(cfg: dict) -> str:
+    """
+    Тег «активного» outbound'а, через который реально ходит трафик —
+    цель для health-пробы watchdog'а:
+      1) selector → его `default` (или первый член, или сам тег группы);
+      2) иначе route.final, если это пользовательский outbound;
+      3) иначе первый пользовательский outbound.
+    '' если не нашли.
+    """
+    if not isinstance(cfg, dict):
+        return ""
+    outs = [o for o in (cfg.get("outbounds") or []) if isinstance(o, dict)]
+    sel = next((o for o in outs if o.get("type") == "selector"), None)
+    if sel is not None:
+        members = sel.get("outbounds") or []
+        return (sel.get("default") or (members[0] if members else "")
+                or sel.get("tag") or "")
+    user_tags = list_user_outbound_tags(cfg)
+    final = ((cfg.get("route") or {}).get("final") or "")
+    if final and final in user_tags:
+        return final
+    return user_tags[0] if user_tags else ""
 
 
 def build_geo_route_rule(outbound_tag: str, *, domains=None,

--- a/core/singbox_watchdog.py
+++ b/core/singbox_watchdog.py
@@ -1,0 +1,298 @@
+# core/singbox_watchdog.py
+"""
+Watchdog для sing-box: автоматически перезапускает инстанс, если прокси
+«завис» — соединение через него перестало проходить (сайты тормозят, потом
+отваливаются), хотя процесс ещё жив.
+
+Аналог core/awg_watchdog.py, но критерий другой. У AWG сигнал — handshake/
+счётчики rx; у sing-box есть Clash API (`experimental.clash_api`), через
+который можно честно проверить связь:
+
+    GET /proxies/<tag>/delay?url=<target>&timeout=<ms>
+
+— движок РЕАЛЬНО открывает соединение к облаку (Cloudflare) ЧЕРЕЗ активный
+outbound и возвращает задержку. Это нельзя «обойти» (в отличие от
+SO_BINDTODEVICE-пробы у AWG): если прокси не работает — проба не пройдёт.
+Заодно ловит и зависший движок: если сам Clash API не отвечает, проба тоже
+падает → рестарт.
+
+Watchdog опциональный, по умолчанию выключен. Включается через settings.json
+(`singbox.watchdog.enabled`) или API. Следим только за ЗАПУЩЕННЫМИ конфигами,
+у которых настроен clash_api (наш routing-флоу добавляет его автоматически).
+"""
+
+import threading
+import time
+import urllib.error
+import urllib.request
+
+from core.log_buffer import log
+
+
+# ─────── defaults ───────
+
+DEFAULT_ENABLED              = False
+DEFAULT_CHECK_INTERVAL_SEC   = 60     # частота проверки
+DEFAULT_COOLDOWN_SEC         = 300    # пауза после рестарта — не дёргать снова
+DEFAULT_MAX_RESTARTS_PER_HOUR = 6     # защита от петли
+DEFAULT_PROBE_TARGET         = "cloudflare"   # пресет proxy_tester / URL
+DEFAULT_PROBE_TIMEOUT_MS     = 5000   # таймаут одного delay-замера
+DEFAULT_PROBE_FAIL_THRESHOLD = 2      # подряд неудач → рестарт
+
+
+# ─────── probe ───────
+
+def probe_outbound(ep: dict, tag: str, target_url: str,
+                   timeout_ms: int) -> bool:
+    """
+    Проверить связь через outbound `tag` Clash API'ем `ep`
+    ({host,port,secret}). True — задержка получена (облако открылось через
+    прокси). Падение Clash API (движок завис) тоже → False.
+    """
+    from core.proxy_tester import parse_delay
+    if not ep or not tag:
+        return False
+    q = urllib.request.quote(target_url, safe="")
+    path = "/proxies/%s/delay?timeout=%d&url=%s" % (
+        urllib.request.quote(tag, safe=""), int(timeout_ms), q)
+    url = "http://%s:%d%s" % (ep.get("host") or "127.0.0.1",
+                              int(ep["port"]), path)
+    headers = {}
+    if ep.get("secret"):
+        headers["Authorization"] = "Bearer %s" % ep["secret"]
+    req = urllib.request.Request(url, headers=headers)
+    http_to = (int(timeout_ms) / 1000.0) + 3.0
+    try:
+        with urllib.request.urlopen(req, timeout=http_to) as r:
+            return parse_delay(r.getcode(),
+                               r.read().decode("utf-8", "replace")).get("ok")
+    except urllib.error.HTTPError as e:
+        try:
+            body = e.read().decode("utf-8", "replace")
+        except Exception:
+            body = ""
+        return parse_delay(e.code, body).get("ok", False)
+    except (urllib.error.URLError, OSError, TimeoutError, ValueError):
+        return False
+
+
+def decide_restart(*, probe_fails: int, probe_threshold: int) -> tuple:
+    """
+    Чистое решение «рестартить ли инстанс». Возвращает (bool, reason).
+    Рестарт, если проба через прокси не прошла `probe_threshold` раз подряд.
+    """
+    if probe_fails >= max(1, probe_threshold):
+        return (True, "проба через прокси не прошла %d раз подряд"
+                % probe_fails)
+    return (False, "")
+
+
+# ─────── settings ───────
+
+def _get_settings() -> dict:
+    """Настройки watchdog'а из settings.json (`singbox.watchdog`)."""
+    try:
+        from core.config_manager import get_config_manager
+        cfg = get_config_manager().load()
+    except Exception:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        cfg = {}
+    sb = cfg.get("singbox") or {}
+    wd = sb.get("watchdog") or {}
+    if not isinstance(wd, dict):
+        wd = {}
+    return {
+        "enabled":              bool(wd.get("enabled", DEFAULT_ENABLED)),
+        "check_interval_sec":   int(wd.get(
+            "check_interval_sec", DEFAULT_CHECK_INTERVAL_SEC)),
+        "cooldown_sec":         int(wd.get(
+            "cooldown_sec", DEFAULT_COOLDOWN_SEC)),
+        "max_restarts_per_hour": int(wd.get(
+            "max_restarts_per_hour", DEFAULT_MAX_RESTARTS_PER_HOUR)),
+        "probe_target":         str(wd.get(
+            "probe_target", DEFAULT_PROBE_TARGET) or DEFAULT_PROBE_TARGET),
+        "probe_timeout_ms":     int(wd.get(
+            "probe_timeout_ms", DEFAULT_PROBE_TIMEOUT_MS)),
+        "probe_fail_threshold": int(wd.get(
+            "probe_fail_threshold", DEFAULT_PROBE_FAIL_THRESHOLD)),
+    }
+
+
+def set_settings(**kwargs) -> dict:
+    """Обновить настройки watchdog'а (персистентно). Возвращает актуальные."""
+    try:
+        from core.config_manager import get_config_manager
+        cm = get_config_manager()
+        for k, v in kwargs.items():
+            if v is None:
+                continue
+            cm.set("singbox", "watchdog", k, v)
+        cm.save()
+    except Exception as e:
+        log.warning("singbox_watchdog: save settings: %s" % e,
+                    source="singbox")
+    get_watchdog().reconfigure()
+    return _get_settings()
+
+
+# ─────── watchdog ───────
+
+class SingboxWatchdog:
+    """Фоновой watchdog по health-пробе через Clash API."""
+
+    def __init__(self):
+        self._lock     = threading.Lock()
+        self._thread   = None
+        self._stop_evt = threading.Event()
+        self._restart_log  = {}   # {name: [ts, ...]} за последний час
+        self._last_restart = {}   # {name: ts}
+        self._probe_fails  = {}   # {name: int}
+
+    # ─── lifecycle ───
+
+    def reconfigure(self):
+        if _get_settings()["enabled"]:
+            self._start()
+        else:
+            self._stop()
+
+    def _start(self):
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_evt.clear()
+            t = threading.Thread(target=self._run_loop,
+                                 name="singbox-watchdog", daemon=True)
+            t.start()
+            self._thread = t
+            log.info("singbox-watchdog: запущен", source="singbox")
+
+    def _stop(self):
+        with self._lock:
+            if self._thread is None:
+                return
+            self._stop_evt.set()
+            self._thread = None
+            log.info("singbox-watchdog: остановлен", source="singbox")
+
+    # ─── main loop ───
+
+    def _run_loop(self):
+        while not self._stop_evt.wait(_get_settings()["check_interval_sec"]):
+            try:
+                self._tick()
+            except Exception as e:
+                log.warning("singbox-watchdog tick: %s" % e, source="singbox")
+
+    def _tick(self):
+        settings = _get_settings()
+        if not settings["enabled"]:
+            self._stop()
+            return
+        try:
+            from core.singbox_manager import get_singbox_manager
+            mgr = get_singbox_manager()
+            configs = mgr.list_configs()
+        except Exception as e:
+            log.warning("singbox-watchdog: список конфигов: %s" % e,
+                        source="singbox")
+            return
+
+        now = time.time()
+        for entry in configs:
+            name = (entry or {}).get("name", "")
+            if not name:
+                continue
+            try:
+                if not mgr.is_running(name):
+                    self._probe_fails.pop(name, None)
+                    continue
+                self._maybe_restart(mgr, name, settings, now)
+            except Exception as e:
+                log.warning("singbox-watchdog: %s: %s" % (name, e),
+                            source="singbox")
+
+    def _maybe_restart(self, mgr, name: str, settings: dict, now: float):
+        # Cooldown — даём прокси установиться после рестарта.
+        if (now - self._last_restart.get(name, 0)) < settings["cooldown_sec"]:
+            return
+
+        from core.singbox_config import (
+            clash_api_endpoint, active_outbound_tag)
+        from core.proxy_tester import resolve_target
+        cfg_resp = mgr.get_config(name)
+        cfg = (cfg_resp.get("parsed") or {}) \
+            if isinstance(cfg_resp, dict) else {}
+        ep = clash_api_endpoint(cfg)
+        tag = active_outbound_tag(cfg)
+        if not ep or not tag:
+            # Нечем проверять (нет clash_api) — не вмешиваемся.
+            return
+
+        ok = probe_outbound(ep, tag, resolve_target(settings["probe_target"]),
+                            settings["probe_timeout_ms"])
+        fails = 0 if ok else self._probe_fails.get(name, 0) + 1
+        self._probe_fails[name] = fails
+
+        should, reason = decide_restart(
+            probe_fails=fails,
+            probe_threshold=settings["probe_fail_threshold"])
+        if not should:
+            return
+
+        # Rate limit.
+        history = self._restart_log.setdefault(name, [])
+        history[:] = [ts for ts in history if (now - ts) < 3600]
+        if len(history) >= settings["max_restarts_per_hour"]:
+            log.warning(
+                "singbox-watchdog: %s — %s, но лимит рестартов исчерпан"
+                " (%d/час). Прокси нездоров — смените сервер/подписку."
+                % (name, reason, settings["max_restarts_per_hour"]),
+                source="singbox")
+            return
+
+        log.warning("singbox-watchdog: %s — %s; рестартую" % (name, reason),
+                    source="singbox")
+        try:
+            mgr.restart(name)
+        except Exception as e:
+            log.warning("singbox-watchdog: restart %s: %s" % (name, e),
+                        source="singbox")
+            return
+        self._last_restart[name] = now
+        self._probe_fails[name] = 0
+        history.append(now)
+
+    # ─── status (для UI) ───
+
+    def get_status(self) -> dict:
+        settings = _get_settings()
+        with self._lock:
+            running = (self._thread is not None and self._thread.is_alive())
+            history_view = {
+                k: len([ts for ts in v if (time.time() - ts) < 3600])
+                for k, v in self._restart_log.items()
+            }
+        return {
+            "enabled":  settings["enabled"],
+            "running":  running,
+            "settings": settings,
+            "restarts_last_hour": history_view,
+        }
+
+
+# ─────── singleton ───────
+
+_watchdog = None
+_watchdog_lock = threading.Lock()
+
+
+def get_watchdog() -> SingboxWatchdog:
+    global _watchdog
+    if _watchdog is None:
+        with _watchdog_lock:
+            if _watchdog is None:
+                _watchdog = SingboxWatchdog()
+                _watchdog.reconfigure()
+    return _watchdog

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -14,7 +14,7 @@ from core import singbox_transparent as tp
 from core.singbox_config import (
     make_transparent_inbounds, set_transparent_inbounds, make_sniff_rule,
     make_hijack_dns_rule, make_tun_inbound, set_tun_inbound,
-    find_tun_interface,
+    find_tun_interface, active_outbound_tag,
 )
 
 
@@ -314,6 +314,87 @@ class TestTunInbound(unittest.TestCase):
         tun = [ib for ib in cfg["inbounds"] if ib["tag"] == "tun-in"]
         self.assertEqual(len(tun), 1)                     # заменён, не дубль
         self.assertEqual(tun[0]["interface_name"], "t1")
+
+    def test_no_dns_section_without_hijack(self):
+        # По умолчанию (hijack_dns=False) DNS-секцию НЕ добавляем —
+        # совместимость со старым поведением.
+        cfg = self._cfg()
+        set_tun_inbound(cfg)
+        self.assertNotIn("dns", cfg)
+        self.assertNotIn(make_hijack_dns_rule(), cfg["route"]["rules"])
+
+    def test_hijack_dns_adds_dns_and_rules(self):
+        # hijack_dns=True (маршрутизация устройства целиком) — перехват DNS,
+        # DNS-секция с резолвером, и LAN мимо прокси.
+        cfg = self._cfg()
+        set_tun_inbound(cfg, hijack_dns=True)
+        self.assertIn("dns", cfg)
+        self.assertTrue(cfg["dns"].get("servers"))
+        rules = cfg["route"]["rules"]
+        self.assertIn(make_hijack_dns_rule(), rules)
+        self.assertIn(make_sniff_rule(), rules)
+        # ip_is_private → direct присутствует
+        self.assertTrue(any(
+            isinstance(r, dict) and r.get("ip_is_private")
+            and r.get("outbound") == "direct" for r in rules))
+        # есть direct-outbound для этого правила
+        self.assertTrue(any(
+            o.get("type") == "direct" for o in cfg["outbounds"]))
+
+    def test_hijack_dns_idempotent(self):
+        cfg = self._cfg()
+        set_tun_inbound(cfg, hijack_dns=True)
+        set_tun_inbound(cfg, hijack_dns=True)
+        rules = cfg["route"]["rules"]
+        # ровно один sniff, один hijack-dns, одно ip_is_private-правило
+        self.assertEqual(sum(1 for r in rules if r == make_sniff_rule()), 1)
+        self.assertEqual(
+            sum(1 for r in rules if r == make_hijack_dns_rule()), 1)
+        self.assertEqual(sum(
+            1 for r in rules if isinstance(r, dict)
+            and r.get("ip_is_private")), 1)
+        self.assertEqual(
+            sum(1 for o in cfg["outbounds"] if o.get("type") == "direct"), 1)
+
+    def test_hijack_dns_typed_format(self):
+        cfg = self._cfg()
+        set_tun_inbound(cfg, hijack_dns=True, typed_dns=True)
+        servers = cfg["dns"]["servers"]
+        # typed-формат: у серверов есть поле type
+        self.assertTrue(all("type" in s for s in servers))
+
+
+class TestActiveOutboundTag(unittest.TestCase):
+
+    def test_selector_default(self):
+        cfg = {"outbounds": [
+            {"type": "vless", "tag": "s1"}, {"type": "vless", "tag": "s2"},
+            {"type": "selector", "tag": "PROXY",
+             "outbounds": ["s1", "s2"], "default": "s2"}]}
+        self.assertEqual(active_outbound_tag(cfg), "s2")
+
+    def test_selector_first_member_when_no_default(self):
+        cfg = {"outbounds": [
+            {"type": "vless", "tag": "s1"},
+            {"type": "selector", "tag": "PROXY", "outbounds": ["s1"]}]}
+        self.assertEqual(active_outbound_tag(cfg), "s1")
+
+    def test_route_final_when_no_selector(self):
+        cfg = {"outbounds": [
+            {"type": "vless", "tag": "a"}, {"type": "vless", "tag": "b"},
+            {"type": "direct", "tag": "direct"}],
+            "route": {"final": "b"}}
+        self.assertEqual(active_outbound_tag(cfg), "b")
+
+    def test_first_user_outbound_fallback(self):
+        cfg = {"outbounds": [
+            {"type": "direct", "tag": "direct"},
+            {"type": "trojan", "tag": "t1"}]}
+        self.assertEqual(active_outbound_tag(cfg), "t1")
+
+    def test_empty_when_no_user_outbounds(self):
+        cfg = {"outbounds": [{"type": "direct", "tag": "direct"}]}
+        self.assertEqual(active_outbound_tag(cfg), "")
 
 
 class TestReapplySaved(unittest.TestCase):

--- a/tests/test_singbox_watchdog.py
+++ b/tests/test_singbox_watchdog.py
@@ -1,0 +1,211 @@
+# tests/test_singbox_watchdog.py
+"""
+Unit-тесты для core/singbox_watchdog.py — чистая логика и интеграция
+_maybe_restart (без фонового потока и без бинаря sing-box).
+"""
+
+import time
+import unittest
+from unittest import mock
+
+from core import singbox_watchdog
+
+
+class FakeConfigManager:
+    def __init__(self, data=None):
+        self.data = data or {}
+
+    def load(self):
+        return self.data
+
+
+class TestGetSettings(unittest.TestCase):
+
+    def test_defaults(self):
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=FakeConfigManager({})):
+            s = singbox_watchdog._get_settings()
+        self.assertFalse(s["enabled"])
+        self.assertEqual(s["check_interval_sec"],
+                         singbox_watchdog.DEFAULT_CHECK_INTERVAL_SEC)
+        self.assertEqual(s["probe_fail_threshold"],
+                         singbox_watchdog.DEFAULT_PROBE_FAIL_THRESHOLD)
+        self.assertEqual(s["probe_target"],
+                         singbox_watchdog.DEFAULT_PROBE_TARGET)
+
+    def test_custom(self):
+        cfg = {"singbox": {"watchdog": {
+            "enabled": True, "check_interval_sec": 30,
+            "probe_fail_threshold": 3}}}
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=FakeConfigManager(cfg)):
+            s = singbox_watchdog._get_settings()
+        self.assertTrue(s["enabled"])
+        self.assertEqual(s["check_interval_sec"], 30)
+        self.assertEqual(s["probe_fail_threshold"], 3)
+
+
+class TestDecideRestart(unittest.TestCase):
+
+    def test_holds_below_threshold(self):
+        should, _ = singbox_watchdog.decide_restart(
+            probe_fails=1, probe_threshold=2)
+        self.assertFalse(should)
+
+    def test_restarts_at_threshold(self):
+        should, reason = singbox_watchdog.decide_restart(
+            probe_fails=2, probe_threshold=2)
+        self.assertTrue(should)
+        self.assertIn("проба", reason)
+
+    def test_threshold_floor_is_one(self):
+        should, _ = singbox_watchdog.decide_restart(
+            probe_fails=1, probe_threshold=0)
+        self.assertTrue(should)
+
+
+class _FakeResp:
+    def __init__(self, code, body):
+        self._code = code
+        self._body = body.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def getcode(self):
+        return self._code
+
+    def read(self):
+        return self._body
+
+
+class TestProbeOutbound(unittest.TestCase):
+
+    EP = {"host": "127.0.0.1", "port": 9090, "secret": "s"}
+
+    def test_ok_on_delay(self):
+        with mock.patch("urllib.request.urlopen",
+                        return_value=_FakeResp(200, '{"delay": 120}')):
+            self.assertTrue(singbox_watchdog.probe_outbound(
+                self.EP, "PROXY", "http://x/generate_204", 5000))
+
+    def test_fail_on_error_body(self):
+        with mock.patch("urllib.request.urlopen",
+                        return_value=_FakeResp(200, '{"message": "timeout"}')):
+            self.assertFalse(singbox_watchdog.probe_outbound(
+                self.EP, "PROXY", "http://x/generate_204", 5000))
+
+    def test_fail_on_connection_error(self):
+        with mock.patch("urllib.request.urlopen",
+                        side_effect=OSError("refused")):
+            self.assertFalse(singbox_watchdog.probe_outbound(
+                self.EP, "PROXY", "http://x/generate_204", 5000))
+
+    def test_empty_args(self):
+        self.assertFalse(singbox_watchdog.probe_outbound({}, "", "u", 1000))
+
+
+class TestMaybeRestart(unittest.TestCase):
+    """Интеграция: cooldown / порог проб / rate-limit / рестарт."""
+
+    CFG = {
+        "experimental": {"clash_api": {
+            "external_controller": "127.0.0.1:9090", "secret": "x"}},
+        "outbounds": [
+            {"type": "vless", "tag": "s1"},
+            {"type": "selector", "tag": "PROXY",
+             "outbounds": ["s1"], "default": "s1"}],
+    }
+
+    def _settings(self, **over):
+        base = {
+            "check_interval_sec": 60, "cooldown_sec": 300,
+            "max_restarts_per_hour": 6, "probe_target": "cloudflare",
+            "probe_timeout_ms": 5000, "probe_fail_threshold": 2,
+            "enabled": True,
+        }
+        base.update(over)
+        return base
+
+    def _mgr(self):
+        mgr = mock.MagicMock()
+        mgr.get_config.return_value = {"ok": True, "parsed": self.CFG}
+        return mgr
+
+    def test_restarts_after_threshold_fails(self):
+        wd = singbox_watchdog.SingboxWatchdog()
+        mgr = self._mgr()
+        now = time.time()
+        with mock.patch("core.singbox_watchdog.probe_outbound",
+                        return_value=False):
+            # 1-й провал — ещё не порог.
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+            mgr.restart.assert_not_called()
+            # 2-й провал подряд — рестарт.
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+            mgr.restart.assert_called_once_with("vpn")
+
+    def test_ok_probe_resets_fails(self):
+        wd = singbox_watchdog.SingboxWatchdog()
+        mgr = self._mgr()
+        now = time.time()
+        with mock.patch("core.singbox_watchdog.probe_outbound",
+                        return_value=False):
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+        with mock.patch("core.singbox_watchdog.probe_outbound",
+                        return_value=True):
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+        self.assertEqual(wd._probe_fails.get("vpn"), 0)
+        mgr.restart.assert_not_called()
+
+    def test_cooldown_blocks(self):
+        wd = singbox_watchdog.SingboxWatchdog()
+        mgr = self._mgr()
+        now = time.time()
+        wd._last_restart["vpn"] = now - 60     # cooldown 300с
+        with mock.patch("core.singbox_watchdog.probe_outbound",
+                        return_value=False):
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+        mgr.restart.assert_not_called()
+
+    def test_skip_without_clash_api(self):
+        wd = singbox_watchdog.SingboxWatchdog()
+        mgr = mock.MagicMock()
+        mgr.get_config.return_value = {"ok": True, "parsed": {
+            "outbounds": [{"type": "vless", "tag": "s1"}]}}
+        now = time.time()
+        with mock.patch("core.singbox_watchdog.probe_outbound",
+                        return_value=False) as p:
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+        p.assert_not_called()       # нечем проверять — не вмешиваемся
+        mgr.restart.assert_not_called()
+
+    def test_rate_limit_blocks(self):
+        wd = singbox_watchdog.SingboxWatchdog()
+        mgr = self._mgr()
+        now = time.time()
+        wd._restart_log["vpn"] = [now - i * 100 for i in range(6)]
+        with mock.patch("core.singbox_watchdog.probe_outbound",
+                        return_value=False):
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+            wd._maybe_restart(mgr, "vpn", self._settings(), now)
+        mgr.restart.assert_not_called()
+
+
+class TestStatus(unittest.TestCase):
+
+    def test_status_fields(self):
+        with mock.patch("core.config_manager.get_config_manager",
+                        return_value=FakeConfigManager({})):
+            s = singbox_watchdog.SingboxWatchdog().get_status()
+        for k in ("enabled", "running", "settings", "restarts_last_hour"):
+            self.assertIn(k, s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -29,6 +29,7 @@ const SingboxDashboardPage = (() => {
     let tpNote = '';                 // последняя ошибка применения firewall (persist)
     let debugEnabled = false;        // /api/singbox/debug (log.level=debug при запуске)
     let logState = {};               // name -> { open, text, loading }
+    let watchdog = null;             // /api/singbox/watchdog status
     let fakeipOpts = null;           // /api/singbox/fakeip/options
     let fakeipRendered = false;      // форму рендерим один раз (не теряем ввод при poll)
     let fakeipBusy = false;
@@ -92,6 +93,13 @@ const SingboxDashboardPage = (() => {
                     <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
                 </div>
             </div>
+
+            <div class="card" id="sb-watchdog" style="margin-top:16px;">
+                <div class="card-title">Проверка соединения (авто-перезапуск)</div>
+                <div id="sb-watchdog-body" style="margin-top:8px;">
+                    <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
+                </div>
+            </div>
         `;
         refresh();
         startPolling();
@@ -105,13 +113,14 @@ const SingboxDashboardPage = (() => {
 
     async function loadAll() {
         try {
-            const [envResp, cfgsResp, autoResp, tpResp, dbgResp, fiResp] = await Promise.all([
+            const [envResp, cfgsResp, autoResp, tpResp, dbgResp, fiResp, wdResp] = await Promise.all([
                 API.get('/api/singbox/environment').catch(() => null),
                 API.get('/api/singbox/configs').catch(() => null),
                 API.get('/api/singbox/autostart').catch(() => null),
                 API.get('/api/singbox/transparent/status').catch(() => null),
                 API.get('/api/singbox/debug').catch(() => null),
                 API.get('/api/singbox/fakeip/options').catch(() => null),
+                API.get('/api/singbox/watchdog').catch(() => null),
             ]);
             env       = envResp || null;
             configs   = (cfgsResp && cfgsResp.configs) || [];
@@ -119,6 +128,7 @@ const SingboxDashboardPage = (() => {
             transparent = tpResp || null;
             debugEnabled = !!(dbgResp && dbgResp.enabled);
             if (fiResp && fiResp.ok) fakeipOpts = fiResp;
+            watchdog = (wdResp && wdResp.status) || watchdog;
             // Подхватываем сохранённые настройки в форму (один раз и при смене).
             if (transparent && transparent.settings && transparent.settings.mode) {
                 const s = transparent.settings;
@@ -151,6 +161,7 @@ const SingboxDashboardPage = (() => {
         renderFakeip();
         renderTransparent();
         renderTun();
+        renderWatchdog();
     }
 
     function startPolling() {
@@ -847,6 +858,68 @@ const SingboxDashboardPage = (() => {
         return escapeHtml(s).replace(/"/g, '&quot;');
     }
 
+    // ══════════════ watchdog (проверка соединения) ══════════════
+
+    function renderWatchdog() {
+        const box = document.getElementById('sb-watchdog-body');
+        if (!box) return;
+        const s = (watchdog && watchdog.settings) || {};
+        const on = !!s.enabled;
+        box.innerHTML = `
+            <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+                <input type="checkbox" id="sb-wd-on" ${on ? 'checked' : ''}
+                       onchange="SingboxDashboardPage.saveWatchdog()">
+                <span>Перезапускать sing-box при плохом соединении</span>
+            </label>
+            <p class="text-muted" style="font-size:12px; margin:6px 0 0;">
+                Периодически проверяет связь <b>через прокси</b> (Clash API:
+                реально открывает облако сквозь активный сервер) и
+                автоматически перезапускает инстанс, если соединение зависло
+                или движок перестал отвечать. Аналог авто-переподключения
+                AmneziaWG. Использует clash_api — наш TUN-флоу включает его
+                автоматически.
+            </p>
+            <div id="sb-wd-adv" style="margin-top:10px; ${on ? '' : 'display:none;'}">
+                <div style="display:grid; grid-template-columns:220px 1fr; gap:6px 12px; max-width:560px; align-items:center;">
+                    <label class="text-muted" style="font-size:12px;">Интервал проверки, с</label>
+                    <input type="number" id="sb-wd-iv" class="form-control" style="max-width:100px;"
+                           min="15" max="3600" value="${escapeAttr(s.check_interval_sec || 60)}">
+                    <label class="text-muted" style="font-size:12px;">Неудач подряд → рестарт</label>
+                    <input type="number" id="sb-wd-thr" class="form-control" style="max-width:100px;"
+                           min="1" max="10" value="${escapeAttr(s.probe_fail_threshold || 2)}">
+                    <label class="text-muted" style="font-size:12px;">Таймаут пробы, мс</label>
+                    <input type="number" id="sb-wd-to" class="form-control" style="max-width:100px;"
+                           min="1000" max="30000" value="${escapeAttr(s.probe_timeout_ms || 5000)}">
+                </div>
+                <div style="margin-top:8px;">
+                    <button class="btn btn-ghost btn-sm" onclick="SingboxDashboardPage.saveWatchdog()">Сохранить параметры</button>
+                </div>
+            </div>
+        `;
+    }
+
+    async function saveWatchdog() {
+        const on = !!(document.getElementById('sb-wd-on') || {}).checked;
+        const iv = (document.getElementById('sb-wd-iv') || {}).value;
+        const thr = (document.getElementById('sb-wd-thr') || {}).value;
+        const to = (document.getElementById('sb-wd-to') || {}).value;
+        const payload = { enabled: on };
+        if (iv) payload.check_interval_sec = parseInt(iv, 10) || 60;
+        if (thr) payload.probe_fail_threshold = parseInt(thr, 10) || 2;
+        if (to) payload.probe_timeout_ms = parseInt(to, 10) || 5000;
+        try {
+            const r = await API.post('/api/singbox/watchdog', payload);
+            if (r && r.ok) {
+                watchdog = r.status || watchdog;
+                Toast.success(on ? 'Проверка соединения включена'
+                                 : 'Проверка соединения выключена');
+                renderWatchdog();
+            } else {
+                Toast.error((r && r.error) || 'ошибка');
+            }
+        } catch (e) { Toast.error(e.message); }
+    }
+
     return {
         render, destroy, refresh,
         up, down, restart,
@@ -854,5 +927,6 @@ const SingboxDashboardPage = (() => {
         setFakeip, toggleFakeipHostlist, createFakeip,
         setTp, applyTransparent, removeTransparent, injectInbounds,
         setTun, createTunInbound,
+        saveWatchdog,
     };
 })();


### PR DESCRIPTION
Маршрутизация через sing-box не работала «из коробки»: тест прокси проходил, а трафик устройства — нет. Причина: TUN-конфиг не обрабатывал DNS, плюс TUN надо было создавать вручную, и не было авто-перезапуска при зависании прокси.

1. DNS в TUN-конфиге (set_tun_inbound hijack_dns):
   - перехват DNS (hijack-dns) + локальный резолвер: у устройства, целиком завёрнутого в TUN, теперь резолвятся имена (раньше DNS уходил в туннель «в никуда» → «инета нет», хотя прокси живой);
   - приватные адреса (LAN) пускаем мимо прокси (ip_is_private → direct);
   - формат DNS подбираем под версию движка через `sing-box check` (legacy → typed 1.12+), без бинаря — legacy.

2. TUN создаётся по умолчанию (минимум действий):
   - при создании конфига и при вставке прокси (import-links) конфиг автоматически делается «готовым к маршрутизации»: TUN + DNS + clash_api. Срабатывает только если есть прокси и ещё нет TUN/transparent (гард _should_auto_route); routing=false отключает. «Обычный» SOCKS-прокси почти не нужен — основной сценарий это умная маршрутизация.

3. Проверка соединения как у AWG (core/singbox_watchdog.py):
   - периодически проверяет связь ЧЕРЕЗ прокси (Clash API /proxies/<tag>/delay — реально открывает облако сквозь активный сервер; обойти нельзя, в отличие от SO_BINDTODEVICE-пробы AWG) и перезапускает инстанс при зависании прокси или движка. cooldown + лимит рестартов/час;
   - стартует автономно при загрузке GUI (app.py), не только из UI;
   - API GET/POST /api/singbox/watchdog, карточка на дашборде sing-box.

Тесты: set_tun_inbound(hijack_dns)/active_outbound_tag и весь watchdog (decide/probe/_maybe_restart/settings). Весь набор (1528) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb