### PR TITLE
mihomo: чинить import-links (Ctrl+V) для конфигов в pyyaml-формате

### DIFF
--- a/core/mihomo_proxies.py
+++ b/core/mihomo_proxies.py
@@ -188,16 +188,38 @@ def _find_top_key(lines: list, key: str):
 
 
 def _proxies_block_end(lines: list, start: int) -> int:
-    """Индекс конца блока `proxies:` — первый следующий ключ col 0."""
+    """
+    Индекс конца блока `proxies:` — первый следующий КЛЮЧ верхнего уровня
+    (col 0, вида `key:`). Элементы списка в col 0 (`- name: …` — именно так их
+    пишет pyyaml/`dump_yaml`) и комментарии блок НЕ заканчивают: иначе дозапись
+    в pyyaml-конфиг попадала бы между `proxies:` и первым узлом с чужим
+    отступом и ломала YAML (`expected <block end>, but found '-'`).
+    """
     end = len(lines)
     for j in range(start + 1, len(lines)):
         l = lines[j]
         if not l.strip():
             continue
-        if not l[0].isspace() and not l.lstrip().startswith("#"):
+        stripped = l.lstrip()
+        if (not l[0].isspace()
+                and not stripped.startswith("#")
+                and not stripped.startswith("- ")
+                and stripped != "-"):
             return j
         end = j + 1
     return end
+
+
+def _seq_item_indent(lines: list, start: int, end: int):
+    """Отступ элементов `-` блока (start, end) — 0 у pyyaml-стиля, 2 у
+    рукописного. None, если элементов нет (пустой/инлайновый блок)."""
+    for j in range(start + 1, end):
+        s = lines[j].strip()
+        if not s or s.startswith("#"):
+            continue
+        if s.startswith("- ") or s == "-":
+            return len(lines[j]) - len(lines[j].lstrip(" "))
+    return None
 
 
 def append_proxies_text(text: str, new_proxies: list) -> str:
@@ -208,12 +230,11 @@ def append_proxies_text(text: str, new_proxies: list) -> str:
     """
     if not new_proxies:
         return text
-    item_lines = dump_seq(new_proxies, indent=2)
     had_nl = text.endswith("\n") or text == ""
     lines = text.splitlines()
     idx = _find_top_key(lines, "proxies")
     if idx is None:
-        block = ["proxies:"] + item_lines
+        block = ["proxies:"] + dump_seq(new_proxies, indent=2)
         base = "\n".join(lines)
         if base and not base.endswith("\n"):
             base += "\n"
@@ -227,6 +248,10 @@ def append_proxies_text(text: str, new_proxies: list) -> str:
     if inline in ("[]", "~", "null"):
         lines[idx] = "proxies:"
     end = _proxies_block_end(lines, idx)
+    # Отступ новых элементов = отступ существующих (col 0 у pyyaml/dump_yaml,
+    # 2 у рукописных конфигов). Смешение col-0 и indent-2 ломает YAML.
+    indent = _seq_item_indent(lines, idx, end)
+    item_lines = dump_seq(new_proxies, indent=2 if indent is None else indent)
     new_lines = lines[:end] + item_lines + lines[end:]
     out = "\n".join(new_lines)
     return out + "\n" if had_nl else out

--- a/tests/test_mihomo_proxies.py
+++ b/tests/test_mihomo_proxies.py
@@ -256,6 +256,21 @@ class TestMutations(unittest.TestCase):
         back = parse_yaml(out)
         self.assertEqual([p["name"] for p in back["proxies"]], ["C"])
 
+    def test_append_into_pyyaml_col0_block(self):
+        # dump_yaml/pyyaml пишет элементы списка БЕЗ отступа (col-0 «- name»).
+        # Дозапись должна совпасть по отступу и дать валидный YAML, а не
+        # «expected <block end>, but found '-'».
+        base = dump_yaml({
+            "proxies": [{"name": "A", "type": "ss", "server": "1.1.1.1",
+                         "port": 1, "cipher": "aes-128-gcm", "password": "p"}],
+            "rules": ["MATCH,DIRECT"]})
+        out = mp.append_proxies_text(base, [
+            {"name": "B", "type": "ss", "server": "2.2.2.2", "port": 2,
+             "cipher": "aes-128-gcm", "password": "q"}])
+        back = parse_yaml(out)          # не должно бросить ParserError
+        self.assertEqual([p["name"] for p in back["proxies"]], ["A", "B"])
+        self.assertEqual(back["rules"], ["MATCH,DIRECT"])   # rules сохранены
+
     def test_enable_external_controller_text(self):
         out = mp.enable_external_controller_text(
             "mixed-port: 7890\nproxies:\n  - name: a\n",


### PR DESCRIPTION
Найдено при сквозной проверке всех функций mihomo на живых прокси: append_proxies_text ломал YAML, когда блок proxies записан в стиле pyyaml/ dump_yaml (элементы списка БЕЗ отступа, '- name' в колонке 0 — именно так пишет наш генератор маршрутизации). _proxies_block_end обрывал блок на первом же таком элементе, и новый прокси вставлялся между 'proxies:' и первым узлом с чужим отступом → 'expected <block end>, but found -'. Теперь конец блока — только следующий КЛЮЧ верхнего уровня (не элемент '-'), а отступ новых элементов берётся из существующих (col-0 у pyyaml, 2 у рукописных). Импорт ссылок в конфиги, созданные карточками маршрутизации, снова работает.

Проверено вживую (11 живых прокси из публичной подписки): учёт трафика per-proxy (устойчивая нагрузка), url-test группа + watchdog-проба, async тест-job, CRUD/validate/debug/autostart/export/delete-bulk/enable-controller, hysteria2/tuic/mixed конфиги (mihomo -t).