### PR TITLE
nfqws2: токенизация multi-flag строк каталога + content-aware ipset +…

### DIFF
--- a/core/asset_importer.py
+++ b/core/asset_importer.py
@@ -246,6 +246,42 @@ def _is_ipset_filename(name: str) -> bool:
     return False
 
 
+# IPv4/IPv6 (+ опциональный CIDR) — для content-детекции ipset-файлов,
+# имя которых не содержит "ipset" (напр. russia-youtube-rtmps.txt — список IP,
+# но подключается через --ipset=, значит обязан лежать в ipset/, а не lists/).
+_IP_LINE_RE = re.compile(
+    r"^(?:\d{1,3}(?:\.\d{1,3}){3}(?:/\d{1,2})?"        # IPv4 [+/CIDR]
+    r"|[0-9A-Fa-f:]*:[0-9A-Fa-f:]+(?:/\d{1,3})?)$"     # IPv6 [+/CIDR]
+)
+
+
+def _content_is_ipset(path: str, sample: int = 40) -> bool:
+    """True, если файл — список IP/CIDR (а не доменов).
+
+    Эвристика по СОДЕРЖИМОМУ (дополняет имя-эвристику `_is_ipset_filename`):
+    среди первых `sample` непустых не-комментарных строк IP-строк строго больше,
+    чем доменных. Нужна, потому что апстрим/каталоги ссылаются на IP-листы с
+    «обычными» именами через --ipset= — без этого они уезжают в lists/ и nfqws2
+    падает с «cannot access ipset file» (см. winws2_*_game_filter).
+    """
+    ip = dom = 0
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                s = line.strip()
+                if not s or s.startswith("#"):
+                    continue
+                if _IP_LINE_RE.match(s):
+                    ip += 1
+                else:
+                    dom += 1
+                if ip + dom >= sample:
+                    break
+    except OSError:
+        return False
+    return ip > dom and ip > 0
+
+
 def _sync_lists_split(src_dir: str, lists_dst: str, ipset_dst: str):
     """
     Разнести содержимое import/lists/ по двум целевым директориям:
@@ -273,7 +309,10 @@ def _sync_lists_split(src_dir: str, lists_dst: str, ipset_dst: str):
         src = os.path.join(src_dir, name)
         if not os.path.isfile(src):
             continue
-        if _is_ipset_filename(name):
+        # ipset если ИМЯ говорит об этом ИЛИ содержимое — список IP/CIDR.
+        # Суперсет: файлы-домены остаются в lists/, IP-листы с «обычными»
+        # именами (russia-youtube-rtmps.txt) корректно уезжают в ipset/.
+        if _is_ipset_filename(name) or _content_is_ipset(src):
             stats, dst_dir = ipset_stats, ipset_dst
         else:
             stats, dst_dir = lists_stats, lists_dst

--- a/core/catalog_loader.py
+++ b/core/catalog_loader.py
@@ -52,7 +52,7 @@ import threading
 from typing import Any, Optional
 
 from core.log_buffer import log
-from core.models import CatalogEntry
+from core.models import CatalogEntry, tokenize_args
 
 
 # WinDivert-специфичные аргументы — фильтруются при парсинге
@@ -669,7 +669,14 @@ class CatalogManager:
         """
         Собрать аргументы nfqws2 из записи каталога.
 
-        Каждая строка args — это один аргумент (--lua-desync=...).
+        Каждая строка args токенизируется в отдельные argv-аргументы
+        (quote-aware), т.к. каталоги (особенно конвертированные winws2-пресеты)
+        кладут НЕСКОЛЬКО флагов в одну строку, напр. цепочку
+        ``--lua-desync=...:strategy=1 --lua-desync=...:strategy=1`` для одного
+        слота circular. Без токенизации такая строка ушла бы в nfqws2 ОДНИМ
+        argv-токеном (hard-ошибка «Invalid port filter» для --filter-tcp или
+        тихая порча для --lua-desync). Кавычки сохраняются — inline-Lua не рвём.
+
         Результат — плоский список строк для передачи в nfqws2.
 
         Args:
@@ -678,7 +685,10 @@ class CatalogManager:
         Returns:
             ['--lua-desync=fake:blob=...', '--lua-desync=multisplit:...']
         """
-        return entry.get_args_list()
+        out: list[str] = []
+        for line in entry.get_args_list():
+            out.extend(tokenize_args(line))
+        return out
 
     @staticmethod
     def resolve_paths_in_args(

--- a/core/models.py
+++ b/core/models.py
@@ -444,6 +444,49 @@ class StrategyScanReport:
 #  INI-каталог стратегий — модель записи
 # ═══════════════════════════════════════════════════════════
 
+def tokenize_args(text: str) -> list[str]:
+    """Разбить строку аргументов nfqws2 на список argv-токенов.
+
+    Разделитель — пробел, НО кавычки (``'``/``"``) группируют: пробел внутри
+    кавычек не разрывает токен. Сами символы кавычек СОХРАНЯЮТСЯ в токене —
+    это критично для inline-Lua в ``--lua-init=``/``--lua-desync=`` (одинарные
+    кавычки там — строковый литерал Lua: ``code='desync.x = 1'`` обязан остаться
+    одним токеном, иначе Lua упадёт).
+
+    Зачем нужно: каталоги (особенно конвертированные winws2-пресеты) кладут
+    несколько флагов в одну строку (``--lua-desync=...:strategy=1 --lua-desync=
+    ...:strategy=1`` — цепочка для одного слота circular). Без токенизации такая
+    строка уходит в nfqws2 ОДНИМ argv-токеном: для ``--filter-tcp=`` это hard-
+    ошибка «Invalid port filter», для ``--lua-desync=`` — тихая порча (значение
+    ``strategy=`` затягивает остаток строки). См. CatalogManager.
+    build_nfqws_args_from_entry и strategy_builder._parse_profile_args.
+
+    argv уходит в nfqws2 списком через subprocess (без shell), поэтому кавычки
+    доходят дословно — повторной интерпретации оболочкой нет.
+    """
+    if not text:
+        return []
+    result: list[str] = []
+    current = ""
+    in_quote = None
+    for char in text:
+        if char in ('"', "'") and in_quote is None:
+            in_quote = char
+            current += char
+        elif char == in_quote:
+            in_quote = None
+            current += char
+        elif char == " " and in_quote is None:
+            if current:
+                result.append(current)
+                current = ""
+        else:
+            current += char
+    if current:
+        result.append(current)
+    return result
+
+
 @dataclass
 class CatalogEntry:
     """

--- a/core/strategy_builder.py
+++ b/core/strategy_builder.py
@@ -444,35 +444,11 @@ class StrategyManager:
         argv уходит в nfqws2 через subprocess списком (без shell), поэтому
         кавычки доходят дословно — повторной интерпретации оболочкой нет.
         """
-        if not args_str:
-            return []
-
-        # Разбиваем по пробелам, не разрывая токен внутри кавычек; сами кавычки
-        # оставляем в токене (см. docstring — нужны для Lua-литералов).
-        result = []
-        current = ""
-        in_quote = None
-
-        for char in args_str:
-            if char in ('"', "'") and in_quote is None:
-                in_quote = char
-                current += char
-                continue
-            elif char == in_quote:
-                in_quote = None
-                current += char
-                continue
-            elif char == ' ' and in_quote is None:
-                if current:
-                    result.append(current)
-                    current = ""
-                continue
-            current += char
-
-        if current:
-            result.append(current)
-
-        return result
+        # Делегируем общей quote-aware токенизации (core.models.tokenize_args):
+        # каталоги (CatalogManager.build_nfqws_args_from_entry) и профили
+        # стратегий разбираются ОДНИМ и тем же протестированным кодом.
+        from core.models import tokenize_args
+        return tokenize_args(args_str)
 
     @staticmethod
     def _compute_list_flags() -> list:

--- a/core/strategy_scanner.py
+++ b/core/strategy_scanner.py
@@ -914,7 +914,7 @@ class StrategyScanner:
         lists_path = cfg.get("zapret", "lists_path",
                              default="/opt/zapret2/lists")
         bin_path = cfg.get("zapret", "bin_path",
-                           default="/opt/zapret2/bin")
+                           default="/opt/zapret2/files/fake")
         ipset_path = cfg.get("zapret", "ipset_path",
                              default="/opt/zapret2/ipset")
 

--- a/import/lists/discord-updates.txt
+++ b/import/lists/discord-updates.txt
@@ -1,0 +1,3 @@
+dl.discordapp.net
+updates.discord.com
+stable.dl2.discordapp.net

--- a/import/lists/googlevideo.txt
+++ b/import/lists/googlevideo.txt
@@ -1,0 +1,1 @@
+googlevideo.com

--- a/import/lists/obsidian.txt
+++ b/import/lists/obsidian.txt
@@ -1,0 +1,1 @@
+obsidian.md

--- a/import/lists/twimg.txt
+++ b/import/lists/twimg.txt
@@ -1,0 +1,1 @@
+twimg.com

--- a/tests/test_asset_importer_classify.py
+++ b/tests/test_asset_importer_classify.py
@@ -1,0 +1,112 @@
+# tests/test_asset_importer_classify.py
+"""Классификация list-файлов на ipset/ vs lists/ при импорте ассетов.
+
+Регрессия (найдено прогоном winws2_*_game_filter через nfqws2 на v1.0.2):
+файл `russia-youtube-rtmps.txt` — это список IP, подключается стратегией через
+`--ipset=lists/russia-youtube-rtmps.txt` (резолвится в <base>/ipset/), но его
+имя НЕ содержит "ipset", поэтому старая чисто-именная эвристика клала его в
+<base>/lists/ → nfqws2 падал: «cannot access ipset file …/ipset/…».
+
+Чинит content-aware классификация (_content_is_ipset): ipset, если ИМЯ говорит
+об этом ИЛИ содержимое — список IP/CIDR. Суперсет: доменные списки остаются в
+lists/, IP-листы с «обычными» именами уезжают в ipset/.
+
+Плюс инвариант целостности: все list/ipset-файлы, на которые ссылаются
+каталоги, реально лежат в bundled import/lists/ (ловит «забыли положить файл»
+без бинарника — как пропавшие googlevideo/discord-updates/obsidian/twimg).
+"""
+
+import os
+import re
+import tempfile
+import unittest
+
+from core import asset_importer as ai
+from core.config_manager import init_config
+from core.catalog_loader import get_catalog_manager
+
+_APP = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_IMPORT_LISTS = os.path.join(_APP, "import", "lists")
+
+
+class TestContentIsIpset(unittest.TestCase):
+
+    def _write(self, text):
+        fd, p = tempfile.mkstemp(suffix=".txt")
+        os.write(fd, text.encode())
+        os.close(fd)
+        self.addCleanup(os.unlink, p)
+        return p
+
+    def test_ipv4_list_is_ipset(self):
+        p = self._write("64.233.161.134\n142.250.0.0/16\n# comment\n8.8.8.8\n")
+        self.assertTrue(ai._content_is_ipset(p))
+
+    def test_ipv6_list_is_ipset(self):
+        p = self._write("2001:4860:4860::8888\n2606:4700::/32\n")
+        self.assertTrue(ai._content_is_ipset(p))
+
+    def test_domain_list_is_not_ipset(self):
+        p = self._write("youtube.com\nyoutubekids.com\nggpht.com\n")
+        self.assertFalse(ai._content_is_ipset(p))
+
+
+class TestSyncListsSplitClassification(unittest.TestCase):
+    """IP-файл с не-ipset именем уезжает в ipset/, доменный — в lists/."""
+
+    def test_ip_file_without_ipset_name_goes_to_ipset(self):
+        src = tempfile.mkdtemp()
+        lists_dst = tempfile.mkdtemp()
+        ipset_dst = tempfile.mkdtemp()
+        for d in (src, lists_dst, ipset_dst):
+            self.addCleanup(_rmtree, d)
+
+        with open(os.path.join(src, "russia-youtube-rtmps.txt"), "w") as f:
+            f.write("64.233.161.134\n64.233.162.134\n")
+        with open(os.path.join(src, "youtube.txt"), "w") as f:
+            f.write("youtube.com\nggpht.com\n")
+
+        ai._sync_lists_split(src, lists_dst=lists_dst, ipset_dst=ipset_dst)
+
+        self.assertTrue(
+            os.path.isfile(os.path.join(ipset_dst, "russia-youtube-rtmps.txt")),
+            "IP-список должен попасть в ipset/")
+        self.assertFalse(
+            os.path.isfile(os.path.join(lists_dst, "russia-youtube-rtmps.txt")),
+            "IP-список НЕ должен попасть в lists/")
+        self.assertTrue(
+            os.path.isfile(os.path.join(lists_dst, "youtube.txt")),
+            "доменный список должен попасть в lists/")
+
+
+class TestCatalogListRefsBundled(unittest.TestCase):
+    """Все --hostlist/--ipset=lists/<file> из каталогов лежат в import/lists/."""
+
+    _REF = re.compile(
+        r"^--(?:hostlist|hostlist-exclude|hostlist-auto|ipset|ipset-exclude)"
+        r"=lists/(.+)$")
+
+    def test_all_referenced_list_files_present(self):
+        init_config()
+        cache = get_catalog_manager().load_all()
+        bundled = set(os.listdir(_IMPORT_LISTS))
+        missing = set()
+        for key in cache:
+            for e in cache[key]:
+                for line in e.get_args_list():
+                    for tok in line.split():
+                        m = self._REF.match(tok)
+                        if m and m.group(1) not in bundled:
+                            missing.add(m.group(1))
+        self.assertEqual(sorted(missing), [],
+                         "каталоги ссылаются на не-bundled list-файлы: %r"
+                         % sorted(missing))
+
+
+def _rmtree(path):
+    import shutil
+    shutil.rmtree(path, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_catalog_argv_tokenize.py
+++ b/tests/test_catalog_argv_tokenize.py
@@ -1,0 +1,113 @@
+# tests/test_catalog_argv_tokenize.py
+"""Каталожные строки с несколькими флагами токенизируются в отдельные argv.
+
+Регрессия (найдено прогоном всех стратегий через nfqws2 --intercept=0 на
+реальном бинарнике v1.0.2): конвертированные winws2-пресеты и z2k-пресеты
+кладут НЕСКОЛЬКО флагов в одну строку каталога, напр.:
+
+    --filter-tcp=80,443 --filter-l7=tls,http --ipcache-hostname=1 ...
+    --lua-desync=send:...:strategy=1 --lua-desync=syndata:...:strategy=1
+
+Раньше CatalogManager.build_nfqws_args_from_entry возвращал каждую СТРОКУ как
+один argv-токен (split только по '\\n'). В результате nfqws2 получал, напр.,
+``--filter-tcp=80,443 --filter-l7=...`` ОДНИМ токеном → hard-ошибка
+«Invalid port filter» (z2k_all_in_one/z2k_tls_circular_smart), а цепочки
+``--lua-desync=...:strategy=N`` тихо схлопывались (значение strategy=
+затягивало остаток строки) — тихий 0% у ~47 строк winws2-пресетов.
+
+Чинит core.models.tokenize_args (quote-aware), которым теперь пользуются и
+build_nfqws_args_from_entry, и strategy_builder._parse_profile_args.
+"""
+
+import unittest
+
+from core.models import CatalogEntry, tokenize_args
+from core.catalog_loader import CatalogManager, get_catalog_manager
+from core.config_manager import init_config
+
+
+class TestTokenizeArgs(unittest.TestCase):
+
+    def test_multi_flag_line_split(self):
+        self.assertEqual(
+            tokenize_args("--filter-tcp=80,443 --filter-l7=tls,http "
+                          "--ipcache-hostname=1"),
+            ["--filter-tcp=80,443", "--filter-l7=tls,http",
+             "--ipcache-hostname=1"],
+        )
+
+    def test_lua_desync_chain_split(self):
+        self.assertEqual(
+            tokenize_args("--lua-desync=send:repeats=2:strategy=1 "
+                          "--lua-desync=syndata:blob=stun_pat:strategy=1"),
+            ["--lua-desync=send:repeats=2:strategy=1",
+             "--lua-desync=syndata:blob=stun_pat:strategy=1"],
+        )
+
+    def test_quoted_inline_lua_kept_as_one_token(self):
+        # Пробел внутри кавычек НЕ разрывает токен — иначе Lua-литерал ломается.
+        self.assertEqual(
+            tokenize_args("--lua-desync=luaexec:code='desync.x = brandom(3)'"),
+            ["--lua-desync=luaexec:code='desync.x = brandom(3)'"],
+        )
+
+    def test_empty(self):
+        self.assertEqual(tokenize_args(""), [])
+        self.assertEqual(tokenize_args(None), [])
+
+
+class TestBuildNfqwsArgsFromEntry(unittest.TestCase):
+
+    def test_entry_multiflag_line_is_tokenized(self):
+        e = CatalogEntry(
+            section_id="x",
+            args="--filter-tcp=80,443 --filter-l7=tls,http\n"
+                 "--lua-desync=fake:strategy=1 --lua-desync=multisplit:strategy=1",
+        )
+        out = CatalogManager.build_nfqws_args_from_entry(e)
+        self.assertEqual(out, [
+            "--filter-tcp=80,443",
+            "--filter-l7=tls,http",
+            "--lua-desync=fake:strategy=1",
+            "--lua-desync=multisplit:strategy=1",
+        ])
+
+
+class TestAllCatalogsTokenizedAtomic(unittest.TestCase):
+    """Инвариант по ВСЕМ каталогам: каждый argv-токен — атомарный.
+
+    Атомарность = повторная токенизация токена возвращает его же. Это ловит
+    любую «склейку» несколько-флагов-в-токене (в т.ч. с --filter-tcp, где
+    nfqws2 падает hard-ошибкой) для всего каталога разом, без бинарника.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        init_config()
+        cls.cache = get_catalog_manager().load_all()
+
+    def test_no_multiflag_token_in_any_entry(self):
+        offenders = []
+        for key in self.cache:
+            for e in self.cache[key]:
+                for tok in CatalogManager.build_nfqws_args_from_entry(e):
+                    if tokenize_args(tok) != [tok]:
+                        offenders.append((key, e.section_id, tok[:80]))
+        self.assertEqual(offenders, [], "не-атомарные токены: %r" % offenders[:5])
+
+    def test_filter_port_tokens_have_no_space(self):
+        # --filter-tcp=/--filter-udp= значение не должно содержать пробел
+        # (иначе nfqws2: «Invalid port filter»).
+        bad = []
+        for key in self.cache:
+            for e in self.cache[key]:
+                for tok in CatalogManager.build_nfqws_args_from_entry(e):
+                    if (tok.startswith("--filter-tcp=")
+                            or tok.startswith("--filter-udp=")):
+                        if " " in tok:
+                            bad.append((key, e.section_id, tok[:80]))
+        self.assertEqual(bad, [], "port-фильтр с пробелом: %r" % bad[:5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
… недостающие hostlist'ы

Найдено и проверено прогоном ВСЕХ 1836 стратегий каталога через настоящий бинарник nfqws2 v1.0.2 (--intercept=0) + анализом модификации пакетов через tcpdump на живом трафике (multisplit/fake/multidisorder реально режут и инжектят пакеты на проводе; production-путь build_nfqws_args→compose_command тоже проверен end-to-end).

Исправлено:
- CatalogManager.build_nfqws_args_from_entry теперь токенизирует каждую строку каталога (quote-aware, общий core.models.tokenize_args). Конвертированные winws2/z2k пресеты кладут несколько флагов в одну строку (--lua-desync=...:strategy=1 --lua-desync=...:strategy=1 — цепочка для одного слота circular). Раньше строка уходила в nfqws2 ОДНИМ argv-токеном → hard-ошибка «Invalid port filter» (z2k_all_in_one/z2k_tls_circular_smart) и ТИХАЯ порча ~47 цепочек lua-desync в winws2-пресетах (значение strategy= затягивало остаток строки → тихий 0%). strategy_builder._parse_profile_args переведён на тот же tokenize_args (DRY).
- asset_importer: классификация lists/ vs ipset/ стала content-aware (_content_is_ipset). russia-youtube-rtmps.txt — список IP, подключается через --ipset=, но имя без "ipset" → раньше уезжал в lists/ и nfqws2 падал «cannot access ipset file». Суперсет: доменные списки остаются в lists/, IP-листы с «обычными» именами уезжают в ipset/.
- strategy_scanner: исправлен дефолт bin_path /opt/zapret2/bin → /opt/zapret2/files/fake (расходился с strategy_builder/diagnostics/config; при отсутствии ключа в конфиге @bin/ резолвился в несуществующий путь → пустые fake → тихий 0%).
- import/lists: добавлены недостающие hostlist'ы, на которые ссылается winws2_default_v1_game_filter: googlevideo.txt, twimg.txt, obsidian.txt, discord-updates.txt (без них nfqws2 падал «cannot access hostlist file»).

Тесты: test_catalog_argv_tokenize (инвариант «каждый argv-токен атомарен» по всем каталогам; --filter-tcp/udp без пробелов), test_asset_importer_classify (content-детекция ipset; все list/ipset-ссылки лежат в import/lists). Полный прогон: 1749 тестов OK.


Claude-Session: https://claude.ai/code/session_01Xu3kL45SvZQACaZ1vS1cio