### PR TITLE
Fix Bottle import failures on Entware/OpenWrt python3-light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -623,6 +623,34 @@
   - Entware-init при неудачном старте показывает **последние строки лога
     сервера** (`/tmp/zapret-gui-server.log`), чтобы причина (напр.
     `ModuleNotFoundError`) была видна сразу, а не пряталась за «FAILED».
+- **«Bottle не найден» на `python3-light`, хотя `vendor/bottle.py` на месте**
+  (`app.py`, `core/bottle_vendor.py`, `install.sh`, `packaging/*`,
+  `Makefile`, issue #231, продолжение). После установки `urllib`/`ssl`
+  пользователь всё равно упирался в `ОШИБКА: Bottle не найден (нет ни
+  системного, ни vendor/bottle.py)` — и переустановка не помогала. Причина:
+  встроенный `bottle.py` на верхнем уровне делает `from unicodedata import
+  normalize`, а `unicodedata` (C-расширение) **не входит в `python3-light`
+  и лежит в отдельном пакете `python3-codecs`** (проверено по фиду
+  bin.entware.net; это единственный недостающий модуль bottle помимо
+  `urllib`/`email`). Файл `vendor/bottle.py` при этом на диске есть, но
+  `import bottle` падает с `ModuleNotFoundError: No module named
+  'unicodedata'` — а `app.py` ловил ЛЮБОЙ `ImportError` и печатал
+  «нет vendor/bottle.py», уводя диагностику в сторону. Теперь:
+  - `app.py` различает «самого bottle нет» и «bottle есть, но не хватает
+    stdlib-модуля X» и печатает **точное имя модуля и пакет** для установки
+    (`opkg install python3-codecs` / `apk add …`), а не общее «Bottle не
+    найден»;
+  - `install.sh` после копирования файлов **реально импортирует** встроенный
+    bottle и, если не хватает модуля, доставляет нужный пакет по карте
+    `модуль→пакет` (`unicodedata`→`python3-codecs`, `ssl`/`hashlib`→
+    `python3-openssl`, …), а не по наивному `python3-<модуль>` (пакета
+    `python3-unicodedata` не существует);
+  - `.ipk`/`.apk` теперь объявляют зависимости `python3-urllib`,
+    `python3-openssl`, `python3-codecs`, `python3-email` (control-файлы и
+    `apk mkpkg --info depends`), поэтому opkg/apk доставляют их **сами** при
+    установке пакета;
+  - postinst и Entware-init (`check`) проверяют bottle **импортом**, а не
+    наличием файла, и при провале называют модуль и пакет.
 - **dnsmasq не стартовал из-за ложного детекта nftset → ронял DNS и
   domain-роутинг** (`core/routing/dnsmasq_integration.py`,
   `core/routing/domain_rule.py`). `supports_nftset()` делал

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ _build_apk_openwrt:
 		--info "origin:$(PKG_NAME)" \
 		--info "url:https://github.com/avatarDD/zapret-gui" \
 		--info "maintainer:avatarDD <https://github.com/avatarDD/zapret-gui>" \
-		--info "depends:python3-light" \
+		--info "depends:python3-light python3-urllib python3-openssl python3-codecs python3-email" \
 		--script "post-install:$(APK_SCRIPTS)/post-install" \
 		--script "pre-deinstall:$(APK_SCRIPTS)/pre-deinstall" \
 		--files "$(DATA_DIR)" \

--- a/app.py
+++ b/app.py
@@ -28,10 +28,33 @@ try:
     # Поднимаем лимит тела запроса (дефолт 100 KB): импорт бэкапа и
     # крупные blob/конфиг-POST'ы могут быть больше.
     _bottle.BaseRequest.MEMFILE_MAX = 16 * 1024 * 1024
-except ImportError:
-    print("ОШИБКА: Bottle не найден (нет ни системного, ни vendor/bottle.py).")
-    print("  Копия проекта неполная? Переустановите zapret-gui")
-    print("  или поставьте вручную: opkg install python3-bottle / pip3 install bottle")
+except ImportError as e:
+    # Различаем два случая (issue #231):
+    #  1) самого bottle нет (неполная копия проекта);
+    #  2) bottle НА МЕСТЕ, но ему не хватает stdlib-модуля Python — на
+    #     Entware/OpenWrt стандартная библиотека разбита на пакеты, и в
+    #     python3-light может не быть, например, `unicodedata`. Тогда
+    #     файл vendor/bottle.py существует, но `import bottle` падает с
+    #     ModuleNotFoundError по ЧУЖОМУ модулю. Раньше это маскировалось
+    #     под «Bottle не найден», и переустановка не помогала.
+    missing = getattr(e, "name", None) or ""
+    have_vendor = False
+    try:
+        from core.bottle_vendor import vendored_bottle_path, stdlib_pkg_for
+        have_vendor = os.path.isfile(vendored_bottle_path())
+    except Exception:
+        stdlib_pkg_for = None
+
+    if missing and missing != "bottle" and (have_vendor or stdlib_pkg_for):
+        pkg = stdlib_pkg_for(missing) if stdlib_pkg_for else "python3-" + missing.split(".")[0]
+        print("ОШИБКА: Bottle установлен, но Python не может его загрузить —")
+        print("  не хватает модуля стандартной библиотеки: '%s'." % missing)
+        print("  На Entware/OpenWrt доустановите пакет и перезапустите:")
+        print("    opkg install %s   (или: apk add %s — OpenWrt 24.10+)" % (pkg, pkg))
+    else:
+        print("ОШИБКА: Bottle не найден (нет ни системного, ни vendor/bottle.py).")
+        print("  Копия проекта неполная? Переустановите zapret-gui")
+        print("  или поставьте вручную: opkg install python3-bottle / pip3 install bottle")
     sys.exit(1)
 
 

--- a/core/bottle_vendor.py
+++ b/core/bottle_vendor.py
@@ -64,3 +64,45 @@ def is_vendored(bottle_module) -> bool:
         return os.path.dirname(os.path.abspath(path)) == VENDOR_DIR
     except Exception:
         return False
+
+
+# На Entware/OpenWrt стандартная библиотека Python разбита на пакеты
+# (python3-light + отдельные python3-*). Для большинства модулей имя пакета —
+# `python3-<модуль>`, но у ряда C-расширений имя пакета НЕ совпадает с именем
+# модуля: например, `unicodedata` лежит в `python3-codecs`, а `ssl`/`hashlib`
+# — в `python3-openssl`. Именно `unicodedata` (bottle: `from unicodedata
+# import normalize`) отсутствует в python3-light и валит старт веб-сервера
+# (issue #231). Карта проверена по фиду bin.entware.net (совпадает с OpenWrt).
+_STDLIB_PKG_OVERRIDES = {
+    "ssl": "python3-openssl",
+    "_ssl": "python3-openssl",
+    "hashlib": "python3-openssl",
+    "_hashlib": "python3-openssl",
+    "unicodedata": "python3-codecs",
+    "_multibytecodec": "python3-codecs",
+    "decimal": "python3-decimal",
+    "_decimal": "python3-decimal",
+    "ctypes": "python3-ctypes",
+    "_ctypes": "python3-ctypes",
+    "lzma": "python3-lzma",
+    "_lzma": "python3-lzma",
+    "sqlite3": "python3-sqlite3",
+    "_sqlite3": "python3-sqlite3",
+    "curses": "python3-ncurses",
+    "_curses": "python3-ncurses",
+    "readline": "python3-readline",
+}
+
+
+def stdlib_pkg_for(module: str) -> str:
+    """opkg/apk-пакет Entware/OpenWrt для stdlib-модуля Python.
+
+    `email.utils` → `python3-email`, `urllib.parse` → `python3-urllib`,
+    `unicodedata` → `python3-codecs`, `ssl` → `python3-openssl`. Для
+    остальных модулей — `python3-<top-level>` (на Entware/OpenWrt так
+    называется большинство под-пакетов).
+    """
+    top = (module or "").split(".", 1)[0]
+    return _STDLIB_PKG_OVERRIDES.get(module) \
+        or _STDLIB_PKG_OVERRIDES.get(top) \
+        or ("python3-" + top if top else "")

--- a/core/version.py
+++ b/core/version.py
@@ -6,4 +6,4 @@
     from core.version import GUI_VERSION
 """
 
-GUI_VERSION = "0.22.26"
+GUI_VERSION = "0.22.27"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ set -e
 
 REPO_URL="https://github.com/avatarDD/zapret-gui"
 BRANCH="${ZAPRET_GUI_BRANCH:-main}"
-VERSION="0.22.26"
+VERSION="0.22.27"
 
 GUI_PORT="${ZAPRET_GUI_PORT:-8080}"
 GUI_HOST="${ZAPRET_GUI_HOST:-0.0.0.0}"
@@ -160,6 +160,36 @@ download() {
 
 OPKG_INSTALLED_LIST=""
 
+# `opkg/apk update` дорого — выполняем один раз за запуск (шарим между
+# ensure_python_stdlib и ensure_bottle_deps).
+_STDLIB_UPDATED=0
+
+# opkg/apk-пакет Entware/OpenWrt для stdlib-модуля Python. У большинства
+# модулей имя пакета — `python3-<модуль>`, но у ряда C-расширений оно НЕ
+# совпадает: `unicodedata` → python3-codecs, `ssl`/`hashlib` → python3-openssl.
+# Карта проверена по фиду bin.entware.net (совпадает с OpenWrt). Имя модуля
+# может быть с точкой (`urllib.parse`) — берём верхний уровень.
+_py_stdlib_pkg() {
+    case "${1%%.*}" in
+        ssl|_ssl|hashlib|_hashlib)     echo "python3-openssl" ;;
+        unicodedata|_multibytecodec)   echo "python3-codecs" ;;
+        decimal|_decimal)              echo "python3-decimal" ;;
+        ctypes|_ctypes)                echo "python3-ctypes" ;;
+        lzma|_lzma)                    echo "python3-lzma" ;;
+        sqlite3|_sqlite3)              echo "python3-sqlite3" ;;
+        curses|_curses)                echo "python3-ncurses" ;;
+        readline)                      echo "python3-readline" ;;
+        *)                             echo "python3-${1%%.*}" ;;
+    esac
+}
+
+# Записать имя установленного пакета для симметричного удаления при uninstall.
+_record_installed_pkg() {
+    [ -n "$CONFIG_DIR" ] || return 0
+    mkdir -p "$CONFIG_DIR" 2>/dev/null
+    echo "$1" >> "$CONFIG_DIR/opkg_installed.list"
+}
+
 _opkg_install_pkg() {
     local pkg="$1"
     # apk использует `apk add`, opkg — `opkg install`.
@@ -192,7 +222,7 @@ ensure_python_stdlib() {
     #   ssl    → python3-openssl  (HTTPS: без него не стартует download_transport)
     _PY_STDLIB_PAIRS="urllib:python3-urllib ssl:python3-openssl"
 
-    local missing="" pair mod pkg updated=0
+    local missing="" pair mod pkg
     for pair in $_PY_STDLIB_PAIRS; do
         mod="${pair%%:*}"
         pkg="${pair##*:}"
@@ -200,17 +230,13 @@ ensure_python_stdlib() {
             ok "python3 stdlib: $mod"
         else
             info "  Python-модуль '$mod' отсутствует → устанавливаем $pkg"
-            [ "$updated" = "0" ] && { $PKG_CMD update 2>/dev/null || true; updated=1; }
+            [ "$_STDLIB_UPDATED" = "0" ] && { $PKG_CMD update 2>/dev/null || true; _STDLIB_UPDATED=1; }
             if [ "$PKG_CMD" = "apk" ]; then
                 $PKG_CMD add "$pkg" 2>/dev/null || warn "  Не удалось установить $pkg"
             else
                 $PKG_CMD install "$pkg" 2>/dev/null || warn "  Не удалось установить $pkg"
             fi
-            # Записываем для симметричного удаления при uninstall.
-            if [ -n "$CONFIG_DIR" ]; then
-                mkdir -p "$CONFIG_DIR" 2>/dev/null
-                echo "$pkg" >> "$CONFIG_DIR/opkg_installed.list"
-            fi
+            _record_installed_pkg "$pkg"
             python3 -c "import $mod" >/dev/null 2>&1 && ok "python3 stdlib: $mod" \
                 || missing="$missing $mod:$pkg"
         fi
@@ -224,6 +250,70 @@ ensure_python_stdlib() {
         for pair in $missing; do
             warn "  $PKG_CMD $_verb ${pair##*:}"
         done
+    fi
+}
+
+# Наличия файла vendor/bottle.py НЕ достаточно: на Entware/OpenWrt Python
+# разбит на пакеты, и bottle тянет submodule'ы (`unicodedata`, `email`, ...),
+# которых в python3-light может не быть. Тогда файл на месте, но `import
+# bottle` падает с ModuleNotFoundError по ЧУЖОМУ модулю, и сервер не
+# стартует — а сообщение выглядит как «Bottle не найден» (issue #231).
+# Поэтому реально ИМПОРТИРУЕМ встроенный bottle и доставляем то, чего не
+# хватает, по имени отсутствующего модуля.
+_bottle_missing_module() {
+    # Печатает имя недостающего модуля (или пусто, если bottle импортируется).
+    PYTHONPATH="$1" python3 - <<'PY' 2>/dev/null
+try:
+    import bottle  # noqa: F401
+except ModuleNotFoundError as e:
+    print(e.name or "")
+except ImportError as e:
+    print(getattr(e, "name", "") or "")
+PY
+}
+
+ensure_bottle_deps() {
+    local vendor_dir="$1"
+    [ -f "$vendor_dir/bottle.py" ] || return 0
+    # Системный bottle имеет приоритет — если он импортируется, vendored не нужен.
+    python3 -c "import bottle" >/dev/null 2>&1 && return 0
+
+    # На обычном Linux stdlib цельная — доставлять нечего, только предупредим.
+    if [ "$PKG_CMD" != "opkg" ] && [ "$PKG_CMD" != "apk" ]; then
+        [ -z "$(_bottle_missing_module "$vendor_dir")" ] \
+            || warn "Встроенный bottle не импортируется — проверьте установку Python"
+        return 0
+    fi
+
+    local attempt=0 mod pkg prev_mod=""
+    while [ "$attempt" -lt 12 ]; do
+        attempt=$((attempt + 1))
+        mod="$(_bottle_missing_module "$vendor_dir")"
+        [ -z "$mod" ] && { ok "python3: встроенный bottle импортируется"; return 0; }
+        # 'bottle' здесь не появится (файл проверен выше), но на всякий случай.
+        [ "$mod" = "bottle" ] && return 0
+        # Тот же модуль после установки — пакет не помог (неверный фид/имя):
+        # выходим, чтобы не ставить одно и то же по кругу.
+        [ "$mod" = "$prev_mod" ] && break
+        prev_mod="$mod"
+
+        pkg="$(_py_stdlib_pkg "$mod")"
+        info "  Bottle требует модуль '$mod' → устанавливаем $pkg"
+        [ "$_STDLIB_UPDATED" = "0" ] && { $PKG_CMD update 2>/dev/null || true; _STDLIB_UPDATED=1; }
+        if [ "$PKG_CMD" = "apk" ]; then
+            $PKG_CMD add "$pkg" 2>/dev/null || { warn "  Не удалось установить $pkg"; break; }
+        else
+            $PKG_CMD install "$pkg" 2>/dev/null || { warn "  Не удалось установить $pkg"; break; }
+        fi
+        _record_installed_pkg "$pkg"
+    done
+
+    # Финальная проверка — если всё ещё не импортируется, явно скажем что и как.
+    mod="$(_bottle_missing_module "$vendor_dir")"
+    if [ -n "$mod" ] && [ "$mod" != "bottle" ]; then
+        local _verb="install"; [ "$PKG_CMD" = "apk" ] && _verb="add"
+        warn "Встроенный bottle не импортируется: не хватает модуля Python '$mod'."
+        warn "Веб-интерфейс не запустится. Доустановите: $PKG_CMD $_verb $(_py_stdlib_pkg "$mod")"
     fi
 }
 
@@ -398,6 +488,11 @@ install_from_github() {
             $SUDO cp -r "$src_dir/$dir" "$APP_DIR/"
         fi
     done
+
+    # Убеждаемся, что встроенный bottle реально импортируется на этой
+    # системе (на Entware/OpenWrt доставляем недостающие python3-*-пакеты).
+    # Файл vendor/bottle.py только что скопирован — проверяем именно его.
+    ensure_bottle_deps "$APP_DIR/vendor"
 
     # Создаём рабочие директории
     $SUDO mkdir -p "$APP_DIR/init.d"

--- a/packaging/entware/S99zapret-gui
+++ b/packaging/entware/S99zapret-gui
@@ -90,6 +90,14 @@ start() {
         return 0
     else
         echo "ОШИБКА: $DESC не удалось запустить. Смотрите $LOG_FILE"
+        # Показываем причину падения — иначе пользователь видит только
+        # «не удалось запустить» без подсказки (напр. не хватает модуля
+        # Python на Entware, issue #231).
+        if [ -s "$LOG_FILE" ]; then
+            echo "--- последние строки $LOG_FILE ---"
+            tail -n 15 "$LOG_FILE"
+            echo "----------------------------------"
+        fi
         rm -f "$PID_FILE"
         return 1
     fi
@@ -167,14 +175,35 @@ check() {
         OK=false
     fi
 
-    # Bottle: системный либо встроенный (vendor/)
+    # Bottle: системный либо встроенный (vendor/). Наличия файла мало —
+    # реально импортируем (issue #231: без python3-codecs bottle не
+    # грузится из-за unicodedata, а файл при этом на месте).
     if python3 -c "import bottle; print('  ✓ bottle', bottle.__version__, '(системный)')" 2>/dev/null; then
         true
-    elif [ -f "$APP_DIR/vendor/bottle.py" ]; then
-        echo "  ✓ bottle: встроенный (vendor/)"
-    else
+    elif [ ! -f "$APP_DIR/vendor/bottle.py" ]; then
         echo "  ✗ bottle не найден (ни системный, ни vendor/)"
         OK=false
+    else
+        _CHK_MISS=$(PYTHONPATH="$APP_DIR/vendor" python3 - <<'PY' 2>/dev/null
+try:
+    import bottle  # noqa: F401
+except ModuleNotFoundError as e:
+    print(e.name or "")
+except ImportError as e:
+    print(getattr(e, "name", "") or "")
+PY
+)
+        if [ -z "$_CHK_MISS" ]; then
+            echo "  ✓ bottle: встроенный (vendor/)"
+        else
+            _CHK_PKG="python3-${_CHK_MISS%%.*}"
+            case "${_CHK_MISS%%.*}" in
+                ssl|_ssl|hashlib|_hashlib)   _CHK_PKG="python3-openssl" ;;
+                unicodedata|_multibytecodec) _CHK_PKG="python3-codecs" ;;
+            esac
+            echo "  ✗ bottle на месте, но не хватает модуля '$_CHK_MISS' (opkg install $_CHK_PKG)"
+            OK=false
+        fi
     fi
 
     # App files

--- a/packaging/entware/control
+++ b/packaging/entware/control
@@ -8,6 +8,6 @@ Description: Web GUI for managing zapret2/nfqws2 DPI bypass tool on Entware rout
  Dark theme, mobile-friendly SPA interface.
 Section: net
 Priority: optional
-Depends: python3-light
+Depends: python3-light, python3-urllib, python3-openssl, python3-codecs, python3-email
 Installed-Size: @SIZE@
 Source: https://github.com/avatarDD/zapret-gui

--- a/packaging/entware/postinst
+++ b/packaging/entware/postinst
@@ -100,13 +100,41 @@ fi
 
 # 8. Bottle встроен в пакет (vendor/bottle.py) — сетевая установка не
 #    нужна. Системный python3-bottle, если стоит, имеет приоритет.
+#    ВАЖНО: наличия файла недостаточно — bottle тянет `unicodedata` и др.
+#    submodule'ы, которых нет в python3-light (issue #231). Реально
+#    импортируем встроенный bottle; недостающие пакеты (python3-codecs,
+#    python3-urllib, python3-openssl, python3-email) opkg ставит сам по
+#    Depends, но если импорт всё же падает — покажем точную причину.
+_bottle_missing_module() {
+    PYTHONPATH="$APP_DIR/vendor" python3 - <<'PY' 2>/dev/null
+try:
+    import bottle  # noqa: F401
+except ModuleNotFoundError as e:
+    print(e.name or "")
+except ImportError as e:
+    print(getattr(e, "name", "") or "")
+PY
+}
+_py_pkg_for() {
+    case "${1%%.*}" in
+        ssl|_ssl|hashlib|_hashlib)   echo "python3-openssl" ;;
+        unicodedata|_multibytecodec) echo "python3-codecs" ;;
+        *)                           echo "python3-${1%%.*}" ;;
+    esac
+}
 if python3 -c "import bottle" 2>/dev/null; then
     echo "  ✓ bottle: системный"
-elif [ -f "$APP_DIR/vendor/bottle.py" ]; then
-    echo "  ✓ bottle: встроенный (vendor/)"
-else
+elif [ ! -f "$APP_DIR/vendor/bottle.py" ]; then
     echo "  ⚠ bottle не найден (нет ни системного, ни $APP_DIR/vendor/bottle.py)"
     echo "  Установите вручную: opkg install python3-bottle"
+else
+    _MISS="$(_bottle_missing_module)"
+    if [ -z "$_MISS" ]; then
+        echo "  ✓ bottle: встроенный (vendor/)"
+    else
+        echo "  ⚠ bottle на месте, но не хватает модуля Python '$_MISS'"
+        echo "    доустановите: opkg install $(_py_pkg_for "$_MISS")"
+    fi
 fi
 
 echo ""

--- a/packaging/openwrt/control
+++ b/packaging/openwrt/control
@@ -7,6 +7,6 @@ Description: Web GUI for managing zapret2/nfqws2 DPI bypass tool.
  real-time logs, autostart and /etc/hosts management.
 Section: net
 Priority: optional
-Depends: python3-light
+Depends: python3-light, python3-urllib, python3-openssl, python3-codecs, python3-email
 Installed-Size: @SIZE@
 Source: https://github.com/avatarDD/zapret-gui

--- a/packaging/openwrt/postinst
+++ b/packaging/openwrt/postinst
@@ -85,14 +85,40 @@ if [ -n "$WAS_RUNNING" ]; then
         || echo "  ⚠ Не удалось запустить"
 fi
 
-# Bottle встроен в пакет (vendor/bottle.py) — сетевая установка не
-# нужна. Системный python3-bottle, если стоит, имеет приоритет.
+# Bottle встроен в пакет (vendor/bottle.py). Наличия файла недостаточно:
+# bottle тянет `unicodedata` и др. submodule'ы, которых нет в python3-light
+# (issue #231). Недостающие пакеты (python3-codecs/urllib/openssl/email)
+# ставятся по Depends, но если импорт всё же падает — покажем причину.
+_bottle_missing_module() {
+    PYTHONPATH="$APP_DIR/vendor" python3 - <<'PY' 2>/dev/null
+try:
+    import bottle  # noqa: F401
+except ModuleNotFoundError as e:
+    print(e.name or "")
+except ImportError as e:
+    print(getattr(e, "name", "") or "")
+PY
+}
+_py_pkg_for() {
+    case "${1%%.*}" in
+        ssl|_ssl|hashlib|_hashlib)   echo "python3-openssl" ;;
+        unicodedata|_multibytecodec) echo "python3-codecs" ;;
+        *)                           echo "python3-${1%%.*}" ;;
+    esac
+}
 if python3 -c "import bottle" 2>/dev/null; then
     echo "  ✓ bottle: системный"
-elif [ -f "$APP_DIR/vendor/bottle.py" ]; then
-    echo "  ✓ bottle: встроенный (vendor/)"
-else
+elif [ ! -f "$APP_DIR/vendor/bottle.py" ]; then
     echo "  ⚠ bottle не найден (нет ни системного, ни $APP_DIR/vendor/bottle.py)"
+else
+    _MISS="$(_bottle_missing_module)"
+    if [ -z "$_MISS" ]; then
+        echo "  ✓ bottle: встроенный (vendor/)"
+    else
+        _ADD="opkg install"; command -v apk >/dev/null 2>&1 && _ADD="apk add"
+        echo "  ⚠ bottle на месте, но не хватает модуля Python '$_MISS'"
+        echo "    доустановите: $_ADD $(_py_pkg_for "$_MISS")"
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes issue #231 where Bottle web server fails to start on Entware/OpenWrt systems with `python3-light`, even though `vendor/bottle.py` exists. The root cause is that Bottle depends on stdlib modules like `unicodedata` (which lives in `python3-codecs` package, not `python3-unicodedata`) that aren't included in the minimal `python3-light` package.

## Key Changes

- **Improved error diagnostics in `app.py`**: Distinguishes between "Bottle file missing" and "Bottle exists but missing stdlib dependency" errors. Now prints the exact missing module name and required package to install (e.g., `opkg install python3-codecs` for `unicodedata`).

- **Added `ensure_bottle_deps()` in `install.sh`**: After copying files, actually imports the vendored Bottle and automatically installs missing stdlib packages using a module-to-package mapping. Handles special cases where module names don't match package names (e.g., `unicodedata` → `python3-codecs`, `ssl` → `python3-openssl`).

- **New `stdlib_pkg_for()` utility in `core/bottle_vendor.py`**: Provides the module-to-package mapping for Entware/OpenWrt, used by both installer and runtime diagnostics.

- **Updated package dependencies**: Added explicit `Depends` declarations for `python3-urllib`, `python3-openssl`, `python3-codecs`, and `python3-email` in control files (Entware and OpenWrt), so package managers install them automatically.

- **Enhanced postinst scripts**: Both Entware and OpenWrt postinst now test Bottle via actual import (not just file existence) and report missing modules with installation instructions.

- **Improved Entware init script**: Shows last 15 lines of server log on startup failure, making errors visible instead of hidden behind generic "FAILED" message.

- **Version bump**: 0.22.26 → 0.22.27

## Implementation Details

- The module-to-package mapping handles C-extensions with non-obvious names: `ssl`/`_ssl`/`hashlib`/`_hashlib` → `python3-openssl`, `unicodedata`/`_multibytecodec` → `python3-codecs`, etc.
- Uses `_STDLIB_UPDATED` flag to avoid redundant `opkg/apk update` calls during installation.
- Implements retry loop (up to 12 attempts) in `ensure_bottle_deps()` to handle cascading dependencies.
- All diagnostic functions use actual Python import testing rather than file existence checks.

https://claude.ai/code/session_01N9nXhM3eAxwQfSVSM8A9Fq