### PR TITLE
sing-box routing: резолвить DNS через прокси (фикс DNS-подмены)

### DIFF
--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -420,10 +420,17 @@ def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
         if proxy:
             cfg.setdefault("route", {})["final"] = proxy
     if hijack_dns:
-        # Локальный резолвер для перехваченного DNS (fakeip=False → только
-        # direct-сервер, см. make_fakeip_dns). LAN — мимо прокси.
-        cfg["dns"] = make_fakeip_dns(proxied_domains=None, direct_dns="local",
-                                     typed=typed_dns, fakeip=False)
+        # DNS перехваченных запросов резолвим ЧЕРЕЗ прокси (DoH поверх
+        # прокси-outbound) — чистый ответ без DNS-подмены DPI/провайдера.
+        # Иначе блокируемые домены резолвятся в подменённые IP и сайты не
+        # открываются, хотя прокси живой. Домены самих прокси-серверов —
+        # напрямую (local), чтобы не было петли (резолв сервера через сам
+        # же прокси).
+        proxy_tag = pick_proxy_outbound(cfg) or "proxy-out"
+        cfg["dns"] = make_routing_dns(
+            proxy_tag=proxy_tag,
+            proxy_server_domains=collect_proxy_server_domains(cfg),
+            typed=typed_dns)
         _ensure_private_direct_rule(cfg)
     return cfg
 
@@ -480,6 +487,65 @@ def active_outbound_tag(cfg: dict) -> str:
     if final and final in user_tags:
         return final
     return user_tags[0] if user_tags else ""
+
+
+def _looks_like_ip(s: str) -> bool:
+    """Грубо: это IP-литерал (v4/v6), а не доменное имя?"""
+    s = (s or "").strip().strip("[]")
+    return bool(_IPV4_RE.match(s)) or (":" in s)
+
+
+def collect_proxy_server_domains(cfg: dict) -> list:
+    """
+    Доменные имена `server` всех пользовательских outbound'ов (не IP).
+    Нужны, чтобы резолвить их НАПРЯМУЮ (а не через прокси) и не словить
+    петлю «резолв адреса прокси через сам прокси».
+    """
+    out = set()
+    for ob in (cfg.get("outbounds") or []):
+        if not isinstance(ob, dict):
+            continue
+        if ob.get("type") in ("direct", "block", "dns", "selector", "urltest"):
+            continue
+        srv = (ob.get("server") or "").strip()
+        if srv and not _looks_like_ip(srv):
+            out.add(srv)
+    return sorted(out)
+
+
+def make_routing_dns(*, proxy_tag: str = "proxy-out",
+                     proxy_server_domains=None, doh_ip: str = "1.1.1.1",
+                     typed: bool = False) -> dict:
+    """
+    DNS-секция для маршрутизации трафика через прокси.
+
+    Клиентские запросы резолвятся ЧЕРЕЗ прокси (DoH `https://<doh_ip>/dns-query`
+    поверх `proxy_tag`) — ответ чистый, без DNS-подмены DPI/провайдера (иначе
+    блокируемые домены резолвятся в подменённые IP и не открываются). DoH-узел
+    задаём IP-литералом (1.1.1.1) — его самого резолвить не нужно, петли нет.
+
+    Домены самих прокси-серверов (`proxy_server_domains`) резолвятся напрямую
+    (`local`) — иначе чтобы подключиться к прокси, надо было бы сперва
+    зайти на прокси (петля).
+
+    typed=False → legacy-формат (1.8–1.13), typed=True → 1.12+.
+    """
+    if typed:
+        srv_proxy = {"tag": "dns-proxy", "type": "https", "server": doh_ip,
+                     "detour": proxy_tag}
+        srv_direct = {"tag": "dns-direct", "type": "local"}
+    else:
+        srv_proxy = {"tag": "dns-proxy",
+                     "address": "https://%s/dns-query" % doh_ip,
+                     "detour": proxy_tag}
+        srv_direct = {"tag": "dns-direct", "address": "local"}
+    rules = []
+    doms = [d for d in (proxy_server_domains or [])
+            if d and not _looks_like_ip(d)]
+    if doms:
+        rules.append({"domain": doms, "server": "dns-direct"})
+    return {"servers": [srv_proxy, srv_direct], "rules": rules,
+            "final": "dns-proxy"}
 
 
 def build_geo_route_rule(outbound_tag: str, *, domains=None,

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -15,6 +15,7 @@ from core.singbox_config import (
     make_transparent_inbounds, set_transparent_inbounds, make_sniff_rule,
     make_hijack_dns_rule, make_tun_inbound, set_tun_inbound,
     find_tun_interface, active_outbound_tag,
+    make_routing_dns, collect_proxy_server_domains,
 )
 
 
@@ -340,6 +341,12 @@ class TestTunInbound(unittest.TestCase):
         # есть direct-outbound для этого правила
         self.assertTrue(any(
             o.get("type") == "direct" for o in cfg["outbounds"]))
+        # КЛЮЧЕВОЕ: DNS резолвится ЧЕРЕЗ прокси (detour на активный outbound),
+        # а не через локальный/провайдерский резолвер (иначе DNS-подмена DPI).
+        dns = cfg["dns"]
+        self.assertEqual(dns["final"], "dns-proxy")
+        proxy_srv = next(s for s in dns["servers"] if s["tag"] == "dns-proxy")
+        self.assertEqual(proxy_srv["detour"], "PROXY")   # selector из _cfg
 
     def test_hijack_dns_idempotent(self):
         cfg = self._cfg()
@@ -395,6 +402,44 @@ class TestActiveOutboundTag(unittest.TestCase):
     def test_empty_when_no_user_outbounds(self):
         cfg = {"outbounds": [{"type": "direct", "tag": "direct"}]}
         self.assertEqual(active_outbound_tag(cfg), "")
+
+
+class TestRoutingDns(unittest.TestCase):
+    """DNS-секция маршрутизации: резолв через прокси, домены прокси — мимо."""
+
+    def test_legacy_resolves_via_proxy(self):
+        dns = make_routing_dns(proxy_tag="PROXY",
+                               proxy_server_domains=["vpn.example.com"])
+        self.assertEqual(dns["final"], "dns-proxy")
+        proxy = next(s for s in dns["servers"] if s["tag"] == "dns-proxy")
+        self.assertEqual(proxy["detour"], "PROXY")
+        self.assertTrue(proxy["address"].startswith("https://"))
+        # домен прокси-сервера резолвится напрямую (без петли)
+        self.assertIn({"domain": ["vpn.example.com"], "server": "dns-direct"},
+                      dns["rules"])
+
+    def test_typed_format(self):
+        dns = make_routing_dns(proxy_tag="proxy-out",
+                               proxy_server_domains=[], typed=True)
+        tags = {s["tag"]: s for s in dns["servers"]}
+        self.assertEqual(tags["dns-proxy"]["type"], "https")
+        self.assertEqual(tags["dns-proxy"]["detour"], "proxy-out")
+        self.assertEqual(tags["dns-direct"]["type"], "local")
+        self.assertEqual(dns["rules"], [])      # нет доменов прокси → нет правил
+
+    def test_ip_proxy_server_no_rule(self):
+        # Прокси задан IP — резолвить нечего, правило не нужно.
+        dns = make_routing_dns(proxy_tag="P", proxy_server_domains=["1.2.3.4"])
+        self.assertEqual(dns["rules"], [])
+
+    def test_collect_domains_skips_ip_and_service(self):
+        cfg = {"outbounds": [
+            {"type": "vless", "tag": "a", "server": "host.example.com"},
+            {"type": "hysteria2", "tag": "b", "server": "5.6.7.8"},
+            {"type": "direct", "tag": "direct", "server": "ignored"},
+            {"type": "selector", "tag": "P", "outbounds": ["a", "b"]}]}
+        self.assertEqual(collect_proxy_server_domains(cfg),
+                         ["host.example.com"])
 
 
 class TestReapplySaved(unittest.TestCase):


### PR DESCRIPTION
Прокси живой и трафик идёт (в логах outbound/hysteria2 → gstatic), но сайты не открывались. Причина — DNS: перехваченные запросы резолвились через `local` (резолвер роутера), а в цензурируемой сети он отдаёт ПОДМЕНЁННЫЕ IP для заблокированных доменов → соединение уходит не туда. Подтверждение от пользователя: включение DoT в браузере (DNS зашифрованно через прокси) чинит открытие сайтов.

- make_routing_dns: клиентские DNS-запросы резолвятся ЧЕРЕЗ прокси (DoH https://1.1.1.1/dns-query поверх прокси-outbound) → чистый ответ, без DPI-подмены. DoH-узел задан IP-литералом — резолвить его не нужно.
- collect_proxy_server_domains + DNS-правило: домены самих прокси-серверов резолвятся напрямую (local), иначе петля «резолв адреса прокси через сам прокси». Это поведение совпадает с прежним (сервер прокси и так резолвился direct), так что подключение к прокси не ломается.
- set_tun_inbound(hijack_dns=True) теперь использует make_routing_dns вместо локального резолвера. Версия DNS (legacy/typed) по-прежнему подбирается через `sing-box check`.

Тесты: make_routing_dns (legacy/typed/без доменов прокси), collect_proxy_server_domains, и что set_tun_inbound резолвит DNS через detour на активный outbound. Весь набор (1536) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb