### PR TITLE
singbox: чинит парсинг прокси-ссылок (obfs/транспорты/insecure), отбр…

### DIFF
--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -992,27 +992,48 @@ def make_vmess_outbound(tag: str, server: str, port: int, uuid: str,
 
 
 def make_trojan_outbound(tag: str, server: str, port: int, password: str,
-                         *, sni: str = "",
+                         *, sni: str = "", insecure: bool = False,
+                         alpn=None, fp: str = "",
                          transport: dict = None) -> dict:
-    out = {"type": "trojan", "tag": tag,
-           "server": server, "server_port": int(port), "password": password}
+    tls: dict[str, Any] = {"enabled": True}
     if sni:
-        out["tls"] = {"enabled": True, "server_name": sni}
-    else:
-        out["tls"] = {"enabled": True, "insecure": True}
+        tls["server_name"] = sni
+    # allowInsecure=1 (self-signed сертификат) обязателен, иначе TLS-рукопожатие
+    # падает. Без SNI — почти всегда self-signed/raw, тоже пропускаем проверку
+    # (историческое поведение).
+    if insecure or not sni:
+        tls["insecure"] = True
+    if fp:
+        tls["utls"] = {"enabled": True, "fingerprint": fp}
+    alpn_list = [a for a in (alpn or []) if a]
+    if alpn_list:
+        tls["alpn"] = alpn_list
+    out = {"type": "trojan", "tag": tag,
+           "server": server, "server_port": int(port), "password": password,
+           "tls": tls}
     if transport:
         out["transport"] = transport
     return out
 
 
 def make_shadowsocks_outbound(tag: str, server: str, port: int,
-                              method: str, password: str) -> dict:
-    return {
+                              method: str, password: str,
+                              *, plugin: str = "",
+                              plugin_opts: str = "") -> dict:
+    out = {
         "type": "shadowsocks", "tag": tag,
         "server": server, "server_port": int(port),
         "method": normalize_ss_method(method) or method,
         "password": password,
     }
+    # SIP003-плагин (obfs-local / v2ray-plugin): сервер с плагином НЕ примет
+    # «голый» Shadowsocks — без plugin/plugin_opts соединение установится по
+    # TCP, но прокси работать не будет (рукопожатие плагина не пройдёт).
+    if plugin:
+        out["plugin"] = plugin
+        if plugin_opts:
+            out["plugin_opts"] = plugin_opts
+    return out
 
 
 # Методы Shadowsocks, которые принимает sing-box (только AEAD + 2022).
@@ -1047,23 +1068,34 @@ def normalize_ss_method(method: str) -> str:
 
 def make_hysteria2_outbound(tag: str, server: str, port: int,
                             password: str, *, sni: str = "",
-                            insecure: bool = False) -> dict:
+                            insecure: bool = False,
+                            obfs_password: str = "",
+                            obfs_type: str = "salamander") -> dict:
     tls_opts: dict[str, Any] = {"enabled": True}
     if sni:
         tls_opts["server_name"] = sni
     if insecure:
         tls_opts["insecure"] = True
-    return {
+    out = {
         "type": "hysteria2", "tag": tag,
         "server": server, "server_port": int(port),
         "password": password,
         "tls": tls_opts,
     }
+    # Salamander-обфускация: сервер с `obfs=salamander` НЕ примет соединение
+    # без совпадающего obfs-пароля (QUIC-рукопожатие не пройдёт — «ничего не
+    # открывается, хотя порт жив»). sing-box поддерживает только salamander.
+    if obfs_password:
+        out["obfs"] = {"type": (obfs_type or "salamander"),
+                       "password": obfs_password}
+    return out
 
 
 def make_tuic_outbound(tag: str, server: str, port: int,
                        uuid: str, password: str = "",
-                       *, sni: str = "") -> dict:
+                       *, sni: str = "", alpn=None, insecure: bool = False,
+                       congestion_control: str = "",
+                       udp_relay_mode: str = "") -> dict:
     out = {
         "type": "tuic", "tag": tag,
         "server": server, "server_port": int(port),
@@ -1071,9 +1103,23 @@ def make_tuic_outbound(tag: str, server: str, port: int,
     }
     if password:
         out["password"] = password
-    out["tls"] = {"enabled": True}
+    # congestion_control / udp_relay_mode часто заданы в ссылке и должны
+    # совпадать с сервером (иначе UDP-релей не работает или режется скорость).
+    if congestion_control:
+        out["congestion_control"] = congestion_control
+    if udp_relay_mode:
+        out["udp_relay_mode"] = udp_relay_mode
+    tls: dict[str, Any] = {"enabled": True}
     if sni:
-        out["tls"]["server_name"] = sni
+        tls["server_name"] = sni
+    if insecure:
+        tls["insecure"] = True
+    # TUIC поверх QUIC обычно требует ALPN h3 — без него многие серверы рвут
+    # рукопожатие («connection refused»/timeout, хотя UDP-порт открыт).
+    alpn_list = [a for a in (alpn or []) if a]
+    if alpn_list:
+        tls["alpn"] = alpn_list
+    out["tls"] = tls
     return out
 
 

--- a/core/singbox_subscription.py
+++ b/core/singbox_subscription.py
@@ -48,13 +48,30 @@ def _safe_tag(name: str, fallback: str = "out") -> str:
     return cleaned[:48] or fallback
 
 
+# Транспорты, которых НЕТ в sing-box (специфичны для Xray). Сервер, требующий
+# такой транспорт, sing-box обслужить не может — ссылку надо отбраковывать
+# сразу (как unsupported flow), иначе она молча превратится в «голый TCP» и
+# соединение не заведётся, засоряя пул «как бы рабочими» серверами.
+_XRAY_ONLY_TRANSPORTS = {"xhttp", "splithttp"}
+
+
 def _parse_query(qs: str) -> dict:
     """urlparse.parse_qs, но возвращает первую запись каждого ключа как str."""
     if not qs:
         return {}
     raw = urllib.parse.parse_qs(qs, keep_blank_values=True)
-    return {k.lower(): urllib.parse.unquote(v[0])
-            for k, v in raw.items() if v}
+    out = {}
+    for k, v in raw.items():
+        if not v:
+            continue
+        key = k.lower()
+        # Часть подписок HTML-экранирует разделители (`&` → `&amp;`), из-за
+        # чего ключи приходят как `amp;udp_relay_mode`/`amp;alpn`. Снимаем
+        # префикс, чтобы такие параметры не терялись (TUIC/Hysteria2 и т.п.).
+        if key.startswith("amp;"):
+            key = key[4:]
+        out[key] = urllib.parse.unquote(v[0])
+    return out
 
 
 def _b64_decode_padded(s: str) -> str:
@@ -115,12 +132,21 @@ def vless_to_outbound(uri: str) -> dict:
     # transport
     transport = None
     t_type = q.get("type", "tcp").lower()
+    if t_type in _XRAY_ONLY_TRANSPORTS:
+        return {"ok": False,
+                "error": "transport '%s' не поддерживается sing-box "
+                         "(Xray-only)" % t_type}
     if t_type == "ws":
         transport = {"type": "ws",
                      "path": q.get("path") or "/"}
         host_hdr = q.get("host")
         if host_hdr:
             transport["headers"] = {"Host": host_hdr}
+    elif t_type == "httpupgrade":
+        # sing-box-нативный транспорт (НЕ Xray xhttp). host — отдельное поле.
+        transport = {"type": "httpupgrade", "path": q.get("path") or "/"}
+        if q.get("host"):
+            transport["host"] = q.get("host")
     elif t_type == "grpc":
         transport = {"type": "grpc",
                      "service_name": q.get("servicename") or
@@ -238,10 +264,18 @@ def vmess_to_outbound(uri: str) -> dict:
     host_hdr = _s("host")
     path = _s("path")
     transport = None
+    if net in _XRAY_ONLY_TRANSPORTS:
+        return {"ok": False,
+                "error": "transport '%s' не поддерживается sing-box "
+                         "(Xray-only)" % net}
     if net == "ws":
         transport = {"type": "ws", "path": path or "/"}
         if host_hdr:
             transport["headers"] = {"Host": host_hdr}
+    elif net == "httpupgrade":
+        transport = {"type": "httpupgrade", "path": path or "/"}
+        if host_hdr:
+            transport["host"] = host_hdr
     elif net == "grpc":
         transport = {"type": "grpc", "service_name": path or ""}
     elif net in ("h2", "http"):
@@ -262,6 +296,12 @@ def vmess_to_outbound(uri: str) -> dict:
         alpn = _s("alpn")
         if alpn:
             tls["alpn"] = [a for a in alpn.split(",") if a]
+        # self-signed: некоторые ссылки несут флаг пропуска проверки TLS
+        # (ключ в JSON в разном регистре/написании).
+        low = {str(k).lower(): v for k, v in data.items()}
+        ins = low.get("allowinsecure") or low.get("skip-cert-verify")
+        if str(ins).strip().lower() in ("1", "true", "yes"):
+            tls["insecure"] = True
 
     outbound = make_vmess_outbound(
         tag=tag, server=server, port=port, uuid=uuid,
@@ -293,15 +333,40 @@ def trojan_to_outbound(uri: str) -> dict:
 
     transport = None
     t_type = q.get("type", "tcp").lower()
+    if t_type in _XRAY_ONLY_TRANSPORTS:
+        return {"ok": False,
+                "error": "transport '%s' не поддерживается sing-box "
+                         "(Xray-only)" % t_type}
     if t_type == "ws":
         transport = {"type": "ws", "path": q.get("path") or "/"}
         if q.get("host"):
             transport["headers"] = {"Host": q["host"]}
+    elif t_type == "httpupgrade":
+        transport = {"type": "httpupgrade", "path": q.get("path") or "/"}
+        if q.get("host"):
+            transport["host"] = q["host"]
+    elif t_type == "grpc":
+        transport = {"type": "grpc",
+                     "service_name": q.get("servicename") or
+                                     q.get("service") or ""}
+    elif (q.get("ws") or "").strip() in ("1", "true"):
+        # Trojan-Go-диалект: ws=1&wspath=/path вместо type=ws&path=.
+        transport = {"type": "ws",
+                     "path": q.get("wspath") or q.get("path") or "/"}
+        if q.get("host"):
+            transport["headers"] = {"Host": q["host"]}
 
     sni = q.get("sni") or q.get("peer") or ""
+    # allowInsecure=1 / insecure=1 — self-signed сертификат: без пропуска
+    # проверки TLS-рукопожатие к таким серверам падает. fp/alpn — uTLS-маскировка
+    # и согласование ALPN (как у vless).
+    insecure = (q.get("allowinsecure") or q.get("insecure")
+                or "").strip().lower() in ("1", "true", "yes", "on")
+    fp = q.get("fp", "")
+    alpn = [a for a in (q.get("alpn") or "").split(",") if a]
     outbound = make_trojan_outbound(
         tag=tag, server=server, port=port, password=password,
-        sni=sni, transport=transport)
+        sni=sni, insecure=insecure, alpn=alpn, fp=fp, transport=transport)
     return {"ok": True, "tag": tag, "outbound": outbound}
 
 
@@ -361,11 +426,28 @@ def ss_to_outbound(uri: str) -> dict:
                              % method}
         method = norm
 
+        # SIP003-плагин: ss://...@host:port?plugin=<name>;<opts>. Без него
+        # сервер с обфускацией не открывается (TCP есть, прокси нет).
+        plugin, plugin_opts = "", ""
+        if query:
+            raw_plugin = _parse_query(query).get("plugin") or ""
+            if raw_plugin:
+                name, _, opts = raw_plugin.partition(";")
+                plugin, plugin_opts = name.strip(), opts.strip()
+                if plugin == "simple-obfs":      # алиас → имя sing-box
+                    plugin = "obfs-local"
+                supported = {"obfs-local", "v2ray-plugin", "shadow-tls"}
+                if plugin not in supported:
+                    return {"ok": False,
+                            "error": "ss plugin '%s' не поддерживается "
+                                     "sing-box" % plugin}
+
         tag = _safe_tag(urllib.parse.unquote(frag or "")
                         or "ss-%s" % host)
         outbound = make_shadowsocks_outbound(
             tag=tag, server=host, port=port,
-            method=method, password=password)
+            method=method, password=password,
+            plugin=plugin, plugin_opts=plugin_opts)
         return {"ok": True, "tag": tag, "outbound": outbound}
     except Exception as e:
         return {"ok": False, "error": "ss parse: %s" % e}
@@ -401,9 +483,18 @@ def hysteria2_to_outbound(uri: str) -> dict:
     insecure = (q.get("insecure") or "").strip().lower() in (
         "1", "true", "yes", "on")
 
+    # Salamander-обфускация: без obfs-пароля сервер с obfs не отвечает.
+    obfs_type = (q.get("obfs") or "").strip().lower()
+    obfs_pw = q.get("obfs-password") or q.get("obfs_password") or ""
+    if obfs_type and obfs_type != "salamander":
+        return {"ok": False,
+                "error": "hysteria2 obfs '%s' не поддерживается sing-box "
+                         "(только salamander)" % obfs_type}
+
     outbound = make_hysteria2_outbound(
         tag=tag, server=server, port=port, password=password,
-        sni=sni, insecure=insecure)
+        sni=sni, insecure=insecure,
+        obfs_password=obfs_pw, obfs_type=obfs_type or "salamander")
     return {"ok": True, "tag": tag, "outbound": outbound}
 
 
@@ -435,10 +526,16 @@ def tuic_to_outbound(uri: str) -> dict:
     tag = _safe_tag(urllib.parse.unquote(p.fragment or "")
                     or "tuic-%s" % p.hostname)
     sni = q.get("sni") or ""
+    alpn = [a for a in (q.get("alpn") or "").split(",") if a]
+    insecure = (q.get("allow_insecure") or q.get("insecure")
+                or "").strip().lower() in ("1", "true", "yes", "on")
+    cc = (q.get("congestion_control") or q.get("congestion") or "").strip()
+    urm = (q.get("udp_relay_mode") or "").strip()
 
     outbound = make_tuic_outbound(
         tag=tag, server=p.hostname, port=p.port,
-        uuid=uuid, password=password, sni=sni)
+        uuid=uuid, password=password, sni=sni, alpn=alpn,
+        insecure=insecure, congestion_control=cc, udp_relay_mode=urm)
     return {"ok": True, "tag": tag, "outbound": outbound}
 
 
@@ -523,6 +620,11 @@ def _transport_params(tr: dict) -> dict:
     elif t_type == "grpc":
         if tr.get("service_name"):
             out["serviceName"] = tr["service_name"]
+    elif t_type == "httpupgrade":
+        if tr.get("path"):
+            out["path"] = tr["path"]
+        if tr.get("host"):
+            out["host"] = tr["host"]
     elif t_type in ("http", "h2"):
         if tr.get("path"):
             out["path"] = tr["path"]
@@ -616,6 +718,12 @@ def _trojan_to_uri(ob: dict) -> str:
         params["sni"] = tls["server_name"]
     if tls.get("insecure"):
         params["allowInsecure"] = "1"
+    fp = (tls.get("utls") or {}).get("fingerprint")
+    if fp:
+        params["fp"] = fp
+    if tls.get("alpn"):
+        params["alpn"] = ",".join(tls["alpn"]) if isinstance(
+            tls["alpn"], list) else tls["alpn"]
     return "trojan://%s@%s?%s#%s" % (
         _q(pwd), _fmt_hostport(server, port),
         _build_query(params), _frag(ob.get("tag")))
@@ -626,11 +734,17 @@ def _ss_to_uri(ob: dict) -> str:
     method, pwd = ob.get("method"), ob.get("password")
     if not (server and port and method):
         return ""
-    # SIP002: ss://base64(method:password)@host:port#tag
+    # SIP002: ss://base64(method:password)@host:port[?plugin=...]#tag
     userinfo = base64.b64encode(
         ("%s:%s" % (method, pwd or "")).encode("utf-8")).decode("ascii").rstrip("=")
-    return "ss://%s@%s#%s" % (
-        userinfo, _fmt_hostport(server, port), _frag(ob.get("tag")))
+    query = ""
+    if ob.get("plugin"):
+        pv = ob["plugin"]
+        if ob.get("plugin_opts"):
+            pv = "%s;%s" % (pv, ob["plugin_opts"])
+        query = "?" + _build_query({"plugin": pv})
+    return "ss://%s@%s%s#%s" % (
+        userinfo, _fmt_hostport(server, port), query, _frag(ob.get("tag")))
 
 
 def _hysteria2_to_uri(ob: dict) -> str:
@@ -643,6 +757,10 @@ def _hysteria2_to_uri(ob: dict) -> str:
         params["sni"] = tls["server_name"]
     if tls.get("insecure"):
         params["insecure"] = "1"
+    obfs = ob.get("obfs") or {}
+    if obfs.get("password"):
+        params["obfs"] = obfs.get("type") or "salamander"
+        params["obfs-password"] = obfs["password"]
     return "hysteria2://%s@%s?%s#%s" % (
         _q(pwd), _fmt_hostport(server, port),
         _build_query(params), _frag(ob.get("tag")))
@@ -656,6 +774,15 @@ def _tuic_to_uri(ob: dict) -> str:
     params = {}
     if tls.get("server_name"):
         params["sni"] = tls["server_name"]
+    if tls.get("insecure"):
+        params["allow_insecure"] = "1"
+    if tls.get("alpn"):
+        params["alpn"] = ",".join(tls["alpn"]) if isinstance(
+            tls["alpn"], list) else tls["alpn"]
+    if ob.get("congestion_control"):
+        params["congestion_control"] = ob["congestion_control"]
+    if ob.get("udp_relay_mode"):
+        params["udp_relay_mode"] = ob["udp_relay_mode"]
     userinfo = "%s:%s" % (_q(uuid), _q(ob.get("password") or ""))
     return "tuic://%s@%s?%s#%s" % (
         userinfo, _fmt_hostport(server, port),

--- a/tests/test_singbox_subscription.py
+++ b/tests/test_singbox_subscription.py
@@ -8,7 +8,7 @@ import unittest
 from core.singbox_subscription import (
     uri_to_outbound, vless_to_outbound, vmess_to_outbound,
     trojan_to_outbound, ss_to_outbound, hysteria2_to_outbound,
-    tuic_to_outbound, _safe_tag,
+    tuic_to_outbound, outbound_to_uri, _safe_tag,
 )
 
 # Валидный 32-байтный x25519 public key (reality-ссылки без него отвергаются,
@@ -89,6 +89,27 @@ class TestVmess(unittest.TestCase):
         r = vmess_to_outbound("vmess://!!!not-base64!!!")
         self.assertFalse(r["ok"])
 
+    def test_httpupgrade_transport(self):
+        uri = _vmess_uri({"add": "h", "port": "443", "id": "u",
+                          "net": "httpupgrade", "path": "/up", "host": "cdn.x"})
+        r = vmess_to_outbound(uri)
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["transport"]["type"], "httpupgrade")
+        self.assertEqual(r["outbound"]["transport"]["host"], "cdn.x")
+
+    def test_xhttp_rejected(self):
+        uri = _vmess_uri({"add": "h", "port": "443", "id": "u", "net": "xhttp"})
+        r = vmess_to_outbound(uri)
+        self.assertFalse(r["ok"])
+        self.assertIn("xhttp", r["error"])
+
+    def test_skip_cert_verify(self):
+        uri = _vmess_uri({"add": "h", "port": "443", "id": "u", "net": "tcp",
+                          "tls": "tls", "skip-cert-verify": "true"})
+        r = vmess_to_outbound(uri)
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertTrue(r["outbound"]["tls"]["insecure"])
+
 
 class TestSafeTag(unittest.TestCase):
 
@@ -159,6 +180,25 @@ class TestVless(unittest.TestCase):
         self.assertEqual(r["outbound"]["transport"]["type"], "grpc")
         self.assertEqual(r["outbound"]["transport"]["service_name"], "svc1")
 
+    def test_httpupgrade_transport(self):
+        # httpupgrade — sing-box-нативный транспорт (НЕ Xray xhttp); host —
+        # отдельное поле, не headers.Host.
+        uri = ("vless://uuid@host:443"
+               "?type=httpupgrade&path=%2Fup&host=cdn.example#hu")
+        r = vless_to_outbound(uri)
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        tr = r["outbound"]["transport"]
+        self.assertEqual(tr["type"], "httpupgrade")
+        self.assertEqual(tr["path"], "/up")
+        self.assertEqual(tr["host"], "cdn.example")
+
+    def test_xhttp_rejected(self):
+        # xhttp — транспорт Xray, в sing-box его нет: отбраковываем, иначе
+        # ссылка молча стала бы «голым TCP» и не подключилась.
+        r = vless_to_outbound("vless://uuid@host:443?type=xhttp&path=/x#x")
+        self.assertFalse(r["ok"])
+        self.assertIn("xhttp", r["error"])
+
     def test_missing_uuid(self):
         r = vless_to_outbound("vless://@host:443")
         self.assertFalse(r["ok"])
@@ -182,6 +222,46 @@ class TestTrojan(unittest.TestCase):
             "trojan://pass@host:443?type=ws&path=/p&host=h#tw")
         self.assertTrue(r["ok"])
         self.assertEqual(r["outbound"]["transport"]["type"], "ws")
+
+    def test_grpc_transport(self):
+        r = trojan_to_outbound(
+            "trojan://pass@host:443?type=grpc&serviceName=svc#tg")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["transport"]["type"], "grpc")
+        self.assertEqual(r["outbound"]["transport"]["service_name"], "svc")
+
+    def test_httpupgrade_transport(self):
+        r = trojan_to_outbound(
+            "trojan://pass@host:443?type=httpupgrade&path=/up&host=h#thu")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["transport"]["type"], "httpupgrade")
+
+    def test_xhttp_rejected(self):
+        r = trojan_to_outbound("trojan://pass@host:443?type=splithttp#x")
+        self.assertFalse(r["ok"])
+
+    def test_allow_insecure_and_fp_alpn(self):
+        # allowInsecure=1 (self-signed) + uTLS fp + ALPN — иначе рукопожатие падает.
+        r = trojan_to_outbound("trojan://pass@host:443"
+                              "?sni=h.com&allowInsecure=1&fp=chrome&alpn=h2,http%2F1.1#ti")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        tls = r["outbound"]["tls"]
+        self.assertTrue(tls["insecure"])
+        self.assertEqual(tls["server_name"], "h.com")
+        self.assertEqual(tls["utls"]["fingerprint"], "chrome")
+        self.assertEqual(tls["alpn"], ["h2", "http/1.1"])
+
+    def test_allow_insecure_zero_keeps_strict(self):
+        r = trojan_to_outbound("trojan://pass@host:443?sni=h.com&allowInsecure=0#ts")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertNotIn("insecure", r["outbound"]["tls"])
+
+    def test_trojan_go_ws_dialect(self):
+        # Trojan-Go: ws=1&wspath=/p вместо type=ws&path=.
+        r = trojan_to_outbound("trojan://pass@host:443?sni=h&ws=1&wspath=%2Fassign#tg")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["transport"]["type"], "ws")
+        self.assertEqual(r["outbound"]["transport"]["path"], "/assign")
 
 
 class TestShadowsocks(unittest.TestCase):
@@ -223,6 +303,26 @@ class TestShadowsocks(unittest.TestCase):
         r = ss_to_outbound("ss://aes-256-cfb:pass@host:8388#x")
         self.assertFalse(r["ok"])
 
+    def test_plugin_obfs_local(self):
+        # SIP002 plugin=<name>;<opts> — без него obfs-сервер не открывается.
+        r = ss_to_outbound("ss://YWVzLTEyOC1nY206cGFzcw==@host:8388"
+                           "?plugin=obfs-local%3Bobfs%3Dtls%3Bobfs-host%3Dwww.bing.com#p")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["plugin"], "obfs-local")
+        self.assertEqual(r["outbound"]["plugin_opts"],
+                         "obfs=tls;obfs-host=www.bing.com")
+
+    def test_plugin_simple_obfs_aliased(self):
+        # simple-obfs (Xray/ss-libev) → имя sing-box obfs-local.
+        r = ss_to_outbound("ss://YWVzLTEyOC1nY206cGFzcw==@host:8388"
+                           "?plugin=simple-obfs%3Bobfs%3Dhttp#p")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["plugin"], "obfs-local")
+
+    def test_unknown_plugin_rejected(self):
+        r = ss_to_outbound("ss://YWVzLTEyOC1nY206cGFzcw==@host:8388?plugin=kcptun#p")
+        self.assertFalse(r["ok"])
+
 
 class TestHysteria2(unittest.TestCase):
 
@@ -239,6 +339,24 @@ class TestHysteria2(unittest.TestCase):
         r = hysteria2_to_outbound("hy2://p@h:443?insecure=1#i")
         self.assertTrue(r["ok"])
         self.assertTrue(r["outbound"]["tls"]["insecure"])
+
+    def test_obfs_salamander(self):
+        # Сервер с obfs не отвечает без совпадающего obfs-пароля.
+        r = hysteria2_to_outbound(
+            "hy2://p@h:443?obfs=salamander&obfs-password=sec&sni=h#o")
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["obfs"],
+                         {"type": "salamander", "password": "sec"})
+
+    def test_obfs_unsupported_rejected(self):
+        # sing-box умеет только salamander.
+        r = hysteria2_to_outbound("hy2://p@h:443?obfs=weird&obfs-password=x#o")
+        self.assertFalse(r["ok"])
+
+    def test_no_obfs_no_field(self):
+        r = hysteria2_to_outbound("hy2://p@h:443#n")
+        self.assertTrue(r["ok"])
+        self.assertNotIn("obfs", r["outbound"])
 
 
 class TestTuic(unittest.TestCase):
@@ -258,6 +376,31 @@ class TestTuic(unittest.TestCase):
     def test_missing_uuid(self):
         r = tuic_to_outbound("tuic://@host:443")
         self.assertFalse(r["ok"])
+
+    def test_full_params(self):
+        # alpn/insecure/congestion_control/udp_relay_mode должны попасть в outbound:
+        # многие TUIC-серверы рвут рукопожатие без alpn h3 / self-signed → insecure.
+        uri = ("tuic://87bc1693-8860-41d7-acf4-e6edf49abbbb:pwd@host:443"
+               "?sni=h&alpn=h3&allow_insecure=1"
+               "&congestion_control=bbr&udp_relay_mode=native#t")
+        r = tuic_to_outbound(uri)
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        ob = r["outbound"]
+        self.assertEqual(ob["congestion_control"], "bbr")
+        self.assertEqual(ob["udp_relay_mode"], "native")
+        self.assertTrue(ob["tls"]["insecure"])
+        self.assertEqual(ob["tls"]["alpn"], ["h3"])
+
+    def test_html_escaped_amp_params(self):
+        # Часть подписок HTML-экранирует '&' → '&amp;'; параметры (insecure и
+        # т.п.) не должны теряться, иначе TLS-рукопожатие к self-signed падает.
+        uri = ("tuic://87bc1693-8860-41d7-acf4-e6edf49abbbb:pwd@host:443"
+               "?congestion_control=bbr&amp;udp_relay_mode=native"
+               "&amp;allow_insecure=1#t")
+        r = tuic_to_outbound(uri)
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        self.assertEqual(r["outbound"]["udp_relay_mode"], "native")
+        self.assertTrue(r["outbound"]["tls"]["insecure"])
 
 
 class TestDispatcher(unittest.TestCase):
@@ -285,6 +428,49 @@ class TestDispatcher(unittest.TestCase):
         r = uri_to_outbound("magic://host:1")
         self.assertFalse(r["ok"])
         self.assertIn("не поддержан", r["error"])
+
+
+class TestRoundTrip(unittest.TestCase):
+    """outbound_to_uri → uri_to_outbound сохраняет ключевые поля новых вариантов
+    (нужно для «копировать сервер как ссылку» в UI)."""
+
+    def _rt(self, uri):
+        r = uri_to_outbound(uri)
+        self.assertTrue(r["ok"], msg=r.get("error"))
+        u2 = outbound_to_uri(r["outbound"])
+        self.assertTrue(u2, "outbound_to_uri вернул пусто")
+        r2 = uri_to_outbound(u2)
+        self.assertTrue(r2["ok"], msg=r2.get("error"))
+        return r2["outbound"]
+
+    def test_httpupgrade_roundtrip(self):
+        ob = self._rt("vless://u@h:443?type=httpupgrade&path=%2Fp&host=cdn&security=tls&sni=cdn#x")
+        self.assertEqual(ob["transport"]["type"], "httpupgrade")
+        self.assertEqual(ob["transport"]["host"], "cdn")
+
+    def test_hysteria2_obfs_roundtrip(self):
+        ob = self._rt("hy2://p@h:443?obfs=salamander&obfs-password=sec&sni=h#x")
+        self.assertEqual(ob["obfs"]["password"], "sec")
+        self.assertEqual(ob["obfs"]["type"], "salamander")
+
+    def test_tuic_params_roundtrip(self):
+        ob = self._rt("tuic://87bc1693-8860-41d7-acf4-e6edf49abbbb:pwd@h:443"
+                      "?sni=h&alpn=h3&allow_insecure=1&congestion_control=bbr#x")
+        self.assertEqual(ob["congestion_control"], "bbr")
+        self.assertEqual(ob["tls"]["alpn"], ["h3"])
+        self.assertTrue(ob["tls"]["insecure"])
+
+    def test_ss_plugin_roundtrip(self):
+        ob = self._rt("ss://YWVzLTEyOC1nY206cGFzcw==@h:8388"
+                      "?plugin=obfs-local%3Bobfs%3Dtls#x")
+        self.assertEqual(ob["plugin"], "obfs-local")
+        self.assertEqual(ob["plugin_opts"], "obfs=tls")
+
+    def test_trojan_insecure_fp_roundtrip(self):
+        ob = self._rt("trojan://p@h:443?sni=h&allowInsecure=1&fp=chrome&alpn=h2#x")
+        self.assertTrue(ob["tls"]["insecure"])
+        self.assertEqual(ob["tls"]["utls"]["fingerprint"], "chrome")
+        self.assertEqual(ob["tls"]["alpn"], ["h2"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…аковка xhttp

При тестировании импорта публичных подписок на реальном sing-box 1.13.13 ряд распространённых вариантов ссылок молча давал неработающий конфиг: параметры терялись при парсинге, конфиг проходил `sing-box check`, но соединение не вставало («порт жив, прокси нет»).

core/singbox_subscription.py + core/singbox_config.py:

- transport httpupgrade (vless/vmess/trojan) — sing-box-нативный транспорт, раньше распознавался как «голый TCP» (97 ссылок в тест-списке);
- transport xhttp/splithttp (Xray-only, в sing-box отсутствует) — теперь отбраковывается с понятной ошибкой, а не превращается молча в TCP (476);
- hysteria2 obfs=salamander + obfs-password (20 ссылок); иной obfs — отбраковка;
- tuic alpn / allow_insecure / congestion_control / udp_relay_mode — без них рукопожатие к self-signed / h3-серверам падает;
- shadowsocks SIP003-плагин (obfs-local / v2ray-plugin; simple-obfs→obfs-local; неизвестный плагин — отбраковка);
- trojan allowInsecure / fp(uTLS) / alpn + диалект Trojan-Go ws=1&wspath= (self-signed trojan: 128 ссылок в списке несут insecure);
- vmess skip-cert-verify / allowInsecure → tls.insecure;
- HTML-экранированные подписки (`&amp;` в query) — ключи вида `amp;param` больше не теряются (_parse_query).

Экспортеры outbound→URI обновлены симметрично (round-trip сохраняет obfs/alpn/plugin/insecure/httpupgrade).

Проверено на sing-box 1.13.13: каждый вариант проходит `sing-box check` и round-trip; httpupgrade / hysteria2-obfs / tuic / trojan-insecure подтверждены e2e через loopback (sing-box server ← клиент из парсера). Добавлены юнит-тесты.

https://claude.ai/code/session_018ACMCRkzPDyHGkjUGeQEMd