### PR TITLE
sing-box: MTU TUN 1500 вместо 9000 (фикс 100% CPU/GC-молотьбы с gvisor)

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -398,7 +398,7 @@ def _binary_has_gvisor(binary):
 
 
 def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
-                           address=None, mtu=9000, stack="gvisor",
+                           address=None, mtu=1500, stack="gvisor",
                            auto_route=False, sniff=True, hijack_dns=True):
     """
     Сделать конфиг «готовым к умной маршрутизации» и сохранить:
@@ -1346,7 +1346,7 @@ def register(app):
             mgr, name, cfg,
             iface=iface,
             address=addr or None,
-            mtu=int(body.get("mtu") or 9000),
+            mtu=int(body.get("mtu") or 1500),
             stack=(body.get("stack") or "gvisor"),
             auto_route=bool(body.get("auto_route", False)),
             sniff=bool(body.get("sniff", True)),

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -342,7 +342,7 @@ _TUN_TAG = "tun-in"
 
 
 def make_tun_inbound(*, interface_name: str = "singbox-tun",
-                     address=None, mtu: int = 9000,
+                     address=None, mtu: int = 1500,
                      stack: str = "system",
                      auto_route: bool = False,
                      strict_route: bool = False,
@@ -364,13 +364,18 @@ def make_tun_inbound(*, interface_name: str = "singbox-tun",
 
     stack: 'system' (быстрее, нужен модуль tun ядра — на Keenetic есть),
            'gvisor' (userspace, переносимее) или 'mixed'.
+
+    mtu по умолчанию 1500 (а не 9000): для туннеля поверх прокси
+    (hysteria2/…) большой MTU бессмысленен (реальный путь ~1400), а с
+    gvisor-стеком 9000 раздувает буферы и на роутере с малым ОЗУ приводит к
+    GC-молотьбе и 100% CPU.
     """
     ib = {
         "type": "tun",
         "tag": _TUN_TAG,
         "interface_name": interface_name or "singbox-tun",
         "address": list(address) if address else ["172.18.0.1/30"],
-        "mtu": int(mtu) if mtu else 9000,
+        "mtu": int(mtu) if mtu else 1500,
         "auto_route": bool(auto_route),
         "strict_route": bool(strict_route),
         "stack": stack or "system",
@@ -381,7 +386,7 @@ def make_tun_inbound(*, interface_name: str = "singbox-tun",
 
 
 def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
-                    address=None, mtu: int = 9000, stack: str = "gvisor",
+                    address=None, mtu: int = 1500, stack: str = "gvisor",
                     auto_route: bool = False, strict_route: bool = False,
                     sniff: bool = True, route_to_proxy: bool = True,
                     hijack_dns: bool = False, typed_dns: bool = False) -> dict:
@@ -756,7 +761,7 @@ def build_fakeip_config(*, proxy_outbound: dict,
                         route_all: bool = False,
                         direct_dns: str = "local",
                         tun_iface: str = "singbox-tun",
-                        tun_address=None, mtu: int = 9000,
+                        tun_address=None, mtu: int = 1500,
                         stack: str = "system",
                         auto_redirect: bool = False,
                         typed_dns: bool = False,

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -23,7 +23,7 @@ const SingboxDashboardPage = (() => {
     let tpScopeAutoSet = false;      // scope уже предложен по профилю окружения
     let tunForm = {                  // форма TUN-интерфейса (для Selective routing)
         config: '', interface_name: 'singbox-tun',
-        address: '172.18.0.1/30', stack: 'gvisor', mtu: 9000,
+        address: '172.18.0.1/30', stack: 'gvisor', mtu: 1500,
         auto_route: false,
     };
     let tpNote = '';                 // последняя ошибка применения firewall (persist)
@@ -726,7 +726,7 @@ const SingboxDashboardPage = (() => {
 
     function setTun(key, value) {
         if (key === 'auto_route') tunForm.auto_route = !!value;
-        else if (key === 'mtu') tunForm.mtu = parseInt(value, 10) || 9000;
+        else if (key === 'mtu') tunForm.mtu = parseInt(value, 10) || 1500;
         else tunForm[key] = value;
     }
 


### PR DESCRIPTION
С gvisor-сборкой sing-box стартует, но грузит CPU на 100% и падает; в дампе горутин — множество в GC (mark termination, gcAssistAlloc, gcParkAssist) = нехватка памяти → GC молотит вхолостую на слабом MIPS-роутере.

Причина — MTU TUN 9000: gvisor выделяет буферы под MTU, и 9000 на роутере с малым ОЗУ раздувает память до GC-thrash. Плюс 9000 бессмысленен для туннеля поверх hysteria2/прокси (реальный путь ~1400) — sing-box терминирует TCP локально, так что MTU TUN не влияет на фрагментацию к прокси.

- make_tun_inbound / set_tun_inbound / build_fakeip_config / _apply_singbox_routing / tun-inbound endpoint / UI: MTU по умолчанию 1500 (было 9000).

Весь набор (1549) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb