### PR TITLE
sing-box: режим маршрутизации на kernel-стеке (auto_route+system, ниж…

### DIFF
--- a/api/singbox.py
+++ b/api/singbox.py
@@ -830,6 +830,40 @@ def register(app):
             response.status = 400
         return res
 
+    @app.route("/api/singbox/lite-route/build", method="POST")
+    def singbox_lite_route_build():
+        """
+        Собрать конфиг маршрутизации на kernel-стеке (auto_route+system+
+        source_ip_cidr) — низкий CPU. body: proxy_link|proxy_config,
+        source_ips[], route_all, reject_quic, tun_iface, name.
+        """
+        response.content_type = "application/json; charset=utf-8"
+        from core.singbox_fakeip import build_lite_route_and_save
+        try:
+            body = request.json or {}
+        except Exception:
+            body = {}
+
+        def _list(v):
+            if isinstance(v, list):
+                return [str(x).strip() for x in v if str(x).strip()]
+            if isinstance(v, str):
+                return [s.strip() for s in re.split(r"[\s,]+", v) if s.strip()]
+            return []
+
+        res = build_lite_route_and_save(
+            name=(body.get("name") or "lite-route"),
+            proxy_link=(body.get("proxy_link") or ""),
+            proxy_config=(body.get("proxy_config") or ""),
+            source_ips=_list(body.get("source_ips")),
+            route_all=bool(body.get("route_all")),
+            reject_quic=bool(body.get("reject_quic")),
+            tun_iface=(body.get("tun_iface") or "singbox-tun"),
+        )
+        if not res.get("ok"):
+            response.status = 400
+        return res
+
     # ─────── outbounds CRUD (для Outbounds Builder UI) ────────────
 
     @app.route("/api/singbox/configs/<name>/outbounds")

--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -842,7 +842,85 @@ def build_fakeip_config(*, proxy_outbound: dict,
     }
 
 
-# Единственный непустой flow, который принимает sing-box для vless.
+def _norm_src_cidr(s: str) -> str:
+    """IP без маски → /32 (v4) или /128 (v6); CIDR — как есть."""
+    s = (s or "").strip()
+    if not s or "/" in s:
+        return s
+    return s + ("/128" if ":" in s else "/32")
+
+
+def build_system_route_config(*, proxy_outbound: dict, source_ips=None,
+                              route_all: bool = False,
+                              tun_iface: str = "singbox-tun",
+                              tun_address=None, mtu: int = 1500,
+                              typed_dns: bool = False,
+                              reject_quic: bool = False,
+                              auto_redirect: bool = False,
+                              doh_ip: str = "1.1.1.1") -> dict:
+    """
+    Конфиг маршрутизации на KERNEL-стеке (low-CPU, без gvisor):
+
+      TUN(auto_route=true, stack="system") — sing-box сам забирает трафик
+      через системный сетевой стек ядра (намного легче gvisor на слабом
+      MIPS), а кого слать в прокси решают ВНУТРЕННИЕ route-правила движка:
+        - route_all=True  → весь трафик → proxy-out (final);
+        - иначе           → только source_ip_cidr выбранных устройств →
+                            proxy-out, остальное → direct (final).
+
+    DNS перехватывается (hijack-dns) и резолвится через прокси (DoH) — как в
+    остальных режимах. Приватные адреса (LAN) — мимо прокси. strict_route НЕ
+    включаем (чтобы случайно не «залочить» роутер), auto_detect_interface для
+    direct-выхода — чтобы не было петли через сам TUN.
+
+    ⚠️ Экспериментально на Keenetic: auto_route ставит свои ip rule/route, что
+    может конфликтовать с NDM; на iptables-Keenetic перехват ПЕРЕСЫЛАЕМОГО
+    трафика LAN-клиентов через auto_route не гарантирован (для nft есть
+    auto_redirect). Откат — простой `down` инстанса (auto_route снимается).
+    """
+    if not isinstance(proxy_outbound, dict) or not proxy_outbound.get("type"):
+        raise ValueError("proxy_outbound должен быть dict с полем type")
+
+    proxy_ob = dict(proxy_outbound)
+    proxy_ob["tag"] = "proxy-out"
+    srcs = [_norm_src_cidr(s) for s in (source_ips or []) if str(s).strip()]
+    selective = (not route_all) and bool(srcs)
+
+    tun = make_tun_inbound(interface_name=tun_iface, address=tun_address,
+                           mtu=mtu, stack="system", auto_route=True,
+                           strict_route=False, auto_redirect=auto_redirect)
+
+    srv = (proxy_ob.get("server") or "").strip()
+    proxy_doms = [srv] if (srv and not _looks_like_ip(srv)) else []
+
+    rules = [
+        {"action": "sniff"},
+        {"protocol": "dns", "action": "hijack-dns"},
+        {"ip_is_private": True, "outbound": "direct"},
+    ]
+    if reject_quic:
+        rules.append({"network": "udp", "port": 443, "action": "reject"})
+    if selective:
+        rules.append({"source_ip_cidr": srcs, "outbound": "proxy-out"})
+
+    route = {
+        "rules": rules,
+        "final": "proxy-out" if route_all else "direct",
+        "auto_detect_interface": True,
+    }
+    if typed_dns:
+        route["default_domain_resolver"] = {"server": "dns-direct"}
+
+    return {
+        "log": {"level": "info", "timestamp": True},
+        "dns": make_routing_dns(proxy_tag="proxy-out",
+                                proxy_server_domains=proxy_doms,
+                                doh_ip=doh_ip, typed=typed_dns),
+        "inbounds": [tun],
+        "outbounds": [proxy_ob, {"type": "direct", "tag": "direct"}],
+        "route": route,
+        "experimental": {"cache_file": {"enabled": True, "path": "cache.db"}},
+    }
 # Любой другой роняет ВЕСЬ процесс на initialize («unsupported flow: …»).
 # Xray-вариант 'xtls-rprx-vision-udp443' (vision + пропуск UDP/443)
 # для sing-box эквивалентен vision — нормализуем. Легаси-flow

--- a/core/singbox_fakeip.py
+++ b/core/singbox_fakeip.py
@@ -217,3 +217,92 @@ def build_and_save(*, name: str = "fakeip", proxy_link: str = "",
         "warning": warning,
         "warnings": save.get("warnings") or [],
     }
+
+
+# ─────────────────────── lite-route (kernel-стек, low-CPU) ───────────────
+
+def build_lite_route_and_save(*, name: str = "lite-route", proxy_link: str = "",
+                              proxy_config: str = "", source_ips=None,
+                              route_all: bool = False, reject_quic: bool = False,
+                              tun_iface: str = "singbox-tun") -> dict:
+    """
+    Собрать конфиг маршрутизации на KERNEL-стеке (auto_route + system +
+    source_ip_cidr внутри движка) — низкий CPU, без gvisor. См.
+    core.singbox_config.build_system_route_config.
+    """
+    import secrets
+    from core.singbox_config import (
+        build_system_route_config, render_conf, ensure_clash_api)
+    from core.singbox_manager import get_singbox_manager
+    from core.singbox_platform import detect_singbox_platform
+    from core.singbox_detector import get_singbox_detector
+    from core.proxy_tester import _free_port
+
+    name = (name or "lite-route").strip()
+    tun_iface = (tun_iface or "singbox-tun").strip()[:15]
+
+    pr = _resolve_proxy(proxy_link, proxy_config)
+    if not pr.get("ok"):
+        return pr
+    proxy_outbound = pr["outbound"]
+
+    srcs = [str(s).strip() for s in (source_ips or []) if str(s).strip()]
+    if not route_all and not srcs:
+        return {"ok": False,
+                "error": "укажите IP устройств (source_ip) или включите"
+                         " режим «весь трафик»"}
+
+    nft = False
+    try:
+        nft = bool(detect_singbox_platform().supports_nftables())
+    except Exception:
+        pass
+
+    def _mk(typed: bool):
+        cfg = build_system_route_config(
+            proxy_outbound=proxy_outbound, source_ips=srcs,
+            route_all=route_all, tun_iface=tun_iface, typed_dns=typed,
+            reject_quic=reject_quic, auto_redirect=nft)
+        try:
+            ensure_clash_api(cfg, port=_free_port(),
+                             secret=secrets.token_hex(8))
+        except Exception:
+            pass
+        return render_conf(cfg)
+
+    ver = _parse_minor(get_singbox_detector().detect_binary().get("version"))
+    order = [True, False] if ver >= (1, 14) else [False, True]
+
+    mgr = get_singbox_manager()
+    chosen_text, fmt, warning, last_err = None, "", "", ""
+    for typed in order:
+        text = _mk(typed)
+        chk = mgr.check_text(text)
+        if chk.get("no_binary"):
+            chosen_text, fmt = text, ("typed" if typed else "legacy")
+            warning = "sing-box не установлен — конфиг сохранён без проверки"
+            break
+        if chk.get("ok"):
+            chosen_text, fmt = text, ("typed" if typed else "legacy")
+            break
+        last_err = chk.get("error") or last_err
+
+    if chosen_text is None:
+        return {"ok": False,
+                "error": "sing-box отверг сгенерированный конфиг: %s"
+                         % (last_err or "неизвестная ошибка")}
+
+    save = mgr.save_config(name, text=chosen_text)
+    if not save.get("ok"):
+        return {"ok": False, "error": save.get("error")}
+
+    log.info("singbox lite-route: конфиг '%s' создан (формат=%s, source=%d,"
+             " режим=%s, auto_redirect=%s)"
+             % (name, fmt, len(srcs), "всё" if route_all else "выборочно",
+                nft), source="singbox")
+    return {
+        "ok": True, "name": name, "dns_format": fmt, "stack": "system",
+        "route_all": bool(route_all), "sources": len(srcs),
+        "auto_redirect": nft, "warning": warning,
+        "warnings": save.get("warnings") or [],
+    }

--- a/tests/test_singbox_transparent.py
+++ b/tests/test_singbox_transparent.py
@@ -16,6 +16,7 @@ from core.singbox_config import (
     make_hijack_dns_rule, make_tun_inbound, set_tun_inbound,
     find_tun_interface, active_outbound_tag,
     make_routing_dns, collect_proxy_server_domains,
+    build_system_route_config,
 )
 
 
@@ -915,6 +916,54 @@ class TestSbinPath(unittest.TestCase):
                           os.environ["PATH"].split(os.pathsep))
         finally:
             os.environ["PATH"] = orig
+
+
+class TestSystemRouteConfig(unittest.TestCase):
+    """build_system_route_config — kernel-стек (auto_route+system+source_ip)."""
+
+    PROXY = {"type": "hysteria2", "tag": "x", "server": "vpn.example.com",
+             "server_port": 8449, "password": "p",
+             "tls": {"enabled": True, "server_name": "sni"}}
+
+    def test_selective_by_source_ip(self):
+        cfg = build_system_route_config(
+            proxy_outbound=self.PROXY, source_ips=["192.168.1.117"])
+        tun = next(ib for ib in cfg["inbounds"] if ib["type"] == "tun")
+        self.assertTrue(tun["auto_route"])
+        self.assertEqual(tun["stack"], "system")
+        self.assertFalse(tun.get("strict_route"))
+        # source_ip_cidr выбранного устройства → proxy-out
+        self.assertTrue(any(
+            r.get("source_ip_cidr") == ["192.168.1.117/32"]
+            and r.get("outbound") == "proxy-out"
+            for r in cfg["route"]["rules"]))
+        self.assertEqual(cfg["route"]["final"], "direct")
+        # служебные правила и прокси-DNS
+        self.assertIn(make_sniff_rule(), cfg["route"]["rules"])
+        self.assertIn(make_hijack_dns_rule(), cfg["route"]["rules"])
+        self.assertEqual(cfg["dns"]["final"], "dns-proxy")
+        self.assertEqual(cfg["outbounds"][0]["tag"], "proxy-out")
+
+    def test_route_all(self):
+        cfg = build_system_route_config(proxy_outbound=self.PROXY,
+                                        route_all=True)
+        self.assertEqual(cfg["route"]["final"], "proxy-out")
+        self.assertFalse(any("source_ip_cidr" in r
+                             for r in cfg["route"]["rules"]))
+
+    def test_reject_quic_and_typed_resolver(self):
+        cfg = build_system_route_config(
+            proxy_outbound=self.PROXY, source_ips=["10.0.0.5"],
+            reject_quic=True, typed_dns=True)
+        self.assertIn({"network": "udp", "port": 443, "action": "reject"},
+                      cfg["route"]["rules"])
+        self.assertEqual(cfg["route"]["default_domain_resolver"],
+                         {"server": "dns-direct"})
+        # домен прокси-сервера резолвится напрямую (без петли)
+        self.assertTrue(any(
+            r.get("server") == "dns-direct"
+            and "vpn.example.com" in (r.get("domain") or [])
+            for r in cfg["dns"]["rules"]))
 
 
 if __name__ == "__main__":

--- a/web/js/pages/singbox.js
+++ b/web/js/pages/singbox.js
@@ -38,6 +38,12 @@ const SingboxDashboardPage = (() => {
         route_all: false, hostlists: {}, domains: '', cidrs: '',
         direct_dns: 'local', stack: 'system', capture_dns: true,
     };
+    let liteForm = {                 // форма маршрутизации на kernel-стеке
+        name: 'lite-route', proxy_link: '', proxy_config: '',
+        source_ips: '', route_all: false, reject_quic: false,
+    };
+    let liteRendered = false;
+    let liteBusy = false;
 
     // ══════════════ render ══════════════
 
@@ -76,6 +82,13 @@ const SingboxDashboardPage = (() => {
             <div class="card" id="sb-fakeip" style="margin-top:16px;">
                 <div class="card-title">Умный доменный роутинг (FakeIP)</div>
                 <div id="sb-fakeip-body" style="margin-top:8px;">
+                    <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
+                </div>
+            </div>
+
+            <div class="card" id="sb-lite" style="margin-top:16px;">
+                <div class="card-title">Весь трафик через прокси — kernel-стек (ниже CPU)</div>
+                <div id="sb-lite-body" style="margin-top:8px;">
                     <div class="page-loading"><div class="spinner"></div><span>Загрузка...</span></div>
                 </div>
             </div>
@@ -159,6 +172,7 @@ const SingboxDashboardPage = (() => {
         renderSummary();
         renderInstances();
         renderFakeip();
+        renderLiteRoute();
         renderTransparent();
         renderTun();
         renderWatchdog();
@@ -932,6 +946,106 @@ const SingboxDashboardPage = (() => {
         return escapeHtml(s).replace(/"/g, '&quot;');
     }
 
+    // ══════════════ lite-route (kernel-стек, ниже CPU) ══════════════
+
+    function renderLiteRoute() {
+        const body = document.getElementById('sb-lite-body');
+        if (!body) return;
+        if (liteRendered) return;       // не перерисовываем при poll (не теряем ввод)
+        liteRendered = true;
+        const f = liteForm;
+        const cfgs = (fakeipOpts && fakeipOpts.configs) || configs.map(c => c.name);
+        const cfgOpts = ['<option value="">— из ссылки ниже —</option>']
+            .concat((cfgs || []).map(n =>
+                `<option value="${escapeAttr(n)}">${escapeHtml(n)}</option>`))
+            .join('');
+        body.innerHTML = `
+            <p class="text-muted" style="font-size:12px; margin:0 0 8px;">
+                Лёгкий режим: sing-box сам забирает трафик через <b>kernel-стек
+                (system + auto_route)</b> — без gvisor, заметно ниже нагрузка на
+                CPU. Кого слать в прокси решают внутренние правила по
+                <b>source-IP</b>. Откат — просто остановите инстанс (down).
+            </p>
+            <div style="padding:8px 10px; border-radius:6px; margin-bottom:10px;
+                        background:rgba(220,170,60,.12); border:1px solid rgba(220,170,60,.4);
+                        font-size:12px;">
+                ⚠️ Экспериментально на Keenetic: auto_route ставит свои маршруты
+                (может конфликтовать с NDM); на iptables-прошивках перехват
+                ПЕРЕсылаемого трафика LAN-устройств не гарантирован. Если
+                устройство за роутером не заворачивается — используйте обычную
+                выборочную маршрутизацию (gvisor) или маршрут по доменам.
+            </div>
+            <div style="display:grid; grid-template-columns:160px 1fr; gap:8px 12px; max-width:640px; align-items:center;">
+                <label class="text-muted" style="font-size:12px;">Имя конфига</label>
+                <input type="text" class="form-control" style="max-width:220px;"
+                       value="${escapeAttr(f.name)}"
+                       oninput="SingboxDashboardPage.setLite('name', this.value)">
+                <label class="text-muted" style="font-size:12px;">Прокси из конфига</label>
+                <select class="form-control" style="max-width:320px;"
+                        onchange="SingboxDashboardPage.setLite('proxy_config', this.value)">${cfgOpts}</select>
+                <label class="text-muted" style="font-size:12px;">…или ссылка прокси</label>
+                <textarea class="form-control" rows="2" placeholder="vless:// / ss:// / hysteria2:// …"
+                          oninput="SingboxDashboardPage.setLite('proxy_link', this.value)">${escapeHtml(f.proxy_link)}</textarea>
+                <label class="text-muted" style="font-size:12px;">IP устройств (через запятую)</label>
+                <input type="text" class="form-control" placeholder="192.168.1.117, 192.168.1.84"
+                       value="${escapeAttr(f.source_ips)}"
+                       oninput="SingboxDashboardPage.setLite('source_ips', this.value)">
+            </div>
+            <label style="display:flex; align-items:center; gap:8px; margin-top:10px; cursor:pointer;">
+                <input type="checkbox" ${f.route_all ? 'checked' : ''}
+                       onchange="SingboxDashboardPage.setLite('route_all', this.checked)">
+                <span>Весь трафик роутера через прокси (игнорировать список IP)</span>
+            </label>
+            <label style="display:flex; align-items:center; gap:8px; margin-top:6px; cursor:pointer;">
+                <input type="checkbox" ${f.reject_quic ? 'checked' : ''}
+                       onchange="SingboxDashboardPage.setLite('reject_quic', this.checked)">
+                <span>Глушить QUIC (если QUIC через прокси не работает)</span>
+            </label>
+            <div style="margin-top:10px;">
+                <button class="btn btn-primary btn-sm" id="sb-lite-create"
+                        onclick="SingboxDashboardPage.createLiteRoute()">Создать конфиг</button>
+            </div>`;
+    }
+
+    function setLite(key, val) {
+        if (key === 'route_all' || key === 'reject_quic') liteForm[key] = !!val;
+        else liteForm[key] = val;
+    }
+
+    async function createLiteRoute() {
+        if (liteBusy) return;
+        const f = liteForm;
+        if (!f.proxy_link.trim() && !f.proxy_config.trim()) {
+            Toast.error('Укажите прокси (ссылку или конфиг)'); return;
+        }
+        const payload = {
+            name: f.name.trim() || 'lite-route',
+            proxy_link: f.proxy_link.trim(),
+            proxy_config: f.proxy_config.trim(),
+            source_ips: f.source_ips,
+            route_all: f.route_all,
+            reject_quic: f.reject_quic,
+        };
+        liteBusy = true;
+        const btn = document.getElementById('sb-lite-create');
+        if (btn) { btn.disabled = true; btn.textContent = 'Создаём…'; }
+        try {
+            const r = await API.post('/api/singbox/lite-route/build', payload);
+            if (r && r.ok) {
+                Toast.success('Конфиг «' + r.name + '» создан (kernel-стек). '
+                    + 'Запустите его. Маршрут через ip rule НЕ нужен — '
+                    + 'sing-box заберёт трафик сам.');
+                await refresh();
+            } else {
+                Toast.error((r && r.error) || 'ошибка', 12000);
+            }
+        } catch (e) { Toast.error(e.message); }
+        finally {
+            liteBusy = false;
+            if (btn) { btn.disabled = false; btn.textContent = 'Создать конфиг'; }
+        }
+    }
+
     // ══════════════ watchdog (проверка соединения) ══════════════
 
     function renderWatchdog() {
@@ -999,6 +1113,7 @@ const SingboxDashboardPage = (() => {
         up, down, restart,
         toggleDebug, showLog, copyLog,
         setFakeip, toggleFakeipHostlist, createFakeip,
+        setLite, createLiteRoute,
         setTp, applyTransparent, removeTransparent, injectInbounds,
         setTun, createTunInbound,
         saveWatchdog,


### PR DESCRIPTION
…е CPU)

Новый выбираемый способ «весь ПК/устройства через прокси» с низкой нагрузкой на CPU: sing-box сам забирает трафик через kernel system-стек (auto_route), без gvisor, а кого слать в прокси решают внутренние правила source_ip_cidr.

- build_system_route_config(): TUN(auto_route=true, stack=system, strict_route=false) + DNS через прокси (DoH) + sniff/hijack-dns + ip_is_private→direct + (опц.) reject QUIC + source_ip_cidr выбранных устройств → proxy-out (или final=proxy-out при route_all). typed-DNS получает default_domain_resolver (1.14). auto_detect_interface — чтобы direct-выход не зациклился на TUN.
- build_lite_route_and_save() (core/singbox_fakeip): резолв прокси, подбор формата DNS под версию через check, ensure clash_api, save.
- API POST /api/singbox/lite-route/build.
- UI: карточка «Весь трафик через прокси — kernel-стек (ниже CPU)» с выбором прокси, списком source-IP, режимом «весь трафик», глушением QUIC и предупреждением про auto_route/NDM на Keenetic.
- Самодостаточный конфиг (как FakeIP): unified-слой и ip rule не нужны, откат — `down` инстанса (auto_route снимается sing-box'ом сам).

Тесты: build_system_route_config (selective/route_all/reject_quic/typed resolver). Весь набор (1560) зелёный.

https://claude.ai/code/session_01QnRCMpp86iSxo4sURgHkjb