### PR TITLE
sing-box: добавить route.default_domain_resolver (фикс FATAL на 1.14)

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -407,15 +407,36 @@ def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
         set_tun_inbound(cfg, interface_name=iface, address=address, mtu=mtu,
                         stack=stack, auto_route=auto_route, sniff=sniff,
                         hijack_dns=False)
+        # убрать возможный остаток от прежней hijack-конфигурации (resolver
+        # ссылался бы на отсутствующий теперь dns-сервер → FATAL)
+        cfg.setdefault("route", {}).pop("default_domain_resolver", None)
     else:
+        # Перебираем сочетания (формат DNS, default_domain_resolver) под
+        # версию движка и берём первое, что проходит `sing-box check`:
+        #   typed + object-resolver → sing-box 1.12.4+/1.13/1.14
+        #   typed + string-resolver → 1.12.0–1.12.3
+        #   legacy без resolver     → 1.8–1.11
+        # default_domain_resolver обязателен на 1.12+ (на 1.14 без него FATAL):
+        # резолвит домены прокси-серверов в dial-полях напрямую (dns-direct),
+        # без петли «резолв адреса прокси через сам прокси».
+        attempts = [
+            (True,  {"server": "dns-direct"}, "typed"),
+            (True,  "dns-direct",             "typed"),
+            (False, None,                     "legacy"),
+        ]
         chosen = None
-        for typed in (False, True):
+        for typed, resolver, label in attempts:
             set_tun_inbound(cfg, interface_name=iface, address=address,
                             mtu=mtu, stack=stack, auto_route=auto_route,
                             sniff=sniff, hijack_dns=True, typed_dns=typed)
+            route = cfg.setdefault("route", {})
+            if resolver is None:
+                route.pop("default_domain_resolver", None)
+            else:
+                route["default_domain_resolver"] = resolver
             chk = mgr.check_text(render_conf(cfg))
             if chk.get("ok") or chk.get("no_binary"):
-                chosen = "typed" if typed else "legacy"
+                chosen = label
                 break
         dns_format = chosen or "typed"
 

--- a/tests/test_api_singbox.py
+++ b/tests/test_api_singbox.py
@@ -319,5 +319,82 @@ class TestSingboxAPI(unittest.TestCase):
         self.assertFalse(r["ok"])
 
 
+class _FakeRoutingMgr:
+    """Поддельный менеджер: check_text принимает конфиг по правилу accept,
+    save_config запоминает сохранённый (разобранный) конфиг."""
+
+    def __init__(self, accept):
+        self.accept = accept
+        self.saved = None
+
+    def check_text(self, text):
+        import json
+        return {"ok": bool(self.accept(json.loads(text)))}
+
+    def save_config(self, name, text=""):
+        import json
+        self.saved = json.loads(text)
+        return {"ok": True}
+
+
+class TestApplyRoutingDomainResolver(unittest.TestCase):
+    """_apply_singbox_routing подбирает default_domain_resolver под версию
+    движка (на 1.14 без него FATAL)."""
+
+    def _cfg(self):
+        return {"outbounds": [{
+            "type": "hysteria2", "tag": "h", "server": "vpn.example.com",
+            "server_port": 8449, "password": "p",
+            "tls": {"enabled": True, "server_name": "sni.example"}}]}
+
+    def test_object_resolver_when_accepted(self):
+        from api.singbox import _apply_singbox_routing
+        mgr = _FakeRoutingMgr(lambda c: True)        # всё ок (1.14)
+        save = _apply_singbox_routing(mgr, "vpn", self._cfg())
+        self.assertTrue(save["ok"])
+        self.assertEqual(mgr.saved["route"]["default_domain_resolver"],
+                         {"server": "dns-direct"})
+        # клиентский DNS — через прокси
+        self.assertEqual(mgr.saved["dns"]["final"], "dns-proxy")
+        self.assertEqual(save["dns_format"], "typed")
+
+    def test_string_resolver_fallback(self):
+        from api.singbox import _apply_singbox_routing
+        # имитируем 1.12.0: принимаем только строковый resolver
+        mgr = _FakeRoutingMgr(
+            lambda c: isinstance(
+                (c.get("route") or {}).get("default_domain_resolver"), str))
+        save = _apply_singbox_routing(mgr, "vpn", self._cfg())
+        self.assertTrue(save["ok"])
+        self.assertEqual(mgr.saved["route"]["default_domain_resolver"],
+                         "dns-direct")
+
+    def test_legacy_has_no_resolver(self):
+        from api.singbox import _apply_singbox_routing
+        # имитируем старый движок (1.8–1.11): typed-DNS не принимается,
+        # только legacy — и тогда resolver быть НЕ должно.
+        def accept(c):
+            servers = (c.get("dns") or {}).get("servers") or []
+            typed = any("type" in s for s in servers)
+            return (not typed) and \
+                "default_domain_resolver" not in (c.get("route") or {})
+        mgr = _FakeRoutingMgr(accept)
+        save = _apply_singbox_routing(mgr, "vpn", self._cfg())
+        self.assertTrue(save["ok"])
+        self.assertNotIn("default_domain_resolver",
+                         mgr.saved.get("route", {}))
+        self.assertEqual(save["dns_format"], "legacy")
+
+    def test_no_resolver_when_hijack_off(self):
+        from api.singbox import _apply_singbox_routing
+        mgr = _FakeRoutingMgr(lambda c: True)
+        save = _apply_singbox_routing(mgr, "vpn", self._cfg(),
+                                      hijack_dns=False)
+        self.assertTrue(save["ok"])
+        self.assertNotIn("default_domain_resolver",
+                         mgr.saved.get("route", {}))
+        self.assertNotIn("dns", mgr.saved)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
После перевода DNS на резолв через прокси (DoH с detour) sing-box 1.14 перестал запускаться: FATAL «missing route.default_domain_resolver or domain_resolver in dial fields». На 1.12+ обязателен явный резолвер для доменов в dial-полях (адреса прокси-серверов); раньше резолв был неявный, в 1.14 это удалено.

- _apply_singbox_routing теперь подбирает связку (формат DNS, default_domain_resolver) под версию движка через `sing-box check`: typed + {"server":"dns-direct"}  → 1.12.4+/1.13/1.14
    typed + "dns-direct" (строка)    → 1.12.0–1.12.3
    legacy без resolver              → 1.8–1.11
  Резолвер указывает на dns-direct (local) — домены прокси-серверов
  резолвятся напрямую, без петли; клиентский DNS по-прежнему через прокси.
- В режиме без hijack_dns подчищаем возможный остаток default_domain_resolver
  (иначе ссылка на отсутствующий dns-сервер → FATAL).

Тесты: выбор object/string-резолвера и legacy-без-резолвера через fake-mgr, отсутствие резолвера без hijack. Весь набор (1540) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb