### PR TITLE
fix: HTTP 500 при сохранении маршрута — у python3-light нет logging д…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,6 +604,30 @@
   deadlock демона (нет ответа вовсе), а не нехватку времени.
 
 ### Исправлено
+- **HTTP 500 при сохранении маршрута на `python3-light`: у
+  `concurrent.futures` нет `logging`** (`core/routing/domain_rule.py`,
+  `packaging/*/control`, `Makefile`, `install.sh`, `core/selfcheck.py`;
+  отчёт с Keenetic 5.0.3, сразу после появления set-пути). В
+  `python3-light` (проверено по содержимому пакета Entware) есть
+  `concurrent/futures`, но НЕТ `logging` — он в отдельном пакете
+  `python3-logging`, а `concurrent/futures/_base.py` импортирует
+  `logging` на верхнем уровне. Поэтому `import concurrent.futures`
+  падает с «No module named 'logging'»: параллельный pre-populate
+  set-пути ронял сохранение маршрута в 500 (и та же мина лежит под
+  blockcheck, тестером прокси, обновлением подписок и connectivity-
+  матрицей — все импортируют `concurrent.futures`). Теперь:
+  - `_prepopulate_domains` при недоступном `concurrent.futures`
+    резолвит домены **последовательным фолбэком** — медленнее, но
+    работает вообще без доустановки пакетов (чинит уже установленные
+    GUI сразу после обновления кода);
+  - сбой set-пути больше не доходит до API: диспетчер ловит любое
+    исключение и откатывается на проверенный iproute-фолбэк (а снятие
+    set-правила возвращает структурную ошибку вместо 500);
+  - `python3-logging` добавлен в Depends `.ipk`/`.apk` и в опциональную
+    доставку `install.sh`; самодиагностика проверяет `stdlib logging`
+    и называет, что без него не работает (warn + подсказка пакета).
+  Тесты — `test_routing_domain_sets.py` (sequential-фолбэк, откат
+  диспетчера, remove без raise).
 - **Доменные маршруты (hostlist'ы) теперь работают на Keenetic и без
   выбора устройства** (`core/routing/domain_rule.py`,
   `core/routing/domain_refresh.py` — новый, `app.py`; отчёт с Keenetic

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ _build_apk_openwrt:
 		--info "origin:$(PKG_NAME)" \
 		--info "url:https://github.com/avatarDD/zapret-gui" \
 		--info "maintainer:avatarDD <https://github.com/avatarDD/zapret-gui>" \
-		--info "depends:python3-light python3-urllib python3-openssl python3-codecs python3-email python3-unittest python3-uuid python3-yaml python3-sqlite3" \
+		--info "depends:python3-light python3-urllib python3-openssl python3-codecs python3-email python3-logging python3-unittest python3-uuid python3-yaml python3-sqlite3" \
 		--script "post-install:$(APK_SCRIPTS)/post-install" \
 		--script "pre-deinstall:$(APK_SCRIPTS)/pre-deinstall" \
 		--files "$(DATA_DIR)" \

--- a/core/routing/domain_rule.py
+++ b/core/routing/domain_rule.py
@@ -299,7 +299,6 @@ def _prepopulate_domains(domains, set_v4, set_v6, backend) -> list:
     общего состояния), поэтому вызовы безопасно идут параллельно — это
     ограничивает суммарное время даже при медленном/глухом резолвере.
     """
-    import concurrent.futures
     tasks = []
     for d in domains:
         tasks.append((set_v4, d, "v4"))
@@ -307,6 +306,20 @@ def _prepopulate_domains(domains, set_v4, set_v6, backend) -> list:
     if not tasks:
         return []
     results = []
+    try:
+        import concurrent.futures
+    except ImportError:
+        # Entware python3-light без python3-logging: concurrent.futures
+        # тянет logging на верхнем уровне (_base.py) и не импортируется —
+        # «No module named 'logging'». Резолвим последовательно:
+        # медленнее, но работает (реальный отчёт с Keenetic — HTTP 500
+        # при сохранении маршрута).
+        for (s, d, f) in tasks:
+            try:
+                results.append(_prepopulate_set(s, d, f, backend))
+            except Exception as e:
+                results.append({"ok": False, "added": 0, "error": str(e)})
+        return results
     workers = min(_PREPOP_WORKERS, len(tasks))
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
         futs = [ex.submit(_prepopulate_set, s, d, f, backend)
@@ -824,7 +837,13 @@ def apply_domain_rule(rule: DomainRoutingRule) -> dict:
             # (масштабируется на большие hostlist'ы). Совсем без set-бэкенда —
             # прежний iproute-фолбэк: ip rule на каждый разрезолвленный IP.
             if _backend_for(prefer_nft=True) is not None:
-                return _apply_domain_via_sets(rule)
+                try:
+                    return _apply_domain_via_sets(rule)
+                except Exception as e:
+                    # Любой сбой set-пути не должен превращаться в HTTP 500
+                    # — откатываемся на проверенный iproute-фолбэк.
+                    log.warning("routing: set-путь без dnsmasq упал (%s) — "
+                                "фолбэк на ip-route" % e, source="routing")
             return _apply_domain_via_iproute(rule)
 
         backend, kind = _detect_backend()
@@ -1021,7 +1040,12 @@ def remove_domain_rule(rule: DomainRoutingRule) -> dict:
     # Set-путь без dnsmasq (Keenetic с ipset/nft) — симметрично apply.
     if rule.id in _sets_state_load():
         with _lock:
-            return _remove_domain_via_sets(rule)
+            try:
+                return _remove_domain_via_sets(rule)
+            except Exception as e:
+                log.warning("routing: снятие set-правила %s упало: %s"
+                            % (rule.id, e), source="routing")
+                return {"ok": False, "error": str(e)}
 
     with _lock:
         backend, kind = _detect_backend()

--- a/core/selfcheck.py
+++ b/core/selfcheck.py
@@ -130,6 +130,10 @@ def check_python() -> dict:
             ("ssl", "TLS-пробы мониторинга, DoH, подписки", "fail"),
             ("socket", "вся сеть", "fail"),
             ("ipaddress", "разбор CIDR", "fail"),
+            ("logging", "без него не работает concurrent.futures: "
+                        "blockcheck, тестер прокси, обновление подписок; "
+                        "резолв доменов маршрутизации — медленнее "
+                        "(Entware: opkg install python3-logging)", "warn"),
             ("unittest", "юнит-тесты самодиагностики пропускаются "
                          "(Entware: opkg install python3-unittest)", "warn"),
             ("sqlite3", "не используется, но полезно знать", "warn")):

--- a/install.sh
+++ b/install.sh
@@ -224,11 +224,14 @@ ensure_python_stdlib() {
     # Опциональные: без них GUI работает, но часть функций деградирует.
     # Ставим сразу все — чтобы будущие фичи не упирались в урезанный
     # python3-light (наличие пакетов проверено по фиду bin.entware.net).
+    #   logging  → python3-logging  (без него не импортируется
+    #              concurrent.futures: blockcheck, тестер прокси, подписки,
+    #              параллельный резолв доменов маршрутизации)
     #   unittest → python3-unittest (юнит-тесты самодиагностики)
     #   uuid     → python3-uuid     (запас: стандартная генерация id)
     #   yaml     → python3-yaml    (PyYAML: round-trip правки mihomo-конфигов)
     #   sqlite3  → python3-sqlite3 (запас: локальные базы)
-    _PY_STDLIB_OPT_PAIRS="unittest:python3-unittest uuid:python3-uuid yaml:python3-yaml sqlite3:python3-sqlite3"
+    _PY_STDLIB_OPT_PAIRS="logging:python3-logging unittest:python3-unittest uuid:python3-uuid yaml:python3-yaml sqlite3:python3-sqlite3"
 
     local missing="" pair mod pkg
     for pair in $_PY_STDLIB_PAIRS $_PY_STDLIB_OPT_PAIRS; do

--- a/packaging/entware/control
+++ b/packaging/entware/control
@@ -8,6 +8,6 @@ Description: Web GUI for managing zapret2/nfqws2 DPI bypass tool on Entware rout
  Dark theme, mobile-friendly SPA interface.
 Section: net
 Priority: optional
-Depends: python3-light, python3-urllib, python3-openssl, python3-codecs, python3-email, python3-unittest, python3-uuid, python3-yaml, python3-sqlite3
+Depends: python3-light, python3-urllib, python3-openssl, python3-codecs, python3-email, python3-logging, python3-unittest, python3-uuid, python3-yaml, python3-sqlite3
 Installed-Size: @SIZE@
 Source: https://github.com/avatarDD/zapret-gui

--- a/packaging/openwrt/control
+++ b/packaging/openwrt/control
@@ -7,6 +7,6 @@ Description: Web GUI for managing zapret2/nfqws2 DPI bypass tool.
  real-time logs, autostart and /etc/hosts management.
 Section: net
 Priority: optional
-Depends: python3-light, python3-urllib, python3-openssl, python3-codecs, python3-email, python3-unittest, python3-uuid, python3-yaml, python3-sqlite3
+Depends: python3-light, python3-urllib, python3-openssl, python3-codecs, python3-email, python3-logging, python3-unittest, python3-uuid, python3-yaml, python3-sqlite3
 Installed-Size: @SIZE@
 Source: https://github.com/avatarDD/zapret-gui

--- a/tests/test_routing_domain_sets.py
+++ b/tests/test_routing_domain_sets.py
@@ -129,6 +129,64 @@ class TestRemoveDomainViaSets(unittest.TestCase):
         self.assertEqual(res.get("backend"), "ipset")
 
 
+class TestPrepopulateWithoutConcurrentFutures(unittest.TestCase):
+    """
+    Entware python3-light без python3-logging: `import concurrent.futures`
+    падает («No module named 'logging'» из _base.py) — это давало HTTP 500
+    при сохранении маршрута. Prepopulate обязан отработать последовательным
+    фолбэком.
+    """
+
+    def test_sequential_fallback(self):
+        import sys
+        with mock.patch.dict(sys.modules, {"concurrent.futures": None}), \
+             mock.patch.object(domain_rule, "_prepopulate_set",
+                               return_value={"ok": True, "added": 1}) as pp:
+            results = domain_rule._prepopulate_domains(
+                ["example.com"], "s4", "s6", ipset_backend)
+        # v4 + v6 задачи выполнены последовательно
+        self.assertEqual(pp.call_count, 2)
+        self.assertEqual(sum(r.get("added", 0) for r in results), 2)
+
+
+class TestSetsPathFallbackToIproute(unittest.TestCase):
+
+    def test_apply_falls_back_on_sets_crash(self):
+        # Любое исключение set-пути не должно доходить до API (HTTP 500) —
+        # диспетчер откатывается на проверенный iproute-фолбэк.
+        rule = _rule()
+        with mock.patch.object(domain_rule, "_ndms_available",
+                               return_value=False), \
+             mock.patch.object(domain_rule, "_backend_for",
+                               return_value=ipset_backend), \
+             mock.patch.object(domain_rule, "_apply_domain_via_sets",
+                               side_effect=RuntimeError("boom")), \
+             mock.patch.object(domain_rule, "_apply_domain_via_iproute",
+                               return_value={"ok": True,
+                                             "backend": "iproute"}) as f, \
+             mock.patch("core.routing.dnsmasq_integration.DnsmasqIntegration") \
+                as Dn:
+            Dn.return_value.status.return_value = {"available": False,
+                                                   "running": False}
+            res = domain_rule.apply_domain_rule(rule)
+        f.assert_called_once()
+        self.assertEqual(res.get("backend"), "iproute")
+
+    def test_remove_sets_crash_returns_error_not_raises(self):
+        rule = _rule()
+        with mock.patch.object(domain_rule, "_ndms_available",
+                               return_value=False), \
+             mock.patch.object(domain_rule, "_iproute_state_load",
+                               return_value={}), \
+             mock.patch.object(domain_rule, "_sets_state_load",
+                               return_value={rule.id: "ipset"}), \
+             mock.patch.object(domain_rule, "_remove_domain_via_sets",
+                               side_effect=RuntimeError("boom")):
+            res = domain_rule.remove_domain_rule(rule)
+        self.assertFalse(res["ok"])
+        self.assertIn("boom", res["error"])
+
+
 class TestDomainRefresh(unittest.TestCase):
 
     def test_refresh_once_tops_up_sets_rules(self):


### PR DESCRIPTION
…ля concurrent.futures

Отчёт с Keenetic 5.0.3 сразу после появления set-пути: сохранение маршрута снова падало в Internal Server Error без следов в логе GUI.

Корень (проверен по содержимому пакета python3-light из фида Entware): в python3-light есть concurrent/futures, но НЕТ logging — он в отдельном пакете python3-logging, а concurrent/futures/_base.py импортирует logging на верхнем уровне. import concurrent.futures падает с «No module named 'logging'»: параллельный pre-populate set-пути ронял apply необработанным исключением → 500. Та же мина — под blockcheck, тестером прокси, обновлением подписок и connectivity-матрицей.

Три слоя защиты:
- _prepopulate_domains при недоступном concurrent.futures резолвит последовательно — работает без доустановки пакетов, чинит уже установленные GUI сразу после обновления кода;
- диспетчер ловит любое исключение set-пути и откатывается на проверенный iproute-фолбэк (снятие set-правила возвращает структурную ошибку вместо raise);
- python3-logging добавлен в Depends ipk/apk и в опциональную доставку install.sh; самодиагностика проверяет stdlib logging и называет зависимые функции с подсказкой пакета.

Тесты: sequential-фолбэк, откат диспетчера, remove без raise (test_routing_domain_sets.py).


Claude-Session: https://claude.ai/code/session_01HTsWnV989TSq2nauY9CgnQ