### PR TITLE
feat(diagnostics): переработаны «Системная информация» и «Конфликты и…

### DIFF
--- a/core/diagnostics.py
+++ b/core/diagnostics.py
@@ -1077,8 +1077,60 @@ def get_system_diagnostics():
     import sys
     info["python_version"] = sys.version.split()[0]
 
+    # Свободное место. На роутере переполненная флешка — штатная причина
+    # «не ставится/не сохраняется»: конфиги, бинари и логи живут в /opt,
+    # а места там обычно единицы гигабайт.
+    info["disks"] = _get_disk_usage()
+
+    # Наличие утилит, от которых зависят поля выше. Без `ip` не будет ни
+    # интерфейсов, ни шлюза, ни исходящего адреса — и раньше это выглядело
+    # как «всё пусто», без единого намёка на причину.
+    info["tools"] = {
+        "ip": bool(shutil.which("ip")),
+        "iptables": bool(shutil.which("iptables")),
+        "nft": bool(shutil.which("nft")),
+        "ipset": bool(shutil.which("ipset")),
+        "dnsmasq": bool(shutil.which("dnsmasq")),
+    }
+
     _cache_set(cache_key, info)
     return info
+
+
+def _get_disk_usage() -> list:
+    """Свободное место на разделах, где живут наши файлы."""
+    from core.platform_dirs import config_dir
+
+    out, seen = [], set()
+    candidates = [
+        ("конфиг", config_dir()),
+        ("/opt", "/opt"),
+        ("/tmp", "/tmp"),
+    ]
+    for label, path in candidates:
+        if not path or not os.path.isdir(path):
+            continue
+        try:
+            st = os.statvfs(path)
+        except OSError:
+            continue
+        # Один раздел показываем один раз: /opt и конфиг обычно совпадают.
+        key = (st.f_blocks, st.f_bsize, st.f_fsid)
+        if key in seen:
+            continue
+        seen.add(key)
+        total = st.f_blocks * st.f_frsize
+        free = st.f_bavail * st.f_frsize
+        if total <= 0:
+            continue
+        out.append({
+            "label": label,
+            "path": path,
+            "total_mb": int(total / (1024 * 1024)),
+            "free_mb": int(free / (1024 * 1024)),
+            "used_percent": int(round((total - free) * 100.0 / total)),
+        })
+    return out
 
 
 def _get_dns_servers():

--- a/core/system_info.py
+++ b/core/system_info.py
@@ -127,17 +127,28 @@ def _get_load_average() -> str:
 
 
 def _get_wan_ip() -> str:
-    """Попробовать определить WAN IP."""
+    """
+    Локальный адрес, с которого уходит трафик в интернет.
+
+    Это `src` из `ip route get 8.8.8.8`, то есть адрес НАШЕГО исходящего
+    интерфейса, а не публичный IP: за NAT/CGNAT он будет серым. В UI
+    подписан соответственно.
+
+    Возвращает пустую строку, когда определить не удалось (нет `ip`, нет
+    маршрута). Раньше здесь возвращался символ «—» — оформление в данных,
+    из-за чего его нельзя было отличить от реального значения.
+    """
     try:
         result = subprocess.run(
             ["ip", "route", "get", "8.8.8.8"],
             capture_output=True, text=True, timeout=3
         )
         if result.returncode == 0:
-            for part in result.stdout.split():
-                if part == "src":
-                    idx = result.stdout.split().index("src")
-                    return result.stdout.split()[idx + 1]
-    except (subprocess.TimeoutExpired, FileNotFoundError, IndexError):
+            parts = result.stdout.split()
+            if "src" in parts:
+                idx = parts.index("src")
+                if idx + 1 < len(parts):
+                    return parts[idx + 1]
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         pass
-    return "—"
+    return ""

--- a/tests/test_diagnostics_conflicts.py
+++ b/tests/test_diagnostics_conflicts.py
@@ -2,6 +2,7 @@
 """Тесты детекции конфликтов окружения (core/diagnostics.evaluate_conflicts)."""
 
 import unittest
+from unittest import mock
 
 from core.diagnostics import evaluate_conflicts, _KNOWN_TOOL_MARKERS
 
@@ -50,3 +51,61 @@ class TestEvaluateConflicts(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSystemInfoExtras(unittest.TestCase):
+    """Диски и наличие утилит в «Системной информации».
+
+    Раньше при отсутствии `ip` поля адресов/шлюза/интерфейсов молча
+    оставались пустыми, и было непонятно — так и надо или что-то сломано.
+    А свободного места не показывалось вовсе, хотя забитая флешка на
+    роутере — штатная причина «не ставится / не сохраняется».
+    """
+
+    def test_disk_usage_shape(self):
+        from core.diagnostics import _get_disk_usage
+        disks = _get_disk_usage()
+        self.assertIsInstance(disks, list)
+        for d in disks:
+            for key in ("label", "path", "total_mb", "free_mb", "used_percent"):
+                self.assertIn(key, d)
+            self.assertGreater(d["total_mb"], 0)
+            self.assertGreaterEqual(d["used_percent"], 0)
+            self.assertLessEqual(d["used_percent"], 100)
+            self.assertLessEqual(d["free_mb"], d["total_mb"])
+
+    def test_disk_usage_deduplicates_same_filesystem(self):
+        # /opt и каталог конфига обычно на одном разделе — не дублируем.
+        from core.diagnostics import _get_disk_usage
+        disks = _get_disk_usage()
+        paths = [d["path"] for d in disks]
+        self.assertEqual(len(paths), len(set(paths)))
+
+
+class TestWanIpValue(unittest.TestCase):
+    """`wan_ip` — это локальный src-адрес, и он не должен нести оформление."""
+
+    def test_returns_empty_string_when_unavailable(self):
+        from core.system_info import _get_wan_ip
+        with mock.patch("subprocess.run", side_effect=FileNotFoundError):
+            self.assertEqual(_get_wan_ip(), "")
+
+    def test_no_dash_placeholder_in_data(self):
+        # Раньше возвращался символ «—» — оформление в данных, из-за чего
+        # его нельзя было отличить от реального значения.
+        from core.system_info import _get_wan_ip
+        with mock.patch("subprocess.run", side_effect=OSError):
+            self.assertNotIn("—", _get_wan_ip())
+
+    def test_parses_src_from_ip_route(self):
+        from core.system_info import _get_wan_ip
+        out = mock.Mock(returncode=0,
+                        stdout="8.8.8.8 via 192.168.1.1 dev eth0 src 192.168.1.50 uid 0")
+        with mock.patch("subprocess.run", return_value=out):
+            self.assertEqual(_get_wan_ip(), "192.168.1.50")
+
+    def test_truncated_output_does_not_crash(self):
+        from core.system_info import _get_wan_ip
+        out = mock.Mock(returncode=0, stdout="8.8.8.8 dev eth0 src")
+        with mock.patch("subprocess.run", return_value=out):
+            self.assertEqual(_get_wan_ip(), "")

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -5011,3 +5011,20 @@ body.expert-mode .expert-note { display: none !important; }
     border-radius: 4px;
     color: var(--text-secondary);
 }
+
+/* ===== Диагностика: группы в «Системной информации» =====
+   Плоский список из десятка разнородных пунктов (железо, сеть, наши
+   компоненты вперемешку) читался плохо — разбиваем на смысловые блоки. */
+.diag-info-group + .diag-info-group {
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+}
+.diag-info-group-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}

--- a/web/js/pages/diagnostics.js
+++ b/web/js/pages/diagnostics.js
@@ -566,76 +566,99 @@ const DiagnosticsPage = (() => {
             ).join(' ');
         }
 
-        el.innerHTML = `
-            <div class="diag-info-grid">
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Хост</span>
-                    <span class="diag-info-value">${_esc(si.hostname || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Платформа</span>
-                    <span class="diag-info-value">${_esc(si.platform || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Ядро</span>
-                    <span class="diag-info-value">${_esc(si.kernel || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Архитектура</span>
-                    <span class="diag-info-value">${_esc(si.arch || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Uptime</span>
-                    <span class="diag-info-value">${_esc(si.uptime_human || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">RAM</span>
-                    <span class="diag-info-value">
-                        ${ram.total_mb ? ram.total_mb + ' MB' : '—'}
-                        ${ram.used_percent ? ' <span class="diag-ram-bar"><span class="diag-ram-fill" style="width:' + ram.used_percent + '%;background:' + (ram.used_percent > 80 ? 'var(--error)' : ram.used_percent > 60 ? 'var(--warning)' : 'var(--success)') + '"></span></span> ' + ram.used_percent + '%' : ''}
-                    </span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Load Average</span>
-                    <span class="diag-info-value">${_esc(si.load_avg || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">WAN IP</span>
-                    <span class="diag-info-value">${_esc(si.wan_ip || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Default Gateway</span>
-                    <span class="diag-info-value">${_esc(si.default_gateway || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">DNS серверы</span>
-                    <span class="diag-info-value">${si.dns_servers && si.dns_servers.length ? si.dns_servers.map(d => _esc(d)).join(', ') : '—'}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Python</span>
-                    <span class="diag-info-value">${_esc(si.python_version || '—')}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">Entware</span>
-                    <span class="diag-info-value">${si.entware_installed ? '<span style="color:var(--success)">Установлен</span>' : '<span style="color:var(--text-muted)">Нет</span>'}</span>
-                </div>
-                <div class="diag-info-item">
-                    <span class="diag-info-label">nfqws2</span>
-                    <span class="diag-info-value">
-                        ${si.nfqws_binary_exists
-                            ? '<span style="color:var(--success)">Найден</span>' + (si.nfqws_version ? ' · v' + _esc(si.nfqws_version) : '')
-                            : '<span style="color:var(--error)">Не найден</span>'
-                        }
-                    </span>
-                </div>
-            </div>
-            ${interfacesHtml ? `
-                <div class="diag-interfaces-section">
-                    <div class="diag-info-label" style="margin-bottom:6px">Сетевые интерфейсы</div>
-                    <div class="diag-iface-list">${interfacesHtml}</div>
-                </div>
-            ` : ''}
-        `;
+        // Плоский список из 13 разнородных пунктов читался плохо: факты о
+        // железе, о сети и о наших компонентах шли вперемешку. Разбиваем
+        // на смысловые группы.
+        const item = (label, value, title) =>
+            `<div class="diag-info-item"${title ? ` title="${_esc(title)}"` : ''}>
+                <span class="diag-info-label">${_esc(label)}</span>
+                <span class="diag-info-value">${value}</span>
+            </div>`;
+        const group = (title, itemsHtml) =>
+            `<div class="diag-info-group">
+                <div class="diag-info-group-title">${_esc(title)}</div>
+                <div class="diag-info-grid">${itemsHtml}</div>
+            </div>`;
+        const bar = (pct) => {
+            const color = pct > 90 ? 'var(--error)'
+                        : pct > 75 ? 'var(--warning)' : 'var(--success)';
+            return `<span class="diag-ram-bar"><span class="diag-ram-fill"
+                     style="width:${pct}%;background:${color}"></span></span> ${pct}%`;
+        };
+
+        // ── Ресурсы ──
+        // Показываем не только «сколько всего», но и сколько СВОБОДНО:
+        // на роутере важно именно это (нехватка ОЗУ роняет движки, а
+        // забитая флешка ломает установку и сохранение конфигов).
+        let ramValue = '—';
+        if (ram.total_mb) {
+            const freeMb = (ram.available_mb != null) ? ram.available_mb : ram.free_mb;
+            // Компактно «свободно / всего»: длинная фраза в узкой колонке
+            // переносилась на три строки и ломала сетку.
+            ramValue = (freeMb != null
+                        ? `${freeMb} / ${ram.total_mb} MB`
+                        : `${ram.total_mb} MB`)
+                     // Именно `!= null`: при 0% старая проверка на
+                     // истинность прятала шкалу целиком.
+                     + (ram.used_percent != null ? ' ' + bar(ram.used_percent) : '');
+        }
+        // Путь — только в подсказке: в подписи он вылезал за колонку и
+        // выдавливал значение за край карточки.
+        const disksHtml = (si.disks || []).map(d =>
+            item(d.label === 'конфиг' ? 'Диск (конфиг)' : `Диск ${d.label}`,
+                 `${d.free_mb} / ${d.total_mb} MB ${bar(d.used_percent)}`,
+                 `${d.path} — свободно ${d.free_mb} MB из ${d.total_mb} MB`)).join('');
+
+        // ── Сеть ──
+        const noIp = si.tools && si.tools.ip === false;
+        const dash = (v) => (v ? _esc(v) : '<span class="text-muted">—</span>');
+        const netNote = noIp
+            ? `<div class="form-hint" style="color:var(--warning); margin-top:6px;">
+                   Утилита <code>ip</code> не найдена — адреса, шлюз и список
+                   интерфейсов определить нечем. Поставьте <code>iproute2</code>.
+               </div>`
+            : '';
+
+        el.innerHTML =
+            group('Система',
+                item('Хост', dash(si.hostname))
+                + item('Платформа', dash(si.platform))
+                + item('Ядро', dash(si.kernel))
+                + item('Архитектура', dash(si.arch))
+                + item('Время работы', dash(si.uptime_human))
+                + item('Python', dash(si.python_version)))
+            + group('Ресурсы',
+                item('Оперативная память', ramValue)
+                + item('Средняя нагрузка', dash(si.load_avg),
+                       'Среднее число процессов в очереди за 1, 5 и 15 минут')
+                + disksHtml)
+            + group('Сеть',
+                item('Исходящий адрес', dash(si.wan_ip),
+                     'Адрес нашего интерфейса, с которого уходит трафик в '
+                     + 'интернет (ip route get 8.8.8.8). За NAT/CGNAT он серый '
+                     + 'и не совпадает с публичным IP')
+                + item('Шлюз по умолчанию', dash(si.default_gateway))
+                + item('DNS-серверы',
+                       (si.dns_servers && si.dns_servers.length)
+                           ? si.dns_servers.map(d => _esc(d)).join(', ')
+                           : '<span class="text-muted">—</span>',
+                       'Из /etc/resolv.conf — то, чем резолвит сам роутер'))
+            + (interfacesHtml
+                ? `<div class="diag-interfaces-section">
+                       <div class="diag-info-label" style="margin-bottom:6px">Сетевые интерфейсы</div>
+                       <div class="diag-iface-list">${interfacesHtml}</div>
+                   </div>`
+                : '')
+            + netNote
+            + group('Компоненты',
+                item('Entware', si.entware_installed
+                        ? '<span style="color:var(--success)">установлен</span>'
+                        : '<span class="text-muted">нет</span>')
+                + item('nfqws2', si.nfqws_binary_exists
+                        ? '<span style="color:var(--success)">найден</span>'
+                          + (si.nfqws_version ? ' · v' + _esc(si.nfqws_version) : '')
+                        : '<span style="color:var(--error)">не найден</span>',
+                       si.nfqws_binary_path || ''));
     }
 
     /* ═══════════════════ Render: Firewall ═══════════════════ */
@@ -769,7 +792,14 @@ const DiagnosticsPage = (() => {
         if (!el) return;
         const ci = conflictsInfo;
         const env = envConflicts;
-        if (!ci && !env) return;
+        if (!ci && !env) {
+            // Оба запроса не дошли — раньше здесь оставалось «Загрузка...»
+            // навсегда, и было непонятно, проверка идёт или отвалилась.
+            el.innerHTML = `<div class="text-muted">
+                Не удалось получить данные о конфликтах — попробуйте «Обновить».
+            </div>`;
+            return;
+        }
 
         let html = '';
 
@@ -792,12 +822,19 @@ const DiagnosticsPage = (() => {
                                 <code class="diag-conflict-cmd">${_esc(c.cmdline)}</code>
                             </div>
                         `).join('')}
+                    </div>
+                    <div class="form-hint" style="margin-top:6px;">
+                        Два процесса на одной очереди NFQUEUE обрабатывают пакеты
+                        по очереди и мешают друг другу: стратегия работает через
+                        раз или не работает вовсе. Обычно это второй установщик
+                        zapret (свой init-скрипт) — остановите его, либо разведите
+                        номера очередей.
                     </div>`;
             } else {
                 html += `
                     <div class="diag-no-conflicts">
                         <span class="diag-dot diag-dot-ok"></span>
-                        Нет сторонних процессов nfqws/tpws.
+                        Посторонних процессов nfqws/tpws нет — очередь NFQUEUE наша.
                     </div>`;
             }
         }
@@ -814,22 +851,44 @@ const DiagnosticsPage = (() => {
                         Сторонние системы обхода/маршрутизации (могут конфликтовать с единым слоем и прозрачным проксированием):
                     </div>
                     <div class="diag-conflicts-list">
-                        ${env.warnings.map(w => `
+                        ${env.warnings.map(w => {
+                            // severity приходит с бэкенда, но раньше не
+                            // использовался: критичное и просто «замечено»
+                            // выглядели одинаково.
+                            const sev = String(w.severity || '').toLowerCase();
+                            const badge = sev === 'error' || sev === 'critical'
+                                ? '<span class="badge badge-error">конфликт</span>'
+                                : (sev === 'warning' || sev === 'warn'
+                                    ? '<span class="badge badge-warning">возможен конфликт</span>'
+                                    : '<span class="badge">замечено</span>');
+                            return `
                             <div class="diag-conflict-item" style="flex-direction:column; align-items:flex-start; gap:4px;">
-                                <div><strong>${_esc(w.title)}</strong>
-                                    <span class="text-muted" style="font-size:11px;">${_esc(w.detail)}</span></div>
-                                <div class="text-muted" style="font-size:12px;">${_esc(w.hint)}</div>
-                            </div>
-                        `).join('')}
+                                <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                                    ${badge}<strong>${_esc(w.title)}</strong>
+                                </div>
+                                ${w.detail ? `<div class="text-muted" style="font-size:11px;">${_esc(w.detail)}</div>` : ''}
+                                ${w.hint ? `<div style="font-size:12px;">${_esc(w.hint)}</div>` : ''}
+                            </div>`;
+                        }).join('')}
                     </div>`;
             } else {
                 html += `
                     <div class="diag-no-conflicts" style="margin-top:12px;">
                         <span class="diag-dot diag-dot-ok"></span>
-                        Сторонних систем обхода (getdomains/XKeen/podkop/Xray) не найдено.
+                        Сторонних систем обхода (getdomains, XKeen, podkop, Xray,
+                        redsocks) не найдено.
                     </div>`;
             }
         }
+
+        html += `
+            <div class="form-hint" style="margin-top:10px;">
+                Здесь ищутся два вида помех: посторонние процессы
+                <code>nfqws</code>/<code>tpws</code> на той же очереди NFQUEUE и
+                установленные рядом системы обхода — они переписывают те же
+                правила firewall и маршрутизации, что и мы. Пусто в обоих
+                блоках — значит, наш слой ни с чем не делит систему.
+            </div>`;
 
         el.innerHTML = html;
     }


### PR DESCRIPTION
… окружение»

Системная информация:
- Плоский список из 13 разнородных пунктов (железо, сеть и наши компоненты вперемешку) разбит на группы: Система / Ресурсы / Сеть / Компоненты.
- Добавлено свободное место на диске. На роутере забитая флешка — штатная причина «не ставится / не сохраняется», а показателя не было вовсе. Разделы дедуплицируются по f_fsid: /opt и каталог конфига обычно один и тот же раздел.
- ОЗУ показывает не только объём, но и сколько СВОБОДНО (available, с фолбэком на free) — на роутере важно именно это.
- Исправлена шкала загрузки памяти: проверка `ram.used_percent ? …` прятала её целиком при 0%. Теперь `!= null`.
- «WAN IP» переименован в «Исходящий адрес» с пояснением в подсказке: это src из `ip route get 8.8.8.8`, то есть адрес нашего интерфейса, а не публичный IP — за NAT/CGNAT он серый. Прежнее название вводило в заблуждение.
- _get_wan_ip() больше не возвращает символ «—»: оформление в данных нельзя было отличить от реального значения. Теперь пустая строка, а прочерк рисует UI. Заодно убран IndexError-путь при усечённом выводе.
- Добавлен признак наличия ip/iptables/nft/ipset/dnsmasq. Без `ip` поля адресов, шлюза и интерфейсов молча оставались пустыми — теперь показывается, что определять их нечем и что поставить.

Конфликты и окружение:
- Если оба запроса не дошли, в блоке навсегда оставалось «Загрузка...» — теперь сообщение с предложением обновить.
- У найденных процессов nfqws/tpws появилось объяснение, чем это грозит (две программы на одной очереди NFQUEUE мешают друг другу) и что делать.
- Поле severity приходило с бэкенда, но не использовалось: критичное и просто замеченное выглядели одинаково. Добавлены бейджи «конфликт» / «возможен конфликт» / «замечено».
- Внизу блока — короткое пояснение, что именно здесь ищется, чтобы «пусто» читалось как результат проверки, а не как её отсутствие.

Тесты: 6 новых (форма и дедупликация разделов, wan_ip без оформления в данных, разбор src, усечённый вывод ip route).


Claude-Session: https://claude.ai/code/session_011RzHmvia9mX5qdxMvKrkUy