### PR TITLE
unified/singbox: geosite/geoip-маршрутизация — разворачивать в domain…

### DIFF
--- a/core/singbox_config.py
+++ b/core/singbox_config.py
@@ -591,27 +591,25 @@ def make_routing_dns(*, proxy_tag: str = "proxy-out",
 
 
 def build_geo_route_rule(outbound_tag: str, *, domains=None,
-                         geosite=None, geoip=None) -> dict:
+                         cidrs=None) -> dict:
     """
-    Собрать route-правило sing-box, отправляющее заданные селекторы в
-    outbound `outbound_tag`. Используется единым слоем для geosite/geoip
-    (их iptables-routing развернуть не может — это нативные концепции
-    движка).
+    Собрать route-правило sing-box: домены (→ `domain_suffix`) и/или CIDR
+    (→ `ip_cidr`) → outbound `outbound_tag`.
 
-    Используем поля sing-box route rule:
-      domain_suffix / geosite / geoip → outbound.
-    Пустые селекторы не добавляются. Возвращает dict-правило.
+    ⚠️ Матчеры `geosite`/`geoip` в route-правилах УДАЛЕНЫ в sing-box 1.12
+    (deprecated с 1.8): конфиг с ними не стартует — FATAL «geosite/geoip
+    database is deprecated in sing-box 1.8.0 and removed in sing-box 1.12.0».
+    Поэтому geosite/geoip-селекторы единого слоя разворачиваются в домены/CIDR
+    (core/routing/alias_resolver) ДО вызова этого хелпера — здесь только
+    валидные на 1.12+ матчеры. Пустые селекторы не добавляются.
     """
     rule = {}
     doms = [str(d).strip().lower() for d in (domains or []) if str(d).strip()]
-    gs = [str(g).strip() for g in (geosite or []) if str(g).strip()]
-    gi = [str(g).strip() for g in (geoip or []) if str(g).strip()]
+    cs = [str(c).strip() for c in (cidrs or []) if str(c).strip()]
     if doms:
         rule["domain_suffix"] = doms
-    if gs:
-        rule["geosite"] = gs
-    if gi:
-        rule["geoip"] = gi
+    if cs:
+        rule["ip_cidr"] = cs
     rule["outbound"] = outbound_tag
     return rule
 

--- a/core/unified/geo_engine.py
+++ b/core/unified/geo_engine.py
@@ -134,15 +134,30 @@ def _inject_singbox(route, config_name, resolved) -> dict:
                 "reason": "в конфиге %s нет прокси-outbound для geo-маршрута"
                           % config_name}
 
+    # geosite/geoip как route-матчеры УДАЛЕНЫ в sing-box 1.12 (FATAL на старте).
+    # Разворачиваем их в домены/CIDR через alias_resolver — тот же путь, что у
+    # OS-routing и AWG, — и строим валидное правило domain_suffix/ip_cidr.
+    from core.routing.alias_resolver import expand_domains
+    tokens = list(resolved.get("domains") or [])
+    tokens += ["geosite:%s" % g for g in (resolved.get("geosite") or [])]
+    tokens += ["geoip:%s" % g for g in (resolved.get("geoip") or [])]
+    exp = expand_domains(tokens)
+    if not exp["domains"] and not exp["cidrs"]:
+        return {"ok": True, "skipped": True,
+                "reason": "geosite/geoip не удалось развернуть в домены/CIDR "
+                          "(нет сети/пустой список) — правило не добавлено"}
+    if exp.get("aliases_failed"):
+        log.warning("unified geo: не развернулись алиасы %s"
+                    % exp["aliases_failed"], source="unified")
+
     # Удаляем прежнее наше правило (по sidecar), затем добавляем новое.
     side = _sidecar()
     prev = side.get(route.id)
     if prev and prev.get("config") == config_name and prev.get("rule"):
         remove_route_rule(cfg, prev["rule"])
 
-    rule = build_geo_route_rule(
-        outbound, domains=resolved.get("domains"),
-        geosite=resolved.get("geosite"), geoip=resolved.get("geoip"))
+    rule = build_geo_route_rule(outbound, domains=exp["domains"],
+                                cidrs=exp["cidrs"])
     add_route_rule(cfg, rule, front=True)
 
     save = mgr.save_config(config_name, text=render_conf(cfg))

--- a/tests/test_unified_geo.py
+++ b/tests/test_unified_geo.py
@@ -12,22 +12,25 @@ from core.unified.model import UnifiedRoute, Destination
 class TestGeoRouteHelpers(unittest.TestCase):
 
     def test_build_rule(self):
+        # geosite/geoip-матчеры удалены в sing-box 1.12 → хелпер принимает уже
+        # развёрнутые домены/CIDR и эмитит ТОЛЬКО domain_suffix/ip_cidr.
         r = sc.build_geo_route_rule("PROXY", domains=["a.com"],
-                                    geosite=["google"], geoip=["ru"])
+                                    cidrs=["1.2.3.0/24"])
         self.assertEqual(r["outbound"], "PROXY")
         self.assertEqual(r["domain_suffix"], ["a.com"])
-        self.assertEqual(r["geosite"], ["google"])
-        self.assertEqual(r["geoip"], ["ru"])
-
-    def test_build_rule_only_geosite(self):
-        r = sc.build_geo_route_rule("P", geosite=["youtube"])
-        self.assertNotIn("domain_suffix", r)
+        self.assertEqual(r["ip_cidr"], ["1.2.3.0/24"])
+        # ключи удалённых матчеров не должны появляться никогда.
+        self.assertNotIn("geosite", r)
         self.assertNotIn("geoip", r)
-        self.assertEqual(r["geosite"], ["youtube"])
+
+    def test_build_rule_only_cidr(self):
+        r = sc.build_geo_route_rule("P", cidrs=["10.0.0.0/8"])
+        self.assertNotIn("domain_suffix", r)
+        self.assertEqual(r["ip_cidr"], ["10.0.0.0/8"])
 
     def test_add_remove_rule(self):
         cfg = {"outbounds": []}
-        rule = sc.build_geo_route_rule("P", geosite=["google"])
+        rule = sc.build_geo_route_rule("P", domains=["google.com"])
         sc.add_route_rule(cfg, rule)
         self.assertEqual(cfg["route"]["rules"][0], rule)
         self.assertTrue(sc.remove_route_rule(cfg, rule))
@@ -121,6 +124,56 @@ class TestApplyGeo(unittest.TestCase):
             res = geo_engine.apply_geo(r, "singbox:tun0")
         self.assertTrue(res["skipped"])
         self.assertIn("не найден", res["reason"])
+
+    def test_singbox_inject_resolves_geo_to_domain_ip(self):
+        # geosite/geoip разворачиваются в domain_suffix/ip_cidr; удалённых в
+        # sing-box 1.12 матчеров в сохранённом конфиге быть не должно.
+        r = self._route(dest={"geosite": ["google"], "geoip": ["ru"]},
+                        method="singbox:tun0")
+        cfg = {"outbounds": [{"type": "vless", "tag": "PROXY"}],
+               "route": {"rules": []}}
+        mgr = mock.Mock()
+        mgr.get_config.return_value = {"ok": True, "parsed": cfg}
+        saved = {}
+        mgr.save_config.side_effect = lambda name, text=None: (
+            saved.update(text=text) or {"ok": True})
+        mgr.is_running.return_value = False
+        with mock.patch("core.unified.geo_engine.locate_singbox_config",
+                        return_value="tun0"), \
+             mock.patch("core.singbox_manager.get_singbox_manager",
+                        return_value=mgr), \
+             mock.patch("core.routing.alias_resolver.expand_domains",
+                        return_value={"domains": ["google.com"],
+                                      "cidrs": ["1.0.0.0/8"],
+                                      "aliases_resolved": [],
+                                      "aliases_failed": []}):
+            res = geo_engine.apply_geo(r, "singbox:tun0")
+        self.assertTrue(res.get("applied"), msg=res)
+        self.assertIn("google.com", saved["text"])
+        self.assertIn("1.0.0.0/8", saved["text"])
+        self.assertNotIn("geosite", saved["text"])
+        self.assertNotIn('"geoip"', saved["text"])
+
+    def test_singbox_inject_skips_when_resolution_empty(self):
+        # Сеть недоступна / пустой результат → не добавляем правило-«ловушку»
+        # без матчеров (иначе завернули бы ВЕСЬ трафик).
+        r = self._route(dest={"geosite": ["google"]}, method="singbox:tun0")
+        cfg = {"outbounds": [{"type": "vless", "tag": "PROXY"}],
+               "route": {"rules": []}}
+        mgr = mock.Mock()
+        mgr.get_config.return_value = {"ok": True, "parsed": cfg}
+        with mock.patch("core.unified.geo_engine.locate_singbox_config",
+                        return_value="tun0"), \
+             mock.patch("core.singbox_manager.get_singbox_manager",
+                        return_value=mgr), \
+             mock.patch("core.routing.alias_resolver.expand_domains",
+                        return_value={"domains": [], "cidrs": [],
+                                      "aliases_resolved": [],
+                                      "aliases_failed": [{"kind": "geosite",
+                                                          "name": "google"}]}):
+            res = geo_engine.apply_geo(r, "singbox:tun0")
+        self.assertTrue(res.get("skipped"))
+        mgr.save_config.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…_suffix/ip_cidr

Матчеры `geosite`/`geoip` в route-правилах sing-box УДАЛЕНЫ в 1.12 (deprecated с 1.8). geo_engine инжектировал их в конфиг через build_geo_route_rule как `{"geosite":[...]}` / `{"geoip":[...]}`, из-за чего на sing-box ≥1.12 ВЕСЬ инстанс падал на старте:

  FATAL initialize router: parse rule[0]: geosite database is deprecated in
  sing-box 1.8.0 and removed in sing-box 1.12.0

То есть любой geosite/geoip-маршрут единого слоя ломал sing-box целиком (проверено на 1.13.13). Обычные домены (`domain_suffix`) работали.

Исправление:
- build_geo_route_rule(outbound, *, domains, cidrs) теперь эмитит ТОЛЬКО валидные на 1.12+ матчеры: domains→domain_suffix, cidrs→ip_cidr (поля geosite/geoip убраны);
- geo_engine._inject_singbox разворачивает geosite→домены и geoip→CIDR через core/routing/alias_resolver.expand_domains (тот же резолвер и путь, что у OS-routing и AWG-геомаршрутов), затем строит правило domain_suffix/ip_cidr. Если развернуть не удалось (нет сети/пустой список) — правило НЕ добавляем (иначе матчер-less правило завернуло бы весь трафик).

Проверено на sing-box 1.13.13: правило проходит `sing-box check` (раньше — FATAL); e2e через TUN — geoip→ip_cidr (по dest-IP) и geosite→domain_suffix (по SNI) корректно заворачивают совпавший трафик в прокси, остальное direct. Тесты в tests/test_unified_geo.py обновлены (domain_suffix/ip_cidr, отсутствие удалённых матчеров, резолв geosite/geoip, guard на пустой результат).

https://claude.ai/code/session_018ACMCRkzPDyHGkjUGeQEMd