### PR TITLE
unified: geosite/geoip-маршрутизация для AWG-туннелей (nftset interva…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 ## Unreleased — Пул публичных серверов, тестер прокси, vmess, urltest-подписки
 
 ### Добавлено
+- **geosite/geoip-маршрутизация теперь работает и для AWG-туннелей**
+  (единый слой, `core/unified` + `core/routing/domain_rule.py`). Раньше
+  geosite/geoip в маршруте применялись ТОЛЬКО на движках (sing-box нативно
+  через geo-правила); для AWG (и mihomo) они молча пропускались с
+  сообщением «работают только с движком». Теперь для нетуннельных-движков:
+  - **geosite → домены** через тот же dnsmasq + ipset/nftset путь, что и
+    обычные доменные правила (резолв набивает set, трафик маркируется и
+    уходит в туннель);
+  - **geoip → CIDR в nftables interval-set** одним mark-правилом
+    (`ip daddr @set`) — БЕЗ тысяч отдельных `ip rule` (geoip:ru ≈ 22k
+    сетей легли бы намертво в policy-db). На системах без nft (ipset
+    hash:ip не хранит сети) geoip-CIDR в iproute-фолбэке капятся
+    (`_IPROUTE_GEOIP_MAX`) с предупреждением.
+  Проверено сквозь живой AWG-туннель: и geosite-домен, и geoip-CIDR
+  заворачивают трафик в туннель (LAN-клиент виден сервером под tunnel-IP).
+  sing-box по-прежнему использует нативный geo-движок (не дублируем).
+  Тесты: `test_unified_applier` (folding), `test_routing_domain_iproute`
+  (`TestGeoExpansionAndStaticCidrs`).
 - **Скачивание nfqws2 и обновлений zapret-gui через средство обхода +
   выбор версии** (по аналогии с sing-box / AmneziaWG / mihomo). Раньше и
   движок nfqws2 (bol-van/zapret2), и сам веб-интерфейс качались только

--- a/core/routing/domain_rule.py
+++ b/core/routing/domain_rule.py
@@ -118,24 +118,80 @@ def _all_domain_rules():
             if isinstance(r, DomainRoutingRule) and r.enabled]
 
 
-def _expand_rule_domains(rule):
+def _expand_rule(rule):
     """
-    Развернуть geosite:/geoip: алиасы в чистые домены/CIDR.
+    Развернуть geosite:/geoip: алиасы правила в (domains, cidrs).
 
-    Для dnsmasq-пути нас интересуют только домены (CIDR не работают
-    через dnsmasq-ipset-хук). Если в правиле встречается geoip: —
-    он логируется как «не поддержано», но правило не падает.
+    geosite → домены (маршрутизируются через dnsmasq + ipset/nftset),
+    geoip   → CIDR. CIDR кладём статически в тот же interval-set
+    (`_add_static_cidrs_to_sets`) — один mark-rule `ip daddr @set`
+    уже маршрутизирует и IP доменов, и geoip-сети. Это и есть
+    «ipset/nftset + cidr» путь для geoip, без тысяч отдельных `ip rule`.
     """
     from core.routing.alias_resolver import expand_domains as _ex
     expanded = _ex(rule.domains or [])
-    domains = expanded.get("domains") or []
-    if expanded.get("cidrs"):
-        log.warning(
-            "dnsmasq-backend: geoip: в правиле %s даёт %d CIDR — "
-            "dnsmasq их не поддерживает, см. NDMS-режим или CIDR-rule"
-            % (rule.id, len(expanded["cidrs"])),
-            source="routing")
-    return domains
+    return (expanded.get("domains") or [], expanded.get("cidrs") or [])
+
+
+def _expand_rule_domains(rule):
+    """Только домены (для dnsmasq-директив managed-файла)."""
+    return _expand_rule(rule)[0]
+
+
+# geoip в iproute-фолбэке (нет dnsmasq, напр. Keenetic с занятым :53):
+# CIDR кладём напрямую через `ip rule to <cidr>`, но с капом — иначе
+# geoip:ru (~22k сетей) забил бы policy-db десятками тысяч правил.
+_IPROUTE_GEOIP_MAX = 1000
+
+
+def _add_static_cidrs_to_sets(cidrs, set_v4, set_v6, backend) -> int:
+    """
+    Положить статические CIDR (из geoip:) в interval-set backend'а.
+
+    nftset держит сети нативно (`flags interval`) — один набор на тысячи
+    сетей, O(log n) на пакет. ipset hash:ip сети НЕ поддерживает —
+    там geoip-CIDR пропускаются (домены всё равно работают; для
+    полноценного geoip на таких системах нужен nftables).
+    """
+    import ipaddress
+    import subprocess
+    if not cidrs:
+        return 0
+    by_fam = {"v4": [], "v6": []}
+    for c in cidrs:
+        try:
+            net = ipaddress.ip_network(str(c).strip(), strict=False)
+        except (ValueError, TypeError):
+            continue
+        by_fam["v6" if net.version == 6 else "v4"].append(str(net))
+
+    if backend is not nftset_backend:
+        total = len(by_fam["v4"]) + len(by_fam["v6"])
+        if total:
+            log.info("routing: geoip-CIDR (%d) пропущены — ipset hash:ip не "
+                     "хранит сети; для geoip нужен nftables" % total,
+                     source="routing")
+        return 0
+
+    added = 0
+    for fam in ("v4", "v6"):
+        items = by_fam[fam]
+        if not items:
+            continue
+        sset = set_v6 if fam == "v6" else set_v4
+        for i in range(0, len(items), 500):  # батчами — длина argv
+            chunk = items[i:i + 500]
+            r = subprocess.run(
+                ["nft", "add", "element", "inet", nftset_backend.TABLE_NAME,
+                 sset, "{ %s }" % ", ".join(chunk)],
+                capture_output=True, text=True, timeout=15)
+            if r.returncode == 0:
+                added += len(chunk)
+            # overlap/«exists» при повторном apply — не ошибка
+    if added:
+        log.info("routing: geoip — добавлено %d CIDR в nft interval-set"
+                 % added, source="routing")
+    return added
 
 
 def _rebuild_managed_dnsmasq():
@@ -414,13 +470,28 @@ def _apply_domain_via_iproute(rule: DomainRoutingRule) -> dict:
                            " разрешатся и применятся при старте" % ifname}
 
     table = _table_id_for(ifname)
-    domains = _expand_rule_domains(rule)
-    if not domains:
+    domains, geoip_cidrs = _expand_rule(rule)
+    if not domains and not geoip_cidrs:
         return {"ok": False, "error": "после развёртки доменов не осталось"}
 
     added = []          # [[cidr, family], ...] для хранения/снятия
     errors = []
     resolved_total = 0
+
+    def _add_rule(cidr, family):
+        subprocess.run(["ip", family, "rule", "del", "to", cidr,
+                        "lookup", str(table)], capture_output=True, timeout=5)
+        r = subprocess.run(["ip", family, "rule", "add", "to", cidr,
+                            "lookup", str(table),
+                            "priority", str(FWMARK_PRIORITY)],
+                           capture_output=True, text=True, timeout=5)
+        if r.returncode == 0:
+            added.append([cidr, family])
+            return True
+        if "File exists" not in (r.stderr or ""):
+            errors.append("ip rule add %s: %s" % (cidr, (r.stderr or "").strip()))
+        return False
+
     for domain in domains:
         for fam in ("v4", "v6"):
             ips = _resolve_ips(domain, fam)
@@ -432,19 +503,28 @@ def _apply_domain_via_iproute(rule: DomainRoutingRule) -> dict:
                 errors.append("default-route %s table %d" % (family, table))
                 continue
             for ip in ips:
-                cidr = ip + ("/128" if fam == "v6" else "/32")
-                subprocess.run(["ip", family, "rule", "del", "to", cidr,
-                                "lookup", str(table)],
-                               capture_output=True, timeout=5)
-                r = subprocess.run(["ip", family, "rule", "add", "to", cidr,
-                                    "lookup", str(table),
-                                    "priority", str(FWMARK_PRIORITY)],
-                                   capture_output=True, text=True, timeout=5)
-                if r.returncode == 0:
-                    added.append([cidr, family])
-                elif "File exists" not in (r.stderr or ""):
-                    errors.append("ip rule add %s: %s"
-                                  % (cidr, (r.stderr or "").strip()))
+                _add_rule(ip + ("/128" if fam == "v6" else "/32"), family)
+
+    # geoip: без dnsmasq/nft interval-set единственный путь — отдельные
+    # `ip rule` на каждую сеть. Это дорого, поэтому КАПИМ: иначе geoip:ru
+    # (~22k сетей) забил бы policy-db. Большие гео лучше гонять на nft-
+    # системе (там сети идут одним interval-set'ом).
+    if geoip_cidrs:
+        import ipaddress
+        if len(geoip_cidrs) > _IPROUTE_GEOIP_MAX:
+            errors.append("geoip: %d сетей > лимита %d для ip-route бэкенда "
+                          "(нужен nftables) — добавлено первые %d"
+                          % (len(geoip_cidrs), _IPROUTE_GEOIP_MAX,
+                             _IPROUTE_GEOIP_MAX))
+        for c in geoip_cidrs[:_IPROUTE_GEOIP_MAX]:
+            try:
+                net = ipaddress.ip_network(str(c).strip(), strict=False)
+            except (ValueError, TypeError):
+                continue
+            family = "-6" if net.version == 6 else "-4"
+            if not _ensure_table_default(ifname, table, family):
+                continue
+            _add_rule(str(net), family)
 
     if added:
         from core.routing import masquerade
@@ -682,11 +762,19 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
             prepop_domains, set_base_v4, set_base_v6, backend)
         prepop_added = sum(r.get("added", 0) for r in prepop_results)
 
+        # geoip: — статические CIDR кладём прямо в interval-set. Тот же
+        # mark-rule `ip daddr @set` маршрутизирует их наравне с IP доменов,
+        # поэтому отдельных `ip rule` (как у CIDR-правил) не плодим.
+        _exp_domains, geoip_cidrs = _expand_rule(rule)
+        cidr_added = _add_static_cidrs_to_sets(
+            geoip_cidrs, set_base_v4, set_base_v6, backend)
+
         ok = bool(added) and not errors and dn_res.get("ok", True)
         log.info(
             "routing: domain-правило %s применено (iface=%s, %d записей,"
-            " %d ошибок, prepop=%d IP)"
-            % (rule.id, ifname, len(added), len(errors), prepop_added),
+            " %d ошибок, prepop=%d IP, geoip=%d CIDR)"
+            % (rule.id, ifname, len(added), len(errors), prepop_added,
+               cidr_added),
             source="routing",
         )
         return {
@@ -695,6 +783,7 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
             "errors":  errors,
             "backend": kind,
             "dnsmasq": dn_res,
+            "geoip_cidrs_added": cidr_added,
             "prepop":  {"total_ips_added": prepop_added,
                         "per_domain": prepop_results},
         }

--- a/core/unified/applier.py
+++ b/core/unified/applier.py
@@ -98,11 +98,29 @@ def apply_route(route: UnifiedRoute, method: str = None) -> dict:
     skipped = []
 
     if kind in ("awg", "singbox", "mihomo"):
-        res = _apply_tunnel(route, target, domains, cidrs)
-        # geosite/geoip — через конфиг движка (sing-box/mihomo), не iptables.
-        geo = _apply_geo(route, method)
-        if geo.get("skipped"):
-            skipped.append(geo.get("reason", "geosite/geoip пропущены"))
+        # sing-box умеет geosite/geoip нативно (geo_engine → route-правила
+        # движка с его geo-базой). Для AWG (и mihomo — у него нет YAML-
+        # эмиттера geo) заворачиваем geo через dnsmasq + ipset/nftset:
+        # geosite → домены, geoip → CIDR в interval-set — тот же путь, что
+        # у обычных доменов (domain_rule._expand_rule/_add_static_cidrs).
+        geo_native = (kind == "singbox")
+        tun_domains = list(domains)
+        if not geo_native and has_geo:
+            tun_domains += ["geosite:%s" % g
+                            for g in (resolved.get("geosite") or [])]
+            tun_domains += ["geoip:%s" % g
+                            for g in (resolved.get("geoip") or [])]
+        res = _apply_tunnel(route, target, tun_domains, cidrs)
+        if geo_native:
+            geo = _apply_geo(route, method)
+            if geo.get("skipped"):
+                skipped.append(geo.get("reason", "geosite/geoip пропущены"))
+        else:
+            # снять возможный прежний sing-box-инжект и не вводить в
+            # заблуждение «skipped» — geo уже в domain-rule выше.
+            _remove_geo(route)
+            geo = ({"ok": True, "via": "domain-set"} if has_geo
+                   else {"ok": True, "noop": True})
         res["method"] = method
         res["geo"] = geo
         res["skipped_selectors"] = skipped

--- a/tests/test_routing_domain_iproute.py
+++ b/tests/test_routing_domain_iproute.py
@@ -115,5 +115,54 @@ class TestRemoveDomainViaIproute(unittest.TestCase):
         save.assert_called()
 
 
+class TestGeoExpansionAndStaticCidrs(unittest.TestCase):
+    """
+    geosite → домены, geoip → CIDR в interval-set (nft). Проверяем
+    разбор алиасов и раскладку geoip-CIDR по семействам одним набором
+    (без тысяч `ip rule`).
+    """
+
+    def test_expand_rule_splits_domains_and_cidrs(self):
+        rule = DomainRoutingRule(target_iface="awg0",
+                                 domains=["a.com", "geosite:x", "geoip:y"],
+                                 rule_id="u")
+        with mock.patch(
+            "core.routing.alias_resolver.expand_domains",
+            return_value={"domains": ["a.com", "z.com"],
+                          "cidrs": ["1.2.3.0/24", "2001:db8::/32"]}):
+            domains, cidrs = domain_rule._expand_rule(rule)
+        self.assertEqual(domains, ["a.com", "z.com"])
+        self.assertEqual(cidrs, ["1.2.3.0/24", "2001:db8::/32"])
+
+    def test_static_cidrs_go_to_nftset_by_family(self):
+        from core.routing import nftset_backend
+        cmds = []
+
+        def fake_run(args, **kw):
+            cmds.append(list(args))
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            added = domain_rule._add_static_cidrs_to_sets(
+                ["1.2.3.0/24", "2001:db8::/32", "10.0.0.0/8"],
+                "set4", "set6", nftset_backend)
+        self.assertEqual(added, 3)
+        adds = [" ".join(c) for c in cmds if "add" in c and "element" in c]
+        v4 = [a for a in adds if "set4" in a][0]
+        v6 = [a for a in adds if "set6" in a][0]
+        self.assertIn("1.2.3.0/24", v4)
+        self.assertIn("10.0.0.0/8", v4)
+        self.assertIn("2001:db8::/32", v6)
+
+    def test_static_cidrs_skipped_on_ipset_backend(self):
+        from core.routing import ipset_backend
+        # ipset hash:ip не хранит сети — geoip-CIDR пропускаются (0 added).
+        with mock.patch("subprocess.run") as run:
+            added = domain_rule._add_static_cidrs_to_sets(
+                ["1.2.3.0/24"], "s4", "s6", ipset_backend)
+        self.assertEqual(added, 0)
+        run.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_unified_applier.py
+++ b/tests/test_unified_applier.py
@@ -75,12 +75,40 @@ class TestApplyTunnel(unittest.TestCase):
         # cidr-правило не создаётся, а возможный старый — снимается (get_rule None → no remove)
         self.mgr.remove_rule.assert_not_called()
 
-    def test_geosite_skipped(self):
+    def test_geosite_geoip_folded_into_domain_rule_for_awg(self):
+        # Для AWG geosite/geoip больше НЕ пропускаются — заворачиваются в
+        # domain-rule: geosite→домены (dnsmasq+set), geoip→CIDR в interval-
+        # set того же набора. В domains правила должны появиться токены.
         r = UnifiedRoute(name="g", method="awg:awg0",
                          destination=Destination(domains=["a.com"],
-                                                  geosite=["google"]))
+                                                  geosite=["google"],
+                                                  geoip=["ru"]))
         res = apply_route(r)
-        self.assertTrue(res["skipped_selectors"])
+        self.assertTrue(res["ok"])
+        self.assertFalse(any("geosite" in s for s in res["skipped_selectors"]))
+        self.assertEqual(res["geo"].get("via"), "domain-set")
+        dom = next((c.args[0] for c in self.mgr.add_rule.call_args_list
+                    if c.args[0].id == _dom_rule_id(r.id)), None)
+        self.assertIsNotNone(dom)
+        self.assertIn("a.com", dom.domains)
+        self.assertIn("geosite:google", dom.domains)
+        self.assertIn("geoip:ru", dom.domains)
+
+    def test_geosite_not_folded_for_singbox(self):
+        # sing-box обрабатывает geo нативно через движок — в domain-rule
+        # geosite-токены НЕ добавляются (иначе geo поехал бы двумя путями).
+        with mock.patch("core.unified.applier._apply_geo",
+                        return_value={"ok": True, "applied": {}}):
+            r = UnifiedRoute(name="g", method="singbox:tun0",
+                             destination=Destination(domains=["a.com"],
+                                                      geosite=["google"]))
+            res = apply_route(r)
+        self.assertTrue(res["ok"])
+        dom = next((c.args[0] for c in self.mgr.add_rule.call_args_list
+                    if c.args[0].id == _dom_rule_id(r.id)), None)
+        self.assertIsNotNone(dom)
+        self.assertIn("a.com", dom.domains)
+        self.assertNotIn("geosite:google", dom.domains)
 
     def test_tunnel_creates_device_and_dscp_rules(self):
         r = _route("awg:awg0",


### PR DESCRIPTION
…l-set)

Раньше geosite/geoip в едином слое применялись ТОЛЬКО на движках (sing-box нативно), а для AWG/mihomo молча пропускались. При сквозном тесте на реальном железе (AWG-туннель к локальному серверу в netns) подтвердил пробел и закрыл его.

Теперь для не-singbox туннельных методов (AWG, mihomo) geo заворачивается через существующий dnsmasq + ipset/nftset путь:
  * geosite → домены (резолв набивает set, как у обычных доменных правил);
  * geoip   → CIDR прямо в nftables interval-set одним mark-правилом
    (`ip daddr @set`), БЕЗ тысяч отдельных `ip rule` — geoip:ru ≈ 22 678
    сетей легли бы намертво в policy-db. На системах без nft (ipset
    hash:ip сети не хранит) geoip-CIDR в iproute-фолбэке капятся
    (_IPROUTE_GEOIP_MAX) с предупреждением.

sing-box по-прежнему использует нативный geo-движок (geo_engine) — не дублируем. Проверено: и geosite-домен, и geoip-CIDR заворачивают трафик в AWG-туннель (LAN-клиент виден сервером под tunnel-IP).

core/unified/applier.py: фолдинг geosite/geoip в domain-rule для не-движка. core/routing/domain_rule.py: _expand_rule → (domains, cidrs);
  _add_static_cidrs_to_sets (geoip → nft interval-set); iproute-фолбэк
  раскладывает geoip-CIDR с капом.
Тесты: test_unified_applier (folding + sing-box не трогаем), test_routing_domain_iproute (TestGeoExpansionAndStaticCidrs).

https://claude.ai/code/session_011PCxSU6Gu1YFwTXHCLXg5e