### PR TITLE
sing-box routing: глушить QUIC (UDP/443) → откат на TCP

### DIFF
--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -432,23 +432,16 @@ def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
             proxy_server_domains=collect_proxy_server_domains(cfg),
             typed=typed_dns)
         _ensure_private_direct_rule(cfg)
+        _ensure_quic_reject_rule(cfg)
     return cfg
 
 
-def _ensure_private_direct_rule(cfg: dict) -> None:
+def _insert_after_managed(cfg: dict, rule: dict) -> None:
     """
-    Гарантировать правило «приватные адреса (LAN/loopback) → direct» и
-    наличие самого `direct`-outbound'а. Чтобы устройство, целиком
-    завёрнутое в TUN, ходило в локальную сеть (роутер, принтеры, NAS)
-    напрямую, а не через прокси. Правило ставится после служебных
-    (sniff/hijack-dns), но перед доменными/final.
+    Идемпотентно вставить route-правило сразу ПОСЛЕ служебных
+    (sniff/hijack-dns, которые _set_managed_route_rules держит в начале),
+    но ПЕРЕД доменными/final. Дубликат не плодим.
     """
-    outs = cfg.setdefault("outbounds", [])
-    if not any(isinstance(o, dict) and o.get("type") == "direct" for o in outs):
-        outs.append({"type": "direct", "tag": "direct"})
-    direct_tag = next((o.get("tag") for o in outs if isinstance(o, dict)
-                       and o.get("type") == "direct"), "direct")
-    rule = {"ip_is_private": True, "outbound": direct_tag}
     route = cfg.setdefault("route", {})
     rules = route.setdefault("rules", [])
     if not isinstance(rules, list):
@@ -456,13 +449,41 @@ def _ensure_private_direct_rule(cfg: dict) -> None:
         route["rules"] = rules
     if rule in rules:
         return
-    # Вставляем сразу после блока служебных правил (sniff/hijack-dns),
-    # которые _set_managed_route_rules держит в начале.
     insert_at = 0
     for i, r in enumerate(rules):
         if isinstance(r, dict) and r.get("action") in ("sniff", "hijack-dns"):
             insert_at = i + 1
     rules.insert(insert_at, rule)
+
+
+def _ensure_private_direct_rule(cfg: dict) -> None:
+    """
+    Гарантировать правило «приватные адреса (LAN/loopback) → direct» и
+    наличие самого `direct`-outbound'а. Чтобы устройство, целиком
+    завёрнутое в TUN, ходило в локальную сеть (роутер, принтеры, NAS)
+    напрямую, а не через прокси.
+    """
+    outs = cfg.setdefault("outbounds", [])
+    if not any(isinstance(o, dict) and o.get("type") == "direct" for o in outs):
+        outs.append({"type": "direct", "tag": "direct"})
+    direct_tag = next((o.get("tag") for o in outs if isinstance(o, dict)
+                       and o.get("type") == "direct"), "direct")
+    _insert_after_managed(cfg, {"ip_is_private": True, "outbound": direct_tag})
+
+
+def _ensure_quic_reject_rule(cfg: dict) -> None:
+    """
+    Глушить QUIC (UDP/443), чтобы браузеры/ОС откатывались на TCP.
+
+    QUIC поверх прокси (hysteria2/tuic/…) часто не проходит (UDP/MTU/PMTU),
+    и тогда «ничего не открывается», хотя TCP через прокси работает. Сюда же
+    относится DNS-over-QUIC (DoH3): пока он висит на UDP/443, имена вообще не
+    резолвятся, и даже обычный TCP-сайт не открыть (его IP неизвестен). reject
+    шлёт ICMP-unreachable → клиент быстро переключается на TCP. Наш DNS (DoH
+    поверх прокси) ходит по TCP, поэтому от этого правила не страдает.
+    """
+    _insert_after_managed(
+        cfg, {"network": "udp", "port": 443, "action": "reject"})
 
 
 def active_outbound_tag(cfg: dict) -> str:

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -348,6 +348,27 @@ class TestTunInbound(unittest.TestCase):
         proxy_srv = next(s for s in dns["servers"] if s["tag"] == "dns-proxy")
         self.assertEqual(proxy_srv["detour"], "PROXY")   # selector из _cfg
 
+    def test_hijack_dns_rejects_quic(self):
+        # QUIC (UDP/443) глушим, чтобы клиенты откатывались на TCP (включая
+        # DNS-over-QUIC) — иначе через прокси «ничего не открывается».
+        cfg = self._cfg()
+        set_tun_inbound(cfg, hijack_dns=True)
+        rules = cfg["route"]["rules"]
+        self.assertIn({"network": "udp", "port": 443, "action": "reject"},
+                      rules)
+        # повторный вызов не плодит дубликат
+        set_tun_inbound(cfg, hijack_dns=True)
+        self.assertEqual(sum(
+            1 for r in cfg["route"]["rules"]
+            if r == {"network": "udp", "port": 443, "action": "reject"}), 1)
+
+    def test_no_quic_reject_without_hijack(self):
+        cfg = self._cfg()
+        set_tun_inbound(cfg)
+        self.assertNotIn(
+            {"network": "udp", "port": 443, "action": "reject"},
+            cfg.get("route", {}).get("rules", []))
+
     def test_hijack_dns_idempotent(self):
         cfg = self._cfg()
         set_tun_inbound(cfg, hijack_dns=True)


### PR DESCRIPTION
Симптом: прокси-тест проходит, sing-box запущен, hysteria2 форвардит, но сайты (даже обычный TCP — 2ip.ru) не открываются. В логах TUN — ТОЛЬКО UDP к :443 (QUIC), ни одного TCP-соединения и ни одного DNS :53.

Причина: ПК резолвит имена по DNS-over-QUIC (UDP/443 к DoH-серверу), а QUIC через прокси не проходит (UDP/MTU/PMTU). Имена не резолвятся → даже обычный TCP-сайт не открыть (его IP неизвестен). TCP через прокси при этом работает (что подтверждает успешный delay-тест).

- set_tun_inbound(hijack_dns=True) добавляет route-правило reject для UDP/443: клиенты получают ICMP-unreachable и откатываются на TCP (DoH-over-TCP или обычный DNS), который резолвится через прокси → сайты открываются. Наш DNS (DoH поверх прокси) ходит по TCP и не страдает.
- Вынесен общий _insert_after_managed (идемпотентная вставка route-правил после служебных sniff/hijack-dns).

Тесты: reject-правило присутствует при hijack и отсутствует без него, идемпотентность. Весь набор (1542) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb