### PR TITLE
feat: ipl:-списки (CIDR сервисов) как назначение маршрута + routing d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 ## Unreleased — Пул публичных серверов, тестер прокси, vmess, urltest-подписки
 
 ### Добавлено
+- **IP-списки zapret2 (ipset-*.txt) как назначение маршрута — `ipl:<имя>`**
+  (`core/unified/model.py`, `web/js/pages/routing_unified.js`; отчёт с
+  Keenetic: «без выбора устройства маршрутизация не работает»). Доменная
+  маршрутизация без dnsmasq принципиально ограничена: роутер видит только
+  IP, которые сам разрезолвил, а клиент ходит на ротацию CDN-поддоменов.
+  Маршрут по CIDR-подсетям сервиса от DNS не зависит вовсе — и готовые
+  списки подсетей (Discord, googlevideo, Cloudflare, Instagram, …) уже
+  лежат в поставке для nfqws2 (`/opt/zapret2/ipset/ipset-*.txt`). Теперь
+  они доступны и в маршрутизации: в редакторе маршрута рядом с
+  nfqws2-хостлистами выбираются IP-списки (id `ipl:<имя>`),
+  `Destination.resolve()` разворачивает их в CIDR через `ipset_manager`
+  (кривые строки файла отфильтровываются, а не валят весь маршрут).
+  Это рекомендуемый способ destination-only маршрута тяжёлых CDN-сервисов
+  на Keenetic. Тесты — `test_unified_model.py`.
+- **Routing doctor — пошаговая диагностика «правило есть, а трафик мимо»**
+  (`core/routing/doctor.py`, `api/routing.py`). По каждому включённому
+  правилу проверяется вся цепочка на живом устройстве: интерфейс поднят →
+  default-route в таблице → ipset существует и наполнен → mark-правила в
+  mangle стоят и **счётчики пакетов растут** → `ip rule fwmark` на месте →
+  masquerade повешен → контрольный резолв домена → IP в set'е →
+  `ip route get <ip> mark <mark>` ведёт в туннель. Первый ✗ в списке —
+  место обрыва. CLI работает даже без bottle:
+  `python3 -m core.routing.doctor` (`--json` — машиночитаемо), API —
+  `GET /api/routing/doctor`. Тесты — `test_routing_doctor.py`.
 - **apk-пакет для нового OpenWrt (24.10+/25.x) в релизах** (`Makefile`,
   `.github/workflows/release.yml`, `README.md`). Новые версии OpenWrt перешли
   с opkg (`.ipk`) на apk (`.apk`, формат APKv3), и старый `.ipk` там не

--- a/api/routing.py
+++ b/api/routing.py
@@ -320,6 +320,20 @@ def register(app):
             response.status = 500
             return {"ok": False, "error": str(e)}
 
+    @app.route("/api/routing/doctor")
+    def routing_doctor():
+        """Пошаговая диагностика цепочки маршрутизации (core/routing/doctor):
+        по каждому правилу — где именно рвётся «правило есть, трафик мимо»."""
+        response.content_type = "application/json; charset=utf-8"
+        try:
+            from core.routing import doctor
+            report = doctor.diagnose()
+            report["text"] = doctor.render_text(report)
+            return report
+        except Exception as e:
+            response.status = 500
+            return {"ok": False, "error": str(e)}
+
     @app.route("/api/routing/dnsmasq/setup/plan")
     def routing_dnsmasq_setup_plan():
         """Что СДЕЛАЕТ кнопка «Настроить dnsmasq» — без побочек."""

--- a/core/routing/doctor.py
+++ b/core/routing/doctor.py
@@ -1,0 +1,356 @@
+# core/routing/doctor.py
+"""
+Пошаговая диагностика маршрутизации ПРЯМО на устройстве: где именно
+рвётся «правило создано, а трафик мимо туннеля».
+
+Для каждого включённого правила проверяется вся цепочка:
+  интерфейс поднят → default-route в его таблице → (set-путь) ipset
+  существует и наполнен → mark-правила в mangle стоят и их счётчики
+  растут → `ip rule fwmark` на месте → masquerade повешен → контрольный
+  резолв первого домена → его IP в set'е → `ip route get <ip> mark <m>`
+  ведёт в туннель. Для iproute/CIDR/device-правил — их собственные звенья
+  (`ip rule to/from`, покрытие резолвленного IP).
+
+Смысл: отчёты вида «без выбора устройства не работает» нельзя чинить
+вслепую — doctor показывает первый ✗ в цепочке.
+
+CLI (работает даже без bottle):
+    python3 -m core.routing.doctor          # человекочитаемо
+    python3 -m core.routing.doctor --json   # машиночитаемо
+API: GET /api/routing/doctor (api/routing.py).
+"""
+
+import json
+import sys
+
+from core.log_buffer import log
+
+
+def _run(args, timeout=5):
+    import subprocess
+    try:
+        r = subprocess.run(args, capture_output=True, text=True,
+                           timeout=timeout)
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except FileNotFoundError as e:
+        return 127, "", str(e)
+    except Exception as e:
+        return 1, "", str(e)
+
+
+def _check(name, ok, details=""):
+    return {"name": name, "ok": bool(ok), "details": details}
+
+
+# ─────────────────────── примитивы проверок ──────────────────────────
+
+def _ipset_count(set_name: str):
+    """Число записей в ipset или None, если set не существует."""
+    rc, out, _e = _run(["ipset", "list", set_name])
+    if rc != 0:
+        return None
+    for line in out.splitlines():
+        if line.lower().startswith("number of entries"):
+            try:
+                return int(line.split(":", 1)[1].strip())
+            except (ValueError, IndexError):
+                break
+    # Фолбэк: считаем строки после "Members:"
+    members = False
+    n = 0
+    for line in out.splitlines():
+        if members and line.strip():
+            n += 1
+        if line.strip().lower() == "members:":
+            members = True
+    return n
+
+
+def _mangle_mark_counters(set_name: str, family: str = "v4"):
+    """
+    (found, packets): стоят ли mark-правила `--match-set <set> dst` в
+    наших mangle-цепочках и сколько пакетов они уже пометили.
+    packets > 0 — маркировка реально срабатывает на живом трафике.
+    """
+    from core.routing import ipset_backend
+    cmd = "iptables" if family == "v4" else "ip6tables"
+    found = False
+    packets = 0
+    for chain in (ipset_backend.PREROUTING_CHAIN,
+                  ipset_backend.OUTPUT_CHAIN):
+        rc, out, _e = _run([cmd, "-t", "mangle", "-L", chain,
+                            "-v", "-n", "-x"])
+        if rc != 0:
+            continue
+        for line in out.splitlines():
+            if set_name in line and "match-set" in line:
+                found = True
+                try:
+                    packets += int(line.split()[0])
+                except (ValueError, IndexError):
+                    pass
+    return found, packets
+
+
+def _ip_rule_lines(family: str = "-4"):
+    rc, out, _e = _run(["ip", family, "rule"])
+    return out.splitlines() if rc == 0 else []
+
+
+def _has_fwmark_rule(mark: int, table: int, family: str = "-4") -> bool:
+    hexmark = "0x%x" % mark
+    for line in _ip_rule_lines(family):
+        if "fwmark" in line and "lookup %d" % table in line \
+                and (hexmark in line or " %d " % mark in line):
+            return True
+    return False
+
+
+def _table_default_iface(table: int, family: str = "-4"):
+    """Интерфейс default-route в таблице или ''."""
+    rc, out, _e = _run(["ip", family, "route", "show", "table",
+                        str(table), "default"])
+    if rc != 0:
+        return ""
+    for line in out.splitlines():
+        parts = line.split()
+        if "dev" in parts:
+            i = parts.index("dev")
+            if i + 1 < len(parts):
+                return parts[i + 1]
+    return ""
+
+
+def _masquerade_present(ifname: str, family: str = "v4") -> bool:
+    from core.routing import ipset_backend
+    cmd = "iptables" if family == "v4" else "ip6tables"
+    rc, out, _e = _run([cmd, "-t", "nat", "-S", ipset_backend.NAT_CHAIN])
+    return rc == 0 and ("-o %s -j MASQUERADE" % ifname) in out
+
+
+def _route_get_dev(ip: str, mark: int = None):
+    """Через какой iface ядро отправит пакет к ip (с меткой mark)."""
+    args = ["ip", "route", "get", ip]
+    if mark is not None:
+        args += ["mark", str(mark)]
+    rc, out, _e = _run(args)
+    if rc != 0:
+        return ""
+    parts = (out.splitlines() or [""])[0].split()
+    if "dev" in parts:
+        i = parts.index("dev")
+        if i + 1 < len(parts):
+            return parts[i + 1]
+    return ""
+
+
+def _ipset_test(set_name: str, ip: str) -> bool:
+    rc, _o, _e = _run(["ipset", "test", set_name, ip])
+    return rc == 0
+
+
+# ─────────────────────── диагностика правил ─────────────────────────
+
+def _diagnose_domain_rule(rule, sets_state, iproute_state) -> list:
+    from core.routing import domain_rule
+    checks = []
+    ifname = rule.target_iface
+    table = domain_rule._table_id_for(ifname)
+    mark = domain_rule._mark_for(rule.id)
+
+    if rule.id in sets_state:
+        kind = sets_state[rule.id]
+        checks.append(_check("бэкенд", True, "%s без dnsmasq" % kind))
+        set_v4 = domain_rule._set_name_for(rule.id, kind)
+        if kind == "ipset":
+            cnt = _ipset_count(set_v4)
+            checks.append(_check(
+                "ipset %s" % set_v4, cnt is not None and cnt > 0,
+                "нет такого set'а" if cnt is None else "%d IP" % cnt))
+        found, pkts = _mangle_mark_counters(set_v4)
+        checks.append(_check(
+            "mark-правила в mangle", found,
+            ("есть, помечено пакетов: %d" % pkts) if found
+            else "нет — маркировка не срабатывает"))
+        if found:
+            checks.append(_check(
+                "маркировка видит трафик", pkts > 0,
+                "%d пакетов" % pkts if pkts > 0 else
+                "0 пакетов — трафик к IP из set'а не идёт "
+                "(клиент ходит на другие IP: DNS/CDN?)"))
+        checks.append(_check(
+            "ip rule fwmark → table %d" % table,
+            _has_fwmark_rule(mark, table),
+            "mark=0x%x" % mark))
+    elif rule.id in iproute_state:
+        entries = iproute_state.get(rule.id) or []
+        checks.append(_check("бэкенд", True,
+                             "iproute (%d IP в state)" % len(entries)))
+        live = sum(1 for line in _ip_rule_lines("-4")
+                   if "lookup %d" % table in line)
+        checks.append(_check(
+            "ip rule → table %d" % table, live > 0,
+            "%d правил в policy-db" % live))
+    else:
+        checks.append(_check("бэкенд", True,
+                             "dnsmasq/NDMS (state этого правила пуст)"))
+
+    dev = _table_default_iface(table)
+    checks.append(_check(
+        "default-route в table %d" % table, dev == ifname,
+        ("dev %s" % dev) if dev else "нет default — трафик некуда слать"))
+    mq = _masquerade_present(ifname)
+    checks.append(_check("masquerade на %s" % ifname, mq,
+                         "" if mq else
+                         "нет — пакеты уйдут с чужим src и сервер их дропнет"))
+
+    # Контрольный прогон: первый домен правила.
+    domains, _cidrs = domain_rule._expand_rule(rule)
+    if domains:
+        probe = domains[0]
+        ips = domain_rule._resolve_ips(probe, "v4")
+        if not ips:
+            checks.append(_check("резолв %s" % probe, False,
+                                 "домен не резолвится с роутера"))
+        else:
+            ip = ips[0]
+            if rule.id in sets_state:
+                in_set = _ipset_test(
+                    domain_rule._set_name_for(rule.id,
+                                              sets_state[rule.id]), ip)
+                checks.append(_check(
+                    "%s (%s) в set'е" % (probe, ip), in_set,
+                    "" if in_set else "IP не в set — рефрешер/prepopulate"
+                                      " не отработал"))
+                via = _route_get_dev(ip, mark=mark)
+            else:
+                via = _route_get_dev(ip)
+            checks.append(_check(
+                "route get %s → %s" % (ip, ifname), via == ifname,
+                "уходит через %s" % (via or "?")))
+    return checks
+
+
+def _diagnose_cidr_rule(rule) -> list:
+    from core.routing.manager import table_id_for
+    checks = []
+    table = table_id_for(rule.target_iface)
+    lines = _ip_rule_lines("-4") + _ip_rule_lines("-6")
+    want = [c for c, _f in rule.cidr_families()]
+    live = sum(1 for line in lines if "lookup %d" % table in line)
+    checks.append(_check(
+        "ip rule to → table %d" % table, live > 0,
+        "%d правил (ожидалось до %d)" % (live, len(want))))
+    dev = _table_default_iface(table)
+    checks.append(_check(
+        "default-route в table %d" % table, dev == rule.target_iface,
+        ("dev %s" % dev) if dev else "нет default"))
+    if want:
+        probe_ip = want[0].split("/")[0]
+        via = _route_get_dev(probe_ip)
+        checks.append(_check(
+            "route get %s → %s" % (probe_ip, rule.target_iface),
+            via == rule.target_iface, "уходит через %s" % (via or "?")))
+    return checks
+
+
+def _diagnose_device_rule(rule) -> list:
+    from core.routing.device_rule import _table_id_for
+    checks = []
+    table = _table_id_for(rule.target_iface)
+    src = rule.source_ip
+    found = any(("from %s" % src) in line and "lookup %d" % table in line
+                for line in _ip_rule_lines("-4") + _ip_rule_lines("-6"))
+    checks.append(_check("ip rule from %s" % src, found,
+                         "table %d" % table))
+    return checks
+
+
+# ─────────────────────── публичный API ──────────────────────────────
+
+def diagnose() -> dict:
+    """Полный отчёт по всем включённым правилам маршрутизации."""
+    from core.routing import domain_rule, storage
+    from core.routing.rules import (CidrRoutingRule, DeviceRoutingRule,
+                                    DomainRoutingRule)
+
+    sets_state = domain_rule._sets_state_load()
+    iproute_state = domain_rule._iproute_state_load()
+
+    env = []
+    rc_ipset, _o, _e = _run(["ipset", "-v"], timeout=3)
+    env.append(_check("ipset", rc_ipset == 0))
+    rc_ipt, _o, _e = _run(["iptables", "-V"], timeout=3)
+    env.append(_check("iptables", rc_ipt == 0))
+    try:
+        from core.routing import dnsmasq_integration
+        st = dnsmasq_integration.DnsmasqIntegration().status()
+        env.append(_check("dnsmasq", True,
+                          "работает" if st.get("running")
+                          else "нет (Keenetic: норм — set-путь/iproute)"))
+    except Exception as e:
+        env.append(_check("dnsmasq", True, "статус не снят: %s" % e))
+
+    rules_report = []
+    for rule in storage.load_rules():
+        entry = {"id": rule.id, "type": rule.type_name,
+                 "iface": rule.target_iface,
+                 "enabled": bool(rule.enabled), "checks": []}
+        if not rule.enabled:
+            entry["checks"].append(_check("правило", True, "выключено"))
+            rules_report.append(entry)
+            continue
+        try:
+            from core.routing.domain_rule import _iface_exists
+            up = _iface_exists(rule.target_iface)
+            entry["checks"].append(_check(
+                "интерфейс %s" % rule.target_iface, up,
+                "" if up else "не поднят — правило в deferred"))
+            if up:
+                if isinstance(rule, DomainRoutingRule):
+                    entry["checks"] += _diagnose_domain_rule(
+                        rule, sets_state, iproute_state)
+                elif isinstance(rule, CidrRoutingRule):
+                    entry["checks"] += _diagnose_cidr_rule(rule)
+                elif isinstance(rule, DeviceRoutingRule):
+                    entry["checks"] += _diagnose_device_rule(rule)
+        except Exception as e:
+            entry["checks"].append(_check("диагностика", False,
+                                          "упала: %s" % e))
+        rules_report.append(entry)
+
+    ok = all(c["ok"] for r in rules_report for c in r["checks"]) \
+        and all(c["ok"] for c in env)
+    return {"ok": ok, "env": env, "rules": rules_report}
+
+
+def render_text(report: dict) -> str:
+    lines = ["── Окружение ──"]
+    for c in report.get("env", []):
+        lines.append(" %s %s%s" % ("✓" if c["ok"] else "✗", c["name"],
+                                   (" — " + c["details"])
+                                   if c.get("details") else ""))
+    for r in report.get("rules", []):
+        lines.append("── %s (%s → %s) ──"
+                     % (r["id"], r["type"], r["iface"]))
+        for c in r["checks"]:
+            lines.append(" %s %s%s" % ("✓" if c["ok"] else "✗", c["name"],
+                                       (" — " + c["details"])
+                                       if c.get("details") else ""))
+    if not report.get("rules"):
+        lines.append("правил маршрутизации нет")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    argv = argv if argv is not None else sys.argv[1:]
+    report = diagnose()
+    if "--json" in argv:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(render_text(report))
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/unified/model.py
+++ b/core/unified/model.py
@@ -37,6 +37,7 @@
     помечает их как skipped для direct/nfqws2.
 """
 
+import ipaddress
 import os
 import time
 
@@ -119,6 +120,18 @@ class Destination:
                     from core.hostlist_manager import get_hostlist_manager
                     doms = get_hostlist_manager().get_hostlist(lid[3:]) or []
                     domains += [str(d) for d in doms]
+                    continue
+                # `ipl:<имя>` — IP-список zapret2 (ipset_manager,
+                # ipset-*.txt): готовые CIDR-подсети сервисов
+                # (Discord/YouTube/Cloudflare, ...). Маршрутизация по ним
+                # идёт CIDR-путём и НЕ зависит от DNS — на Keenetic без
+                # dnsmasq это самый надёжный способ destination-маршрута
+                # (домены ловят только IP, разрезолвленные роутером,
+                # и не видят ротацию CDN-поддоменов).
+                if isinstance(lid, str) and lid.startswith("ipl:"):
+                    from core.ipset_manager import get_ipset_manager
+                    entries = get_ipset_manager().get_ipset(lid[4:]) or []
+                    cidrs += _clean_cidrs(entries)
                     continue
                 from core.named_lists import resolve as _resolve_list
                 r = _resolve_list(lid)
@@ -273,6 +286,23 @@ def _clean_dscp(v):
     if not (0 <= n <= 63):
         raise ValueError("DSCP вне диапазона 0..63: %d" % n)
     return n
+
+
+def _clean_cidrs(entries) -> list:
+    """Оставить только валидные IP/CIDR: файлы ipset-*.txt правятся
+    руками и могут содержать мусор — одна кривая строка не должна
+    валить весь маршрут (CidrRoutingRule бросает ValueError)."""
+    out = []
+    for e in entries or []:
+        s = str(e or "").strip()
+        if not s:
+            continue
+        try:
+            ipaddress.ip_network(s, strict=False)
+        except ValueError:
+            continue
+        out.append(s)
+    return out
 
 
 def _clean_list(v, lower=False) -> list:

--- a/tests/test_routing_doctor.py
+++ b/tests/test_routing_doctor.py
@@ -1,0 +1,126 @@
+# tests/test_routing_doctor.py
+"""
+Routing doctor — пошаговая диагностика «правило есть, а трафик мимо
+туннеля» (core/routing/doctor). Проверяем разбор вывода утилит и сборку
+отчёта по здоровой/сломанной цепочке.
+"""
+
+import unittest
+from unittest import mock
+
+from core.routing import doctor
+from core.routing.rules import DomainRoutingRule
+
+
+class TestParsers(unittest.TestCase):
+
+    def test_ipset_count_parses_header(self):
+        out = ("Name: awgr_x\nType: hash:ip\nNumber of entries: 42\n"
+               "Members:\n1.2.3.4\n")
+        with mock.patch.object(doctor, "_run",
+                               return_value=(0, out, "")):
+            self.assertEqual(doctor._ipset_count("awgr_x"), 42)
+
+    def test_ipset_count_missing_set(self):
+        with mock.patch.object(doctor, "_run",
+                               return_value=(1, "", "does not exist")):
+            self.assertIsNone(doctor._ipset_count("nope"))
+
+    def test_has_fwmark_rule_hex(self):
+        lines = ["0:\tfrom all lookup local",
+                 "10100:\tfrom all fwmark 0x1abcd lookup 361",
+                 "32766:\tfrom all lookup main"]
+        with mock.patch.object(doctor, "_ip_rule_lines",
+                               return_value=lines):
+            self.assertTrue(doctor._has_fwmark_rule(0x1abcd, 361))
+            self.assertFalse(doctor._has_fwmark_rule(0x1abcd, 999))
+
+    def test_mangle_counters(self):
+        out = ("Chain AWG_ROUTING_PRE (1 references)\n"
+               "    pkts      bytes target     prot opt in     out\n"
+               "     123     4567 MARK       all  --  *      *       "
+               "0.0.0.0/0  0.0.0.0/0  match-set awgr_x dst MARK set 0x1abcd\n")
+        with mock.patch.object(doctor, "_run",
+                               return_value=(0, out, "")):
+            found, pkts = doctor._mangle_mark_counters("awgr_x")
+        self.assertTrue(found)
+        # обе цепочки (PRE и OUT) вернули одинаковый мок → 123*2
+        self.assertEqual(pkts, 246)
+
+    def test_route_get_dev(self):
+        out = "1.2.3.4 dev WARPv1_61 table 361 src 172.16.0.2\n"
+        with mock.patch.object(doctor, "_run",
+                               return_value=(0, out, "")):
+            self.assertEqual(doctor._route_get_dev("1.2.3.4", mark=7),
+                             "WARPv1_61")
+
+
+class TestDiagnose(unittest.TestCase):
+
+    def _rule(self):
+        return DomainRoutingRule(target_iface="awg0",
+                                 domains=["example.com"],
+                                 rule_id="uni-doc")
+
+    def _patch_chain(self, healthy=True):
+        from core.routing import domain_rule
+        return [
+            mock.patch("core.routing.storage.load_rules",
+                       return_value=[self._rule()]),
+            mock.patch.object(domain_rule, "_sets_state_load",
+                              return_value={"uni-doc": "ipset"}),
+            mock.patch.object(domain_rule, "_iproute_state_load",
+                              return_value={}),
+            mock.patch.object(domain_rule, "_iface_exists",
+                              return_value=True),
+            mock.patch.object(domain_rule, "_resolve_ips",
+                              return_value=["1.2.3.4"]),
+            mock.patch.object(doctor, "_ipset_count", return_value=10),
+            mock.patch.object(doctor, "_mangle_mark_counters",
+                              return_value=(True, 5 if healthy else 0)),
+            mock.patch.object(doctor, "_has_fwmark_rule",
+                              return_value=True),
+            mock.patch.object(doctor, "_table_default_iface",
+                              return_value="awg0"),
+            mock.patch.object(doctor, "_masquerade_present",
+                              return_value=True),
+            mock.patch.object(doctor, "_ipset_test", return_value=True),
+            mock.patch.object(doctor, "_route_get_dev",
+                              return_value="awg0" if healthy else "eth0"),
+            mock.patch.object(doctor, "_run",
+                              return_value=(0, "", "")),
+        ]
+
+    def _run_diag(self, healthy):
+        patches = self._patch_chain(healthy)
+        for p in patches:
+            p.start()
+        try:
+            return doctor.diagnose()
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_healthy_chain_all_ok(self):
+        report = self._run_diag(healthy=True)
+        self.assertTrue(report["ok"], doctor.render_text(report))
+        self.assertEqual(len(report["rules"]), 1)
+
+    def test_broken_chain_flags_failures(self):
+        report = self._run_diag(healthy=False)
+        self.assertFalse(report["ok"])
+        bad = [c["name"] for c in report["rules"][0]["checks"]
+               if not c["ok"]]
+        # 0 пакетов на mark-правиле и route get мимо туннеля — оба видны
+        self.assertTrue(any("маркировка" in n for n in bad), bad)
+        self.assertTrue(any("route get" in n for n in bad), bad)
+
+    def test_render_text_smoke(self):
+        report = self._run_diag(healthy=True)
+        text = doctor.render_text(report)
+        self.assertIn("uni-doc", text)
+        self.assertIn("✓", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unified_model.py
+++ b/tests/test_unified_model.py
@@ -80,6 +80,32 @@ class TestDestination(unittest.TestCase):
         self.assertIn("yt.com", r["domains"])
         self.assertIn("vk.com", r["domains"])
 
+    def test_resolve_with_ipset_list(self):
+        # list_id вида `ipl:<имя>` разворачивается через ipset_manager
+        # (IP-списки zapret2 → CIDR: destination-маршрут без DNS).
+        fake_im = mock.Mock()
+        fake_im.get_ipset.return_value = ["162.159.128.0/24", "1.2.3.4"]
+        with mock.patch("core.ipset_manager.get_ipset_manager",
+                        return_value=fake_im):
+            d = Destination(cidrs=["10.0.0.0/8"],
+                            list_ids=["ipl:ipset-discord"])
+            r = d.resolve()
+        fake_im.get_ipset.assert_called_once_with("ipset-discord")
+        self.assertIn("10.0.0.0/8", r["cidrs"])
+        self.assertIn("162.159.128.0/24", r["cidrs"])
+        self.assertIn("1.2.3.4", r["cidrs"])
+
+    def test_resolve_ipset_list_filters_garbage(self):
+        # Кривые строки из ipset-файла не должны валить маршрут
+        # (CidrRoutingRule бросает ValueError на невалидном CIDR).
+        fake_im = mock.Mock()
+        fake_im.get_ipset.return_value = ["1.2.3.0/24", "not-an-ip",
+                                          "", "999.1.1.1"]
+        with mock.patch("core.ipset_manager.get_ipset_manager",
+                        return_value=fake_im):
+            r = Destination(list_ids=["ipl:ipset-x"]).resolve()
+        self.assertEqual(r["cidrs"], ["1.2.3.0/24"])
+
     def test_empty(self):
         self.assertTrue(Destination().is_empty())
         self.assertFalse(Destination(domains=["a.com"]).is_empty())

--- a/web/js/pages/routing_unified.js
+++ b/web/js/pages/routing_unified.js
@@ -24,6 +24,7 @@ const RoutingUnifiedPage = (() => {
     let awgConfigs = [];      // /api/awg/configs (цели даже для лежащих туннелей)
     let namedLists = [];
     let hostLists = [];       // /api/hostlists — nfqws2-хостлисты (id `hl:имя`)
+    let ipLists = [];         // /api/ipsets — IP-списки zapret2 (id `ipl:имя`)
     let legacyRules = [];     // /api/unified/legacy — старый формат
     let dnsmasqInfo = null;   // /api/routing/dnsmasq/status
     let ndmsInfo = null;      // /api/routing/ndms/status
@@ -137,7 +138,7 @@ const RoutingUnifiedPage = (() => {
     async function loadAux() {
         try {
             const [ifResp, listResp, cfgResp, dnResp, ndmsResp, envResp,
-                   netResp, legResp, hlResp] =
+                   netResp, legResp, hlResp, iplResp] =
                 await Promise.all([
                     API.get('/api/routing/interfaces').catch(() => null),
                     API.get('/api/lists').catch(() => null),
@@ -148,6 +149,7 @@ const RoutingUnifiedPage = (() => {
                     API.get('/api/network/environment').catch(() => null),
                     API.get('/api/unified/legacy').catch(() => null),
                     API.get('/api/hostlists').catch(() => null),
+                    API.get('/api/ipsets').catch(() => null),
                 ]);
             interfaces  = (ifResp && ifResp.interfaces) || [];
             namedLists  = (listResp && listResp.lists) || [];
@@ -159,6 +161,16 @@ const RoutingUnifiedPage = (() => {
                 name: ((f.name || f.file || '') + ' (nfqws2'
                        + (f.count != null ? ', ' + f.count : '') + ')'),
             })).filter(x => x.id !== 'hl:');
+            // IP-списки zapret2 (ipset-*.txt) как назначение маршрута
+            // (id `ipl:имя`): готовые CIDR-подсети сервисов. Маршрут по
+            // ним не зависит от DNS — на Keenetic без dnsmasq это самый
+            // надёжный destination-путь (домены ловят лишь IP, которые
+            // разрезолвил роутер). Пустые файлы не показываем.
+            const iplFiles = (iplResp && iplResp.files) || [];
+            ipLists = iplFiles.filter(f => (f.count || 0) > 0).map(f => ({
+                id: 'ipl:' + (f.name || ''),
+                name: ((f.name || '') + ' (IP, ' + f.count + ')'),
+            })).filter(x => x.id !== 'ipl:');
             awgConfigs  = (cfgResp && cfgResp.configs) || [];
             dnsmasqInfo = dnResp || null;
             ndmsInfo    = ndmsResp || null;
@@ -582,7 +594,7 @@ const RoutingUnifiedPage = (() => {
         if (!editing) { box.innerHTML = ''; renderBanners(); return; }
         const e = editing;
         const d = e.destination || {};
-        const allLists = namedLists.concat(hostLists);
+        const allLists = namedLists.concat(hostLists, ipLists);
         const listChecks = allLists.map(l =>
             `<label class="text-muted" style="display:inline-flex; gap:4px; margin-right:12px; font-size:12px;">
                 <input type="checkbox" value="${escAttr(l.id)}"


### PR DESCRIPTION
…octor

Продолжение «без выбора устройства маршрутизация не работает» (Keenetic).

1. IP-списки zapret2 (ipset-*.txt) теперь выбираются как назначение маршрута (id ipl:<имя>) рядом с nfqws2-хостлистами. Доменный путь без dnsmasq принципиально ограничен (роутер видит только свои резолвы, а клиент ходит на ротацию CDN-поддоменов) — маршрут по готовым CIDR-подсетям сервиса (Discord, googlevideo, Cloudflare, ...) от DNS не зависит вовсе и работает надёжно. Destination.resolve разворачивает ipl: через ipset_manager, кривые строки файла отфильтровываются (одна плохая запись не валит маршрут).

2. Routing doctor (core/routing/doctor.py, GET /api/routing/doctor, CLI python3 -m core.routing.doctor): пошаговая проверка цепочки на живом устройстве — iface, default-route, ipset наполнен, mark-правила и их счётчики пакетов, ip rule fwmark, masquerade, контрольный резолв и ip route get. Первый крест в списке — место обрыва; для удалённой отладки отчётов «правило есть, трафик мимо».

Тесты: test_unified_model.py (ipl:, фильтрация мусора), test_routing_doctor.py (парсеры и здоровая/сломанная цепочка).


Claude-Session: https://claude.ai/code/session_01HTsWnV989TSq2nauY9CgnQ