### PR TITLE
sing-box: собирать с gvisor + детект/фолбэк + предупреждение + лог-копия

### DIFF
--- a/.github/workflows/build-singbox-binaries.yml
+++ b/.github/workflows/build-singbox-binaries.yml
@@ -45,7 +45,7 @@ env:
   SINGBOX_REPO: SagerNet/sing-box
   # Набор tags для роутерного билда. Меньше дефолтного апстрима —
   # выкидываем with_v2ray_api, with_acme (нам незачем Let's Encrypt на
-  # роутере), with_gvisor (большой) и with_dhcp.
+  # роутере) и with_dhcp.
   # Оставляем то, что критично:
   #   with_quic     — Hysteria, Hysteria2, TUIC
   #   with_grpc     — VLESS+gRPC transport
@@ -55,10 +55,18 @@ env:
   #     временный sing-box и дёргает /proxies/<tag>/delay). Без него
   #     тест/health-filter пула не работает: «clash api is not included
   #     in this build».
+  #   with_gvisor   — ОБЯЗАТЕЛЕН для выборочной маршрутизации через TUN.
+  #     Трафик в TUN заворачивают наши `ip rule` (auto_route=false), а
+  #     системный сетевой стек sing-box БЕЗ auto_route НЕ перехватывает TCP
+  #     (UDP/DNS при этом работают) → «сайты не открываются, хотя прокси
+  #     живой». gvisor (userspace-стек) читает все пакеты из TUN сам и
+  #     работает независимо от auto_route. Без него старт TUN падает с
+  #     «gVisor is not included in this build». Немного увеличивает размер —
+  #     ради рабочей маршрутизации это оправдано.
   # ВАЖНО: НЕ включаем with_ech — начиная с sing-box 1.10 ECH
   # реализован в stdlib, отдельный тэг deprecated и при попытке
   # сборки даёт ошибку «cannot use string constant as int».
-  SINGBOX_TAGS: 'with_quic with_grpc with_wireguard with_utls with_clash_api'
+  SINGBOX_TAGS: 'with_quic with_grpc with_wireguard with_utls with_clash_api with_gvisor'
 
 jobs:
   # ── 0. Авто-детект новых версий апстрима (только cron) ─────

--- a/api/singbox.py
+++ b/api/singbox.py
@@ -376,6 +376,27 @@ def _should_auto_route(cfg: dict) -> bool:
     return bool(list_user_outbound_tags(cfg))
 
 
+def _binary_has_gvisor(binary):
+    """
+    Собран ли sing-box с with_gvisor (по `version` → строка `Tags:`).
+    True — есть; False — Tags распарсились, gvisor нет; None — не определить.
+    """
+    if not binary:
+        return None
+    import subprocess as _sp
+    import re as _re
+    try:
+        r = _sp.run([binary, "version"], capture_output=True, text=True,
+                    timeout=4)
+    except (FileNotFoundError, OSError, _sp.SubprocessError):
+        return None
+    m = _re.search(r"^\s*Tags:\s*(.+)$", r.stdout or "", _re.I | _re.M)
+    if not m:
+        return None
+    tags = [t.strip() for t in _re.split(r"[,\s]+", m.group(1)) if t.strip()]
+    return any("gvisor" in t for t in tags)
+
+
 def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
                            address=None, mtu=9000, stack="gvisor",
                            auto_route=False, sniff=True, hijack_dns=True):
@@ -388,7 +409,7 @@ def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
       • clash_api (нужен health-watchdog'у и учёту трафика).
     Формат DNS подбираем под версию движка через `sing-box check`
     (legacy → typed 1.12+). Без бинаря оставляем legacy (валиден 1.8–1.13).
-    Возвращает save-dict (+ interface_name, dns_format).
+    Возвращает save-dict (+ interface_name, dns_format, stack, gvisor_missing).
     """
     import secrets as _secrets
     from core.singbox_config import (
@@ -401,6 +422,22 @@ def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
                              secret=_secrets.token_hex(8))
         except Exception:
             pass
+
+    # gvisor нужен для выборочной маршрутизации (system-стек без auto_route не
+    # перехватывает TCP). Но если бинарь собран БЕЗ gvisor — старт TUN падает
+    # с «gVisor is not included in this build». Поэтому используем gvisor
+    # только когда он ТОЧНО есть; иначе откатываемся на system (без FATAL) и
+    # помечаем gvisor_missing — UI подскажет обновить sing-box.
+    gvisor_missing = False
+    if stack in ("gvisor", "mixed"):
+        try:
+            binpath = mgr._binary() if hasattr(mgr, "_binary") else ""
+        except Exception:
+            binpath = ""
+        has_gvisor = _binary_has_gvisor(binpath)
+        if has_gvisor is not True:
+            gvisor_missing = (has_gvisor is False)
+            stack = "system"
 
     dns_format = "none"
     if not hijack_dns:
@@ -444,6 +481,8 @@ def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
     if isinstance(save, dict):
         save["interface_name"] = iface
         save["dns_format"] = dns_format
+        save["stack"] = stack
+        save["gvisor_missing"] = gvisor_missing
     return save
 
 

--- a/core/singbox_detector.py
+++ b/core/singbox_detector.py
@@ -74,18 +74,20 @@ class SingboxDetector:
             path = _find_binary(["sing-box"])
         if not path:
             return {"installed": False, "path": "", "version": "",
-                    "tags": [], "has_clash_api": False}
+                    "tags": [], "has_clash_api": False, "has_gvisor": False}
         info = self._probe_version_info(path)
         return {"installed": True, "path": path,
                 "version":       info["version"],
                 "tags":          info["tags"],
-                # has_clash_api отражает УВЕРЕННОЕ наличие тега в сборке.
-                # Если `Tags:`-строку распарсить не удалось (tags пуст) —
-                # оставляем False, но потребители (proxy_tester/installer)
-                # реагируют только на «уверенно отсутствует»: tags непуст и
-                # clash_api в них нет. Это страхует от ложных срабатываний
-                # на сборках, не печатающих Tags.
-                "has_clash_api": info["has_clash_api"]}
+                # has_clash_api / has_gvisor отражают УВЕРЕННОЕ наличие тега в
+                # сборке. Если `Tags:`-строку распарсить не удалось (tags пуст)
+                # — оставляем False, но потребители реагируют только на
+                # «уверенно отсутствует» (tags непуст и тега там нет). Это
+                # страхует от ложных срабатываний на сборках без Tags.
+                # has_gvisor: gvisor ОБЯЗАТЕЛЕН для выборочной маршрутизации
+                # через TUN (system-стек без auto_route не ловит TCP).
+                "has_clash_api": info["has_clash_api"],
+                "has_gvisor": any("gvisor" in t for t in info["tags"])}
 
     def _probe_version(self, binary: str) -> str:
         """Только номер версии (обёртка над `_probe_version_info`)."""

--- a/tests/test_api_singbox.py
+++ b/tests/test_api_singbox.py
@@ -396,5 +396,70 @@ class TestApplyRoutingDomainResolver(unittest.TestCase):
         self.assertNotIn("dns", mgr.saved)
 
 
+class TestBinaryHasGvisor(unittest.TestCase):
+
+    def _run(self, stdout):
+        import types
+        return mock.patch("subprocess.run", return_value=types.SimpleNamespace(
+            stdout=stdout, returncode=0))
+
+    def test_present(self):
+        from api.singbox import _binary_has_gvisor
+        with self._run("sing-box version 1.14.0\n"
+                       "Tags: with_quic,with_gvisor,with_clash_api\n"):
+            self.assertTrue(_binary_has_gvisor("/x"))
+
+    def test_absent(self):
+        from api.singbox import _binary_has_gvisor
+        with self._run("sing-box version 1.14.0\nTags: with_quic,with_clash_api\n"):
+            self.assertFalse(_binary_has_gvisor("/x"))
+
+    def test_no_tags_line(self):
+        from api.singbox import _binary_has_gvisor
+        with self._run("sing-box version 1.14.0\n"):
+            self.assertIsNone(_binary_has_gvisor("/x"))
+
+    def test_empty_binary(self):
+        from api.singbox import _binary_has_gvisor
+        self.assertIsNone(_binary_has_gvisor(""))
+
+
+class TestGvisorStackFallback(unittest.TestCase):
+    """Без gvisor в сборке откатываемся на system (без FATAL) + флаг."""
+
+    def _cfg(self):
+        return {"outbounds": [{
+            "type": "hysteria2", "tag": "h", "server": "vpn.example.com",
+            "server_port": 8449, "password": "p",
+            "tls": {"enabled": True, "server_name": "sni"}}]}
+
+    def _mgr(self):
+        mgr = _FakeRoutingMgr(lambda c: True)
+        mgr._binary = lambda: "/opt/sbin/sing-box"
+        return mgr
+
+    def test_fallback_to_system_without_gvisor(self):
+        from api import singbox as sb
+        mgr = self._mgr()
+        with mock.patch.object(sb, "_binary_has_gvisor", return_value=False):
+            save = sb._apply_singbox_routing(mgr, "vpn", self._cfg())
+        self.assertTrue(save["gvisor_missing"])
+        self.assertEqual(save["stack"], "system")
+        tun = next(ib for ib in mgr.saved["inbounds"]
+                   if ib.get("type") == "tun")
+        self.assertEqual(tun["stack"], "system")
+
+    def test_uses_gvisor_when_present(self):
+        from api import singbox as sb
+        mgr = self._mgr()
+        with mock.patch.object(sb, "_binary_has_gvisor", return_value=True):
+            save = sb._apply_singbox_routing(mgr, "vpn", self._cfg())
+        self.assertFalse(save["gvisor_missing"])
+        self.assertEqual(save["stack"], "gvisor")
+        tun = next(ib for ib in mgr.saved["inbounds"]
+                   if ib.get("type") == "tun")
+        self.assertEqual(tun["stack"], "gvisor")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -198,7 +198,25 @@ const SingboxDashboardPage = (() => {
                   Установить sing-box
               </button>`;
 
-        body.innerHTML = `
+        // gvisor обязателен для выборочной маршрутизации через TUN. Если
+        // бинарь его уверенно не содержит (tags непуст, gvisor нет) — баннер.
+        const gvisorMissing = installed && (bin.tags || []).length
+                              && !bin.has_gvisor;
+        const gvisorBanner = gvisorMissing ? `
+            <div style="margin-bottom:12px; padding:10px 12px; border-radius:6px;
+                        background:rgba(220,80,80,.12); border:1px solid rgba(220,80,80,.4);
+                        font-size:13px; line-height:1.5;">
+                ⚠️ <strong>sing-box собран без gvisor.</strong> Для маршрутизации
+                трафика через TUN он обязателен — без него сайты не открываются
+                (системный стек без auto_route не пропускает TCP), а запуск
+                TUN может падать с «gVisor is not included».
+                <button class="btn btn-primary btn-sm" style="margin-left:6px;"
+                        onclick="window.location.hash='singbox-setup'">
+                    Обновить sing-box
+                </button>
+            </div>` : '';
+
+        body.innerHTML = gvisorBanner + `
             <div style="display:flex; gap:24px; flex-wrap:wrap; font-size:13px;">
                 <div>
                     <div class="text-muted" style="font-size:11px;">Платформа</div>
@@ -303,6 +321,17 @@ const SingboxDashboardPage = (() => {
                 ${renderLogBlock(c.name)}
             </div>`;
         }).join('');
+        _scrollOpenLogs();
+    }
+
+    // Прокрутить все открытые блоки лога в конец (автопромотка к свежим
+    // строкам). Зовём после каждого ре-рендера инстансов.
+    function _scrollOpenLogs() {
+        try {
+            document.querySelectorAll('.sb-log-pre').forEach(el => {
+                el.scrollTop = el.scrollHeight;
+            });
+        } catch (_) { /* no-op */ }
     }
 
     function renderLogBlock(name) {
@@ -319,15 +348,41 @@ const SingboxDashboardPage = (() => {
                     </span>
                     <span style="display:flex; gap:6px;">
                         <button class="btn btn-ghost btn-sm"
+                                onclick="SingboxDashboardPage.copyLog('${escapeAttr(name)}')">⧉ Копировать</button>
+                        <button class="btn btn-ghost btn-sm"
                                 onclick="SingboxDashboardPage.showLog('${escapeAttr(name)}', true)">↻ Обновить</button>
                         <button class="btn btn-ghost btn-sm"
                                 onclick="SingboxDashboardPage.showLog('${escapeAttr(name)}')">Скрыть</button>
                     </span>
                 </div>
-                <pre style="max-height:340px; overflow:auto; font-size:11px; line-height:1.4;
+                <pre class="sb-log-pre" style="max-height:340px; overflow:auto; font-size:11px; line-height:1.4;
                             background:var(--bg-code, #111); padding:10px; border-radius:6px;
                             white-space:pre-wrap; word-break:break-word; margin:0;">${body}</pre>
             </div>`;
+    }
+
+    async function copyLog(name) {
+        const st = logState[name];
+        const text = (st && st.text) || '';
+        if (!text) { Toast.error('Лог пуст'); return; }
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(text);
+            } else {
+                // Фолбэк для http/старых браузеров: временный textarea.
+                const ta = document.createElement('textarea');
+                ta.value = text;
+                ta.style.position = 'fixed';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand('copy');
+                document.body.removeChild(ta);
+            }
+            Toast.success('Лог скопирован в буфер');
+        } catch (e) {
+            Toast.error('Не удалось скопировать: ' + e.message);
+        }
     }
 
     // ══════════════ actions ══════════════
@@ -684,8 +739,17 @@ const SingboxDashboardPage = (() => {
                   stack: tunForm.stack, mtu: tunForm.mtu,
                   auto_route: tunForm.auto_route });
             if (r && r.ok) {
-                Toast.success('TUN-инбаунд добавлен в ' + tunForm.config +
-                    '. (Пере)запустите конфиг, затем настройте Selective routing.');
+                if (r.gvisor_missing) {
+                    Toast.error('Внимание: ваш sing-box собран БЕЗ gvisor — ' +
+                        'для выборочной маршрутизации он обязателен (system-стек ' +
+                        'без auto_route не пропускает TCP). Откатился на system. ' +
+                        'Обновите sing-box (раздел «Установка») на сборку с gvisor.',
+                        14000);
+                } else {
+                    Toast.success('TUN-инбаунд добавлен в ' + tunForm.config +
+                        ' (стек ' + (r.stack || 'gvisor') + '). (Пере)запустите ' +
+                        'конфиг, затем настройте Selective routing.');
+                }
                 await refresh();
             } else Toast.error((r && r.error) || 'ошибка');
         } catch (e) { Toast.error(e.message); }


### PR DESCRIPTION
Финальная причина «не работает / не стартует»: НАША сборка sing-box делалась БЕЗ with_gvisor (ради размера), а gvisor обязателен для выборочной маршрутизации через TUN — system-стек без auto_route не перехватывает TCP (UDP/DNS работают). Форс gvisor на такой сборке → FATAL «gVisor is not included». Throne работает, т.к. собран с gvisor.

- .github/workflows/build-singbox-binaries.yml: добавлен with_gvisor в SINGBOX_TAGS (наши бинари теперь с gvisor). После пересборки релиза и переустановки в GUI выборочная маршрутизация заработает.
- _apply_singbox_routing: детект gvisor по `version` Tags (_binary_has_gvisor). gvisor используем только если ТОЧНО есть; иначе откат на system без FATAL
  + флаг gvisor_missing. Возвращаем stack/gvisor_missing в ответе.
- singbox_detector.detect_binary: добавлено has_gvisor.
- UI: баннер в обзоре sing-box «собран без gvisor — обновите», предупреждение при «Создать TUN-инбаунд», когда был откат на system.
- UI: кнопка «Копировать» лог в буфер + автопрокрутка лога в конец.

Тесты: _binary_has_gvisor (есть/нет/без Tags/пусто), откат стека на system без gvisor и gvisor при наличии. Весь набор (1549) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb