### PR TITLE
Релизы: apk-пакет для нового OpenWrt (24.10+/25.x), ipk сохранён

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,11 @@
 # Версия берётся из тега — core/version.py синхронизируется автоматически.
 #
 # Артефакты релиза:
-#   zapret-gui-X.Y.Z-keenetic.ipk  — для Keenetic / Entware
-#   zapret-gui-X.Y.Z-openwrt.ipk   — для OpenWrt
-#   zapret-gui-X.Y.Z-linux.tar.gz  — универсальный архив для Linux
+#   zapret-gui-keenetic.ipk  — для Keenetic / Entware (opkg)
+#   zapret-gui-entware.ipk   — для роутеров с Entware (opkg)
+#   zapret-gui-openwrt.ipk   — для OpenWrt ≤23.05 (opkg)
+#   zapret-gui-openwrt.apk   — для нового OpenWrt 24.10+/25.x (apk-tools 3)
+#   zapret-gui-linux.tar.gz  — универсальный архив для Linux
 # ═══════════════════════════════════════════════════════════════
 
 name: Build & Release
@@ -97,6 +99,19 @@ jobs:
       - name: Build OpenWrt ipk
         run: make openwrt-ipk
 
+      # Новый OpenWrt (24.10+/25.x) ставит пакеты через apk (apk-tools 3),
+      # формат APKv3. Собираем той же командой `apk mkpkg`, что и штатная
+      # build-система OpenWrt. apk-tools 3 в ubuntu нет — берём apk.static из
+      # Alpine edge и собираем внутри контейнера (root → файлы пакета root:root).
+      - name: Build OpenWrt apk (apk-tools 3, via Alpine edge)
+        run: |
+          docker run --rm -v "$PWD":/work -w /work alpine:edge sh -eu -c '
+            apk add --no-cache apk-tools-static make python3 >/dev/null
+            make openwrt-apk APK=apk.static
+          '
+          echo "── Собранный apk ──"
+          ls -lh dist/*_openwrt.apk
+
       - name: Create Linux archive
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -124,6 +139,7 @@ jobs:
           cp "dist/${PKG_NAME}_${VERSION}-1_all.ipk"     "release-artifacts/${PKG_NAME}-keenetic.ipk"
           cp "dist/${PKG_NAME}_${VERSION}-1_all.ipk"     "release-artifacts/${PKG_NAME}-entware.ipk"
           cp "dist/${PKG_NAME}_${VERSION}-1_openwrt.ipk" "release-artifacts/${PKG_NAME}-openwrt.ipk"
+          cp "dist/${PKG_NAME}_${VERSION}-1_openwrt.apk" "release-artifacts/${PKG_NAME}-openwrt.apk"
           cp "/tmp/${PKG_NAME}-${VERSION}-linux.tar.gz"  "release-artifacts/${PKG_NAME}-linux.tar.gz"
 
           echo "── Артефакты релиза ──"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## Unreleased — Пул публичных серверов, тестер прокси, vmess, urltest-подписки
 
 ### Добавлено
+- **apk-пакет для нового OpenWrt (24.10+/25.x) в релизах** (`Makefile`,
+  `.github/workflows/release.yml`, `README.md`). Новые версии OpenWrt перешли
+  с opkg (`.ipk`) на apk (`.apk`, формат APKv3), и старый `.ipk` там не
+  ставится. Теперь релиз собирает **оба** формата:
+  - `zapret-gui-openwrt.ipk` — для OpenWrt ≤ 23.05 (opkg), как раньше;
+  - `zapret-gui-openwrt.apk` — для OpenWrt 24.10+/25.x
+    (`apk add --allow-untrusted ./zapret-gui-openwrt.apk`).
+  Совместимость со старыми OpenWrt, Keenetic/Entware (`.ipk`) и Linux
+  (`.tar.gz`) полностью сохранена — добавлен только новый артефакт.
+  `make openwrt-apk` собирает пакет той же командой `apk mkpkg`, что и штатная
+  build-система OpenWrt (`include/package-pack.mk`): маппинг сопровождающих
+  скриптов postinst→post-install, prerm→pre-deinstall, `arch:noarch`. В CI
+  пакет собирается внутри `alpine:edge` (`apk.static` из apk-tools 3, файлы
+  пакета — root:root).
 - **Установка модулей ядра NFQUEUE для OpenWrt — прямо из GUI, без консоли**
   (`core/kmod_manager.py`, `api/diagnostics.py`, `web/js/pages/diagnostics.js`).
   На стоковом OpenWrt модуль `nfnetlink_queue` в прошивку не входит — без него

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 #
 # Использование:
 #   make ipk          — собрать ipk-пакет для Entware
-#   make openwrt-ipk  — собрать ipk-пакет для OpenWrt
+#   make openwrt-ipk  — собрать ipk-пакет для OpenWrt (старые, opkg)
+#   make openwrt-apk  — собрать apk-пакет для нового OpenWrt (24.10+/25.x,
+#                       apk-tools 3; передайте APK=apk.static при отсутствии apk)
 #   make release      — создать git-тег и запустить релиз
 #   make clean        — очистить артефакты сборки
 #   make lint         — проверка синтаксиса Python
@@ -48,7 +50,8 @@ EXCLUDE      := --exclude='__pycache__' --exclude='*.pyc' --exclude='*.pyo' \
 # Цели
 # ═══════════════════════════════════════════════════════════════
 
-.PHONY: all ipk openwrt-ipk clean _clean_build lint info help release tag
+.PHONY: all ipk openwrt-ipk openwrt-apk clean _clean_build lint info help release tag \
+        _prepare_apk_scripts _build_apk_openwrt
 
 all: ipk
 
@@ -57,7 +60,8 @@ help:
 	@echo "  Zapret Web-GUI — Makefile"
 	@echo "  ─────────────────────────"
 	@echo "  make ipk          — собрать ipk для Entware"
-	@echo "  make openwrt-ipk  — собрать ipk для OpenWrt"
+	@echo "  make openwrt-ipk  — собрать ipk для OpenWrt (старые, opkg)"
+	@echo "  make openwrt-apk  — собрать apk для нового OpenWrt (apk-tools 3; APK=apk.static)"
 	@echo "  make release VERSION=X.Y.Z — обновить версию, создать тег и запустить релиз"
 	@echo "  make clean        — очистить build/ и dist/"
 	@echo "  make lint         — проверка синтаксиса Python"
@@ -244,6 +248,62 @@ _build_ipk_openwrt:
 		./debian-binary ./control.tar.gz ./data.tar.gz
 
 	@echo "Сборка ipk (OpenWrt): OK"
+
+# ── Сборка apk для НОВОГО OpenWrt (24.10+/25.x, apk-tools 3) ──
+#
+# Новые OpenWrt перешли с opkg (.ipk) на apk (.apk, формат APKv3). Пакет
+# собирается той же командой `apk mkpkg`, что и штатный build-система OpenWrt
+# (include/package-pack.mk): маппинг сопровождающих скриптов postinst →
+# post-install, prerm → pre-deinstall; arch=noarch для arch-независимого пакета.
+#
+# Требуется apk-tools 3 (`apk mkpkg`). В PATH обычно нет — задайте APK=apk.static
+# (напр. из alpine:edge `apk add apk-tools-static`), как это делает CI. Файловое
+# дерево берём тем же `_prepare_data_openwrt`, что и для ipk — один источник.
+#
+# Старый OpenWrt/Entware/Keenetic по-прежнему обслуживаются целями ipk —
+# ничего не ломаем.
+APK          ?= apk
+FAKEROOT     ?=
+APK_VERSION  := $(PKG_VERSION)-r$(PKG_RELEASE)
+APK_SCRIPTS  := $(BUILD_DIR)/apk-scripts
+APK_OUT      := $(DIST_DIR)/$(PKG_NAME)_$(PKG_VERSION)-$(PKG_RELEASE)_openwrt.apk
+
+openwrt-apk: _clean_build _prepare_data_openwrt _prepare_apk_scripts _build_apk_openwrt
+	@echo ""
+	@echo "✓ OpenWrt apk собран: $(APK_OUT)"
+	@ls -lh $(APK_OUT)
+	@echo ""
+
+_prepare_apk_scripts:
+	@echo "── Подготовка apk-скриптов ──"
+	@mkdir -p $(APK_SCRIPTS)
+	# apk lifecycle: postinst → post-install, prerm → pre-deinstall
+	@cp packaging/openwrt/postinst $(APK_SCRIPTS)/post-install
+	@cp packaging/openwrt/prerm    $(APK_SCRIPTS)/pre-deinstall
+	@chmod 755 $(APK_SCRIPTS)/post-install $(APK_SCRIPTS)/pre-deinstall
+	@echo "Подготовка apk-скриптов: OK"
+
+_build_apk_openwrt:
+	@echo "── Сборка apk (OpenWrt) через '$(APK) mkpkg' ──"
+	@mkdir -p $(DIST_DIR)
+	@command -v $(APK) >/dev/null 2>&1 || { \
+		echo "ОШИБКА: '$(APK)' не найден. Нужен apk-tools 3 (apk mkpkg)."; \
+		echo "  Локально/CI: возьмите apk.static из alpine:edge и передайте APK=apk.static"; \
+		exit 1; }
+	SOURCE_DATE_EPOCH=0 $(FAKEROOT) $(APK) mkpkg \
+		--info "name:$(PKG_NAME)" \
+		--info "version:$(APK_VERSION)" \
+		--info "description:Web GUI for managing zapret2/nfqws2 DPI bypass tool" \
+		--info "arch:noarch" \
+		--info "origin:$(PKG_NAME)" \
+		--info "url:https://github.com/avatarDD/zapret-gui" \
+		--info "maintainer:avatarDD <https://github.com/avatarDD/zapret-gui>" \
+		--info "depends:python3-light" \
+		--script "post-install:$(APK_SCRIPTS)/post-install" \
+		--script "pre-deinstall:$(APK_SCRIPTS)/pre-deinstall" \
+		--files "$(DATA_DIR)" \
+		--output "$(APK_OUT)"
+	@echo "Сборка apk (OpenWrt): OK"
 
 # ── Очистка ───────────────────────────────────────────────────
 clean:

--- a/README.md
+++ b/README.md
@@ -103,12 +103,24 @@ opkg install zapret-gui-entware.ipk
 /opt/etc/init.d/S99zapret-gui start
 ```
 
-**OpenWrt:**
+**OpenWrt (старые версии, ≤ 23.05 — opkg):**
 ```bash
 wget https://github.com/avatarDD/zapret-gui/releases/latest/download/zapret-gui-openwrt.ipk
 opkg install zapret-gui-openwrt.ipk
 /etc/init.d/zapret-gui start
 ```
+
+**OpenWrt (новые версии, 24.10+ / 25.x — apk):**
+```bash
+wget https://github.com/avatarDD/zapret-gui/releases/latest/download/zapret-gui-openwrt.apk
+apk add --allow-untrusted ./zapret-gui-openwrt.apk
+/etc/init.d/zapret-gui start
+```
+> Новые OpenWrt перешли с opkg на apk. Пакет `.apk` не подписан ключами
+> репозитория, поэтому нужен флаг `--allow-untrusted` (обычная практика для
+> локальных `.apk`), а имя файла — с `./`, чтобы apk взял именно файл, а не
+> искал пакет в репозитории. Не уверены, opkg у вас или apk? Проверьте:
+> `command -v apk || command -v opkg`.
 
 **Linux (tar.gz):**
 ```bash


### PR DESCRIPTION
Новые версии OpenWrt перешли с opkg (.ipk) на apk (.apk, формат APKv3), и старый .ipk там не ставится. Добавлен второй артефакт релиза; все существующие форматы (ipk для старого OpenWrt/Keenetic/Entware, tar.gz для Linux) сохранены без изменений.

- Makefile: цель openwrt-apk собирает пакет командой `apk mkpkg` (apk-tools 3), один в один как штатная build-система OpenWrt (include/package-pack.mk): маппинг postinst→post-install, prerm→pre-deinstall, arch:noarch, depends: python3-light. Файловое дерево берётся тем же _prepare_data_openwrt, что и для ipk (один источник). APK-бинарь настраивается (APK=apk.static).
- release.yml: новый шаг собирает apk внутри alpine:edge (apk.static из apk-tools-static, файлы пакета root:root) и публикует стабильный артефакт zapret-gui-openwrt.apk рядом с zapret-gui-openwrt.ipk.
- README: инструкция установки для нового OpenWrt (apk add --allow-untrusted ./zapret-gui-openwrt.apk), старый opkg-путь оставлен для ≤23.05.

Проверено локально: apk собран apk.static 3.0.6 и успешно установлен в тестовый root (657 файлов, init-скрипт 755, root:root); ipk-цели и lint не затронуты.


Claude-Session: https://claude.ai/code/session_01BkmfFZ72m5cqvgmxtNEYym