### PR TITLE
sing-box routing: TUN stack gvisor вместо system (фикс: TCP не шёл)

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -377,7 +377,7 @@ def _should_auto_route(cfg: dict) -> bool:
 
 
 def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
-                           address=None, mtu=9000, stack="system",
+                           address=None, mtu=9000, stack="gvisor",
                            auto_route=False, sniff=True, hijack_dns=True):
     """
     Сделать конфиг «готовым к умной маршрутизации» и сохранить:
@@ -1308,7 +1308,7 @@ def register(app):
             iface=iface,
             address=addr or None,
             mtu=int(body.get("mtu") or 9000),
-            stack=(body.get("stack") or "system"),
+            stack=(body.get("stack") or "gvisor"),
             auto_route=bool(body.get("auto_route", False)),
             sniff=bool(body.get("sniff", True)),
             hijack_dns=bool(body.get("hijack_dns", True)))

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -381,7 +381,7 @@ def make_tun_inbound(*, interface_name: str = "singbox-tun",
 
 
 def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
-                    address=None, mtu: int = 9000, stack: str = "system",
+                    address=None, mtu: int = 9000, stack: str = "gvisor",
                     auto_route: bool = False, strict_route: bool = False,
                     sniff: bool = True, route_to_proxy: bool = True,
                     hijack_dns: bool = False, typed_dns: bool = False) -> dict:
@@ -389,6 +389,13 @@ def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
     Вставить/заменить TUN-inbound в конфиге (cfg мутируется и
     возвращается). Прежний наш `tun-in` убирается, остальные inbound'ы
     сохраняются. Чистая функция (без I/O).
+
+    stack='gvisor' (НЕ 'system') — критично для выборочной маршрутизации:
+    при auto_route=False трафик в TUN заворачивают НАШИ `ip rule`, а
+    системный стек sing-box БЕЗ auto_route не перехватывает TCP-соединения
+    (UDP/DNS при этом работают) → «сайты не открываются, хотя прокси живой».
+    gvisor читает все пакеты из TUN сам, поэтому TCP+UDP работают независимо
+    от auto_route.
 
     После этого конфиг можно запустить — интерфейс `interface_name`
     появится в системе и в «Selective routing» (как цель device/domain/

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -316,6 +316,15 @@ class TestTunInbound(unittest.TestCase):
         self.assertEqual(len(tun), 1)                     # заменён, не дубль
         self.assertEqual(tun[0]["interface_name"], "t1")
 
+    def test_routing_tun_uses_gvisor_stack(self):
+        # system-стек без auto_route не перехватывает TCP — для выборочной
+        # маршрутизации (auto_route=False) нужен gvisor.
+        cfg = self._cfg()
+        set_tun_inbound(cfg)
+        tun = next(ib for ib in cfg["inbounds"] if ib["tag"] == "tun-in")
+        self.assertEqual(tun["stack"], "gvisor")
+        self.assertFalse(tun["auto_route"])
+
     def test_no_dns_section_without_hijack(self):
         # По умолчанию (hijack_dns=False) DNS-секцию НЕ добавляем —
         # совместимость со старым поведением.

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -23,7 +23,7 @@ const SingboxDashboardPage = (() => {
     let tpScopeAutoSet = false;      // scope уже предложен по профилю окружения
     let tunForm = {                  // форма TUN-интерфейса (для Selective routing)
         config: '', interface_name: 'singbox-tun',
-        address: '172.18.0.1/30', stack: 'system', mtu: 9000,
+        address: '172.18.0.1/30', stack: 'gvisor', mtu: 9000,
         auto_route: false,
     };
     let tpNote = '';                 // последняя ошибка применения firewall (persist)
@@ -645,8 +645,8 @@ const SingboxDashboardPage = (() => {
                 <label class="text-muted">Сетевой стек</label>
                 <select class="form-control" style="max-width:280px;"
                         onchange="SingboxDashboardPage.setTun('stack', this.value)">
-                    ${opt('system', tunForm.stack, 'system (быстрее, нужен tun ядра)')}
-                    ${opt('gvisor', tunForm.stack, 'gvisor (userspace, переносимее)')}
+                    ${opt('gvisor', tunForm.stack, 'gvisor (для выборочной маршрутизации — TCP+UDP)')}
+                    ${opt('system', tunForm.stack, 'system (только для режима «весь трафик»/auto_route)')}
                     ${opt('mixed', tunForm.stack, 'mixed')}
                 </select>
 


### PR DESCRIPTION
По логам пользователя: DNS резолвится (hijack→DoH через прокси → 2ip.ru → 188.40.167.82), QUIC рубится, но в TUN НЕТ НИ ОДНОГО TCP-соединения — только UDP. Сайты не открываются.

Причина: "stack": "system". Системный стек sing-box не перехватывает TCP без auto_route. У нас выборочная маршрутизация (auto_route=false, трафик заворачивается нашими ip rule), поэтому UDP/DNS работают, а TCP — нет (пакеты приходят в singbox-tun, но system-стек их не подхватывает как соединения). Throne работает, потому что использует gvisor.

- set_tun_inbound / _apply_singbox_routing / tun-inbound endpoint: стек по умолчанию gvisor (читает все пакеты из TUN сам → TCP+UDP работают независимо от auto_route). FakeIP-путь (auto_route=true) по-прежнему system.
- UI: дефолт стека TUN — gvisor, подписи опций уточнены.

Тест: выборочный TUN использует gvisor при auto_route=false. Весь набор (1543) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb