### PR TITLE
sing-box: reject-QUIC опционален (выкл по умолчанию) + фикс кнопки ко…

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -399,7 +399,8 @@ def _binary_has_gvisor(binary):
 
 def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
                            address=None, mtu=1500, stack="gvisor",
-                           auto_route=False, sniff=True, hijack_dns=True):
+                           auto_route=False, sniff=True, hijack_dns=True,
+                           reject_quic=False):
     """
     Сделать конфиг «готовым к умной маршрутизации» и сохранить:
       • TUN-inbound (цель для device/domain/cidr-правил «Маршрутизации»);
@@ -465,7 +466,8 @@ def _apply_singbox_routing(mgr, name, cfg, *, iface="singbox-tun",
         for typed, resolver, label in attempts:
             set_tun_inbound(cfg, interface_name=iface, address=address,
                             mtu=mtu, stack=stack, auto_route=auto_route,
-                            sniff=sniff, hijack_dns=True, typed_dns=typed)
+                            sniff=sniff, hijack_dns=True, typed_dns=typed,
+                            reject_quic=reject_quic)
             route = cfg.setdefault("route", {})
             if resolver is None:
                 route.pop("default_domain_resolver", None)
@@ -1350,7 +1352,8 @@ def register(app):
             stack=(body.get("stack") or "gvisor"),
             auto_route=bool(body.get("auto_route", False)),
             sniff=bool(body.get("sniff", True)),
-            hijack_dns=bool(body.get("hijack_dns", True)))
+            hijack_dns=bool(body.get("hijack_dns", True)),
+            reject_quic=bool(body.get("reject_quic", False)))
         if not (isinstance(save, dict) and save.get("ok")):
             response.status = 500
             return save

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -389,7 +389,8 @@ def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
                     address=None, mtu: int = 1500, stack: str = "gvisor",
                     auto_route: bool = False, strict_route: bool = False,
                     sniff: bool = True, route_to_proxy: bool = True,
-                    hijack_dns: bool = False, typed_dns: bool = False) -> dict:
+                    hijack_dns: bool = False, typed_dns: bool = False,
+                    reject_quic: bool = False) -> dict:
     """
     Вставить/заменить TUN-inbound в конфиге (cfg мутируется и
     возвращается). Прежний наш `tun-in` убирается, остальные inbound'ы
@@ -444,7 +445,15 @@ def set_tun_inbound(cfg: dict, *, interface_name: str = "singbox-tun",
             proxy_server_domains=collect_proxy_server_domains(cfg),
             typed=typed_dns)
         _ensure_private_direct_rule(cfg)
-        _ensure_quic_reject_rule(cfg)
+        # QUIC-reject опционален и ВЫКЛ по умолчанию: глушение UDP/443 ломает
+        # DNS-over-QUIC (DoH3) клиента, если он не откатывается на TCP/plain —
+        # тогда имена вообще не резолвятся. Включать стоит, только если QUIC
+        # через прокси реально не ходит (тогда браузер уйдёт на TCP).
+        if reject_quic:
+            _ensure_quic_reject_rule(cfg)
+        else:
+            remove_route_rule(
+                cfg, {"network": "udp", "port": 443, "action": "reject"})
     return cfg
 
 

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -357,26 +357,38 @@ class TestTunInbound(unittest.TestCase):
         proxy_srv = next(s for s in dns["servers"] if s["tag"] == "dns-proxy")
         self.assertEqual(proxy_srv["detour"], "PROXY")   # selector из _cfg
 
-    def test_hijack_dns_rejects_quic(self):
-        # QUIC (UDP/443) глушим, чтобы клиенты откатывались на TCP (включая
-        # DNS-over-QUIC) — иначе через прокси «ничего не открывается».
+    _QUIC_REJECT = {"network": "udp", "port": 443, "action": "reject"}
+
+    def test_quic_not_rejected_by_default(self):
+        # По умолчанию QUIC НЕ глушим: иначе ломается DNS-over-QUIC клиента.
         cfg = self._cfg()
         set_tun_inbound(cfg, hijack_dns=True)
+        self.assertNotIn(self._QUIC_REJECT, cfg["route"]["rules"])
+
+    def test_hijack_dns_rejects_quic_when_enabled(self):
+        # reject_quic=True — добавляем правило (для прокси без UDP/QUIC).
+        cfg = self._cfg()
+        set_tun_inbound(cfg, hijack_dns=True, reject_quic=True)
         rules = cfg["route"]["rules"]
-        self.assertIn({"network": "udp", "port": 443, "action": "reject"},
-                      rules)
+        self.assertIn(self._QUIC_REJECT, rules)
         # повторный вызов не плодит дубликат
-        set_tun_inbound(cfg, hijack_dns=True)
+        set_tun_inbound(cfg, hijack_dns=True, reject_quic=True)
         self.assertEqual(sum(
-            1 for r in cfg["route"]["rules"]
-            if r == {"network": "udp", "port": 443, "action": "reject"}), 1)
+            1 for r in cfg["route"]["rules"] if r == self._QUIC_REJECT), 1)
+
+    def test_reject_quic_toggle_off_removes_rule(self):
+        # Выключение reject_quic убирает ранее добавленное правило.
+        cfg = self._cfg()
+        set_tun_inbound(cfg, hijack_dns=True, reject_quic=True)
+        self.assertIn(self._QUIC_REJECT, cfg["route"]["rules"])
+        set_tun_inbound(cfg, hijack_dns=True, reject_quic=False)
+        self.assertNotIn(self._QUIC_REJECT, cfg["route"]["rules"])
 
     def test_no_quic_reject_without_hijack(self):
         cfg = self._cfg()
         set_tun_inbound(cfg)
-        self.assertNotIn(
-            {"network": "udp", "port": 443, "action": "reject"},
-            cfg.get("route", {}).get("rules", []))
+        self.assertNotIn(self._QUIC_REJECT,
+                         cfg.get("route", {}).get("rules", []))
 
     def test_hijack_dns_idempotent(self):
         cfg = self._cfg()

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -24,7 +24,7 @@ const SingboxDashboardPage = (() => {
     let tunForm = {                  // форма TUN-интерфейса (для Selective routing)
         config: '', interface_name: 'singbox-tun',
         address: '172.18.0.1/30', stack: 'gvisor', mtu: 1500,
-        auto_route: false,
+        auto_route: false, reject_quic: false,
     };
     let tpNote = '';                 // последняя ошибка применения firewall (persist)
     let debugEnabled = false;        // /api/singbox/debug (log.level=debug при запуске)
@@ -716,6 +716,14 @@ const SingboxDashboardPage = (() => {
                            onchange="SingboxDashboardPage.setTun('auto_route', this.checked)">
                     auto_route — завернуть ВЕСЬ трафик (вместо выборочной маршрутизации)
                 </label>
+
+                <label class="text-muted">QUIC</label>
+                <label class="text-muted" style="display:flex; align-items:center; gap:6px;">
+                    <input type="checkbox" ${tunForm.reject_quic ? 'checked' : ''}
+                           onchange="SingboxDashboardPage.setTun('reject_quic', this.checked)">
+                    Глушить QUIC (UDP/443) — включать ТОЛЬКО если QUIC через прокси
+                    не работает; ломает DNS-over-QUIC, если клиент не откатывается на TCP
+                </label>
             </div>
             <div style="margin-top:12px;">
                 <button class="btn btn-primary btn-sm"
@@ -726,6 +734,7 @@ const SingboxDashboardPage = (() => {
 
     function setTun(key, value) {
         if (key === 'auto_route') tunForm.auto_route = !!value;
+        else if (key === 'reject_quic') tunForm.reject_quic = !!value;
         else if (key === 'mtu') tunForm.mtu = parseInt(value, 10) || 1500;
         else tunForm[key] = value;
     }
@@ -737,7 +746,8 @@ const SingboxDashboardPage = (() => {
                 `/api/singbox/configs/${encodeURIComponent(tunForm.config)}/tun-inbound`,
                 { interface_name: tunForm.interface_name, address: tunForm.address,
                   stack: tunForm.stack, mtu: tunForm.mtu,
-                  auto_route: tunForm.auto_route });
+                  auto_route: tunForm.auto_route,
+                  reject_quic: tunForm.reject_quic });
             if (r && r.ok) {
                 if (r.gvisor_missing) {
                     Toast.error('Внимание: ваш sing-box собран БЕЗ gvisor — ' +
@@ -987,7 +997,7 @@ const SingboxDashboardPage = (() => {
     return {
         render, destroy, refresh,
         up, down, restart,
-        toggleDebug, showLog,
+        toggleDebug, showLog, copyLog,
         setFakeip, toggleFakeipHostlist, createFakeip,
         setTp, applyTransparent, removeTransparent, injectInbounds,
         setTun, createTunInbound,


### PR DESCRIPTION
…пир. лога

1. Кнопка «Копировать» лог не работала: функция copyLog не была добавлена в экспорт SingboxDashboardPage → onclick дёргал undefined. Добавлена в return.

2. reject-QUIC (глушение UDP/443) сделан опциональным и ВЫКЛЮЧЕН по умолчанию. Он ломал DNS-over-QUIC (DoH3) клиента: по логам ПК резолвит имена через DoH по QUIC (UDP/443 к Google 216.239.x), reject рубил эти запросы, а клиент не откатывался на TCP/plain → имена не резолвились → сайты не открывались, и в TUN был только отбиваемый UDP (ни одного TCP). hysteria2 — QUIC-нативный и UDP/QUIC переносит, поэтому по умолчанию QUIC пропускаем через прокси. Включать reject_quic стоит, только если QUIC через конкретный прокси не ходит (тогда браузер уйдёт на TCP). Добавлен чекбокс в карточке TUN; флаг проброшен set_tun_inbound → _apply_singbox_routing → tun-inbound endpoint; выключение убирает ранее добавленное правило (remove_route_rule).

Тесты: QUIC не глушится по умолчанию; reject_quic=True добавляет правило (идемпотентно); выключение убирает. Весь набор (1551) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb