### PR TITLE
fix: списки не применялись без перезапуска (#265) + падение сканера (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,33 @@
 - **CLI для новых функций** — `usque`, `tgproxy`, `opera`, `monitor`,
   `updates`, `dns-routing`. (`core/cli.py`)
 
+### Исправлено
+- **Списки применялись только после перезапуска обхода**
+  ([#265](https://github.com/avatarDD/zapret-gui/issues/265)). nfqws2 держит
+  хостлисты и ipset-ы в памяти и перечитывает их только по SIGHUP, а GUI
+  сигнал не слал — из-за этого домен, добавленный в «Исключения»
+  (`netrogat.txt`), продолжал ломаться десинком. Теперь запись любого списка
+  доменов/IP сопровождается SIGHUP всем живым nfqws2 (PID-файлы + скан
+  `/proc`, т.к. GUI поднимает движок без `--daemon`).
+  (`core/nfqws_reload.py`, `core/hostlist_manager.py`, `core/ipset_manager.py`,
+  `core/strategy_state.py`)
+- **Исключения терялись на пресетах со своими списками**
+  ([#265](https://github.com/avatarDD/zapret-gui/issues/265)). Профиль,
+  который сам несёт `--hostlist=` (полные winws2-пресеты), полностью
+  пропускал подмешивание флагов — вместе с предохранителем
+  `--hostlist-exclude=netrogat.txt`. Теперь exclude доезжает и туда, а
+  include/auto-флаги по-прежнему не лезут в чужой отбор.
+  (`core/strategy_builder.py`)
+- **`aliexpress.ru` добавлен в дефолтные исключения** — ломался десинком с
+  `ERR_TLS13_DOWNGRADE_DETECTED` ([#265](https://github.com/avatarDD/zapret-gui/issues/265)).
+  (`core/hostlist_manager.py`, `import/lists/netrogat*.txt`)
+- **Сканер стратегий падал в самом начале с `name 'total' is not defined`**
+  ([#266](https://github.com/avatarDD/zapret-gui/issues/266)). Опечатка в
+  throttle-условии сохранения resume-state роняла весь цикл подбора.
+  Добавлен статический сторож на обращения к несуществующим именам —
+  `make lint` (`ast.parse`) такой класс ошибок не ловит.
+  (`core/strategy_scanner.py`, `tests/test_no_undefined_names.py`)
+
 ### Изменено
 - **Хардненинг дефолтов Web-GUI:** для новой установки bind по умолчанию
   `127.0.0.1` (раньше `0.0.0.0`). HTTP-аутентификация остаётся **выключенной

--- a/core/hostlist_manager.py
+++ b/core/hostlist_manager.py
@@ -125,6 +125,8 @@ DEFAULT_NETROGAT = [
     "wildberries.ru",
     "wb.ru",
     "wbbasket.ru",
+    # issue #265: ломался десинком (ERR_TLS13_DOWNGRADE_DETECTED)
+    "aliexpress.ru",
     # Контент / медиа / прочее
     "deepl.com",
     "ixbt.com",
@@ -407,6 +409,17 @@ class HostlistManager:
                     f.write("\n".join(clean) + "\n" if clean else "")
 
             log.info(f"Сохранён {name}.txt ({len(clean)} доменов)", source="hostlists")
+
+            # nfqws2 держит хостлисты в памяти и перечитывает их только по
+            # SIGHUP. Без этого правка списка (в т.ч. исключений netrogat)
+            # не действовала до перезапуска обхода — issue #265.
+            try:
+                from core.nfqws_reload import reload_lists
+                reload_lists("%s.txt" % name)
+            except Exception as e:
+                log.debug(f"SIGHUP после записи {name}.txt не удался: {e}",
+                          source="hostlists")
+
             return True
         except Exception as e:
             log.error(f"Ошибка записи {name}.txt: {e}", source="hostlists")

--- a/core/ipset_manager.py
+++ b/core/ipset_manager.py
@@ -388,6 +388,17 @@ class IPSetManager:
                     f.write("\n".join(clean) + "\n" if clean else "")
 
             log.info(f"Сохранён {name}.txt ({len(clean)} записей)", source="ipsets")
+
+            # См. core/nfqws_reload: ipset-файлы, как и хостлисты, читаются
+            # nfqws2 один раз при старте — правка вступает в силу только
+            # после SIGHUP (issue #265).
+            try:
+                from core.nfqws_reload import reload_lists
+                reload_lists("%s.txt" % name)
+            except Exception as e:
+                log.debug(f"SIGHUP после записи {name}.txt не удался: {e}",
+                          source="ipsets")
+
             return True
         except Exception as e:
             log.error(f"Ошибка записи {name}.txt: {e}", source="ipsets")

--- a/core/nfqws_reload.py
+++ b/core/nfqws_reload.py
@@ -1,0 +1,104 @@
+# core/nfqws_reload.py
+"""
+Горячая перезагрузка списков в работающем nfqws2 (SIGHUP).
+
+nfqws2 читает файлы списков (``--hostlist``, ``--hostlist-exclude``,
+``--ipset``, ``--ipset-exclude``) ОДИН раз — при разборе опций
+(``RegisterHostlist()`` в ``nfq2/hostlist.c``). Дальше список живёт в памяти
+процесса, и правка файла на диске сама по себе НЕ меняет ничего: движок
+перечитывает зарегистрированные хостлисты и ipset-ы только по **SIGHUP**
+(см. §10.5 справочника nfqws2).
+
+Именно на этом ломался сценарий из issue #265 «добавил сайт в Exclude, а он
+всё равно не грузится»: GUI честно дописывал домен в ``lists/netrogat.txt``,
+но живой nfqws2 продолжал работать со старой копией списка — до ближайшего
+ручного перезапуска обхода. Теперь запись любого списка домёнов/IP
+сопровождается SIGHUP, и исключение начинает действовать на новых
+соединениях сразу.
+
+PID ищем максимально широко, потому что nfqws2 может быть поднят по-разному:
+  • ``/var/run/zapret-gui-nfqws.pid`` — процесс, поднятый GUI;
+  • ``/var/run/zapret-nfqws.pid``     — процесс автозапуска S99zapret
+    (``--daemon``, свой PID-файл);
+  • скан ``/proc``                    — страховка на случай, когда PID-файла
+    нет вовсе (GUI запускает nfqws2 обычным Popen, без ``--daemon``) или он
+    протух.
+
+SIGHUP безопасен: для nfqws2 это «перечитать списки», а не перезапуск —
+установленные соединения не рвутся.
+"""
+
+import os
+import signal
+
+from core.log_buffer import log
+
+# PID-файлы, куда nfqws2 могли записать снаружи (GUI и автозапуск).
+PID_FILES = (
+    "/var/run/zapret-gui-nfqws.pid",
+    "/var/run/zapret-nfqws.pid",
+)
+
+
+def find_nfqws_pids() -> list:
+    """Все живые PID nfqws/nfqws2 (PID-файлы + скан /proc), без дублей."""
+    pids = []
+
+    for pf in PID_FILES:
+        try:
+            with open(pf, "r") as f:
+                pid = int((f.read() or "0").strip())
+            if pid > 0 and pid not in pids:
+                pids.append(pid)
+        except (IOError, OSError, ValueError):
+            continue
+
+    # Скан /proc — единый источник правды, когда PID-файла нет или он протух.
+    try:
+        from core.nfqws_manager import NFQWSManager
+        for pid in NFQWSManager._find_nfqws_pids():
+            if pid not in pids:
+                pids.append(pid)
+    except Exception:
+        pass
+
+    return pids
+
+
+def reload_lists(reason: str = "") -> dict:
+    """Послать SIGHUP всем работающим nfqws2 — перечитать списки.
+
+    Args:
+        reason: что именно поменялось (идёт в лог, напр. ``netrogat.txt``).
+
+    Returns:
+        dict: ``{"ok": bool, "pids": [...], "error": str}``. ``ok=False`` без
+        ошибки означает просто «обход не запущен» — это штатная ситуация
+        (списки подхватятся при следующем старте), а не сбой.
+    """
+    pids = find_nfqws_pids()
+    if not pids:
+        log.debug(
+            "SIGHUP не нужен: nfqws2 не запущен (%s)" % (reason or "lists"),
+            source="hostlists",
+        )
+        return {"ok": False, "pids": [], "error": "nfqws2 не запущен"}
+
+    signalled = []
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGHUP)
+            signalled.append(pid)
+        except (OSError, ProcessLookupError):
+            # Процесс умер между поиском и сигналом — не наша проблема.
+            continue
+
+    if not signalled:
+        return {"ok": False, "pids": [], "error": "nfqws2 не запущен"}
+
+    log.info(
+        "SIGHUP → nfqws2 PID %s: перечитать списки (%s)"
+        % (", ".join(str(p) for p in signalled), reason or "lists"),
+        source="hostlists",
+    )
+    return {"ok": True, "pids": signalled, "error": ""}

--- a/core/strategy_builder.py
+++ b/core/strategy_builder.py
@@ -506,12 +506,29 @@ class StrategyManager:
     def _inject_list_flags(args: list, list_flags: list) -> list:
         """Вставить флаги списков в профиль (после --filter-*, перед --payload).
 
-        Если профиль уже содержит какой-либо --hostlist*/--ipset* — не трогаем
-        (полные winws2-пресеты несут свои списки).
+        Если профиль уже содержит какой-либо --hostlist*/--ipset* (полные
+        winws2-пресеты несут свои списки), то include/auto-флаги НЕ
+        подмешиваем — сужать чужой отбор нельзя, а --hostlist-auto вообще
+        сменил бы логику выбора профиля.
+
+        НО предохранитель ``--hostlist-exclude=netrogat.txt`` доезжает и туда.
+        Раньше он молча терялся на любом профиле со своим списком, и
+        пользовательские исключения (aliexpress.ru, банки, …) не действовали
+        на пресетах — issue #265. Профиль со СВОИМ ``--hostlist-exclude``
+        оставляем как есть: он уже управляет исключениями сам.
         """
-        for a in args:
-            if a.startswith("--hostlist") or a.startswith("--ipset"):
-                return args  # профиль сам задаёт списки
+        has_own_lists = any(
+            a.startswith("--hostlist") or a.startswith("--ipset")
+            for a in args
+        )
+        if has_own_lists:
+            if any(a.startswith("--hostlist-exclude") for a in args):
+                return args  # профиль сам задаёт исключения
+            list_flags = [
+                f for f in list_flags if f.startswith("--hostlist-exclude=")
+            ]
+            if not list_flags:
+                return args
 
         insert_pos = 0
         for i, a in enumerate(args):

--- a/core/strategy_scanner.py
+++ b/core/strategy_scanner.py
@@ -479,9 +479,14 @@ class StrategyScanner:
                     self._save_counter = 0
                 self._save_counter += 1
                 now = time.time()
+                # Последняя стратегия ЭТОГО прогона: idx нумерует срез
+                # `strategies` (при resume он уже обрезан по _start_index),
+                # поэтому сравнивать надо с len(strategies), а не с
+                # self._total/actual_idx — иначе при resume условие
+                # срабатывало бы на каждой итерации (issue #266).
                 if (self._save_counter % 5 == 0
                         or (now - self._last_save_time) >= 10
-                        or actual_idx >= total - 1):
+                        or idx >= len(strategies) - 1):
                     self._save_resume_state(save_idx)
                     self._last_save_time = now
 

--- a/core/strategy_state.py
+++ b/core/strategy_state.py
@@ -421,20 +421,14 @@ def reload_nfqws() -> dict:
     нашего clear_*() Lua не написала обратно из своего in-RAM состояния,
     мы шлём SIGHUP — это nfqws2 интерпретирует как «перечитать хостлисты
     и сбросить кэши». state.tsv Lua заново подхватит при следующей записи.
+
+    Поиск PID делегирован core.nfqws_reload (PID-файлы + скан /proc): GUI
+    запускает nfqws2 без --daemon, и PID-файла может не быть вовсе.
     """
-    pid_files = (
-        "/var/run/zapret-gui-nfqws.pid",
-        "/var/run/zapret-nfqws.pid",
-    )
-    for pf in pid_files:
-        try:
-            with open(pf, "r") as f:
-                pid = int((f.read() or "0").strip())
-            if pid > 0:
-                os.kill(pid, 1)  # SIGHUP
-                log.info("SIGHUP → nfqws2 PID %d (reload state)" % pid,
-                         source="strategy")
-                return {"ok": True, "pid": pid}
-        except (OSError, ValueError):
-            continue
-    return {"ok": False, "error": "nfqws2 не запущен"}
+    from core.nfqws_reload import reload_lists
+
+    result = reload_lists("reload state")
+    pids = result.get("pids") or []
+    if pids:
+        return {"ok": True, "pid": pids[0], "pids": pids}
+    return {"ok": False, "error": result.get("error") or "nfqws2 не запущен"}

--- a/import/lists/netrogat.base.txt
+++ b/import/lists/netrogat.base.txt
@@ -74,6 +74,7 @@ ozonusercontent.com
 wildberries.ru
 wb.ru
 wbbasket.ru
+aliexpress.ru
 
 # --- Контент / медиа / прочее ---
 deepl.com

--- a/import/lists/netrogat.txt
+++ b/import/lists/netrogat.txt
@@ -49,6 +49,7 @@ ozonusercontent.com
 wildberries.ru
 wb.ru
 wbbasket.ru
+aliexpress.ru
 deepl.com
 ixbt.com
 gitflic.ru

--- a/tests/test_nfqws_reload_lists.py
+++ b/tests/test_nfqws_reload_lists.py
@@ -1,0 +1,111 @@
+# tests/test_nfqws_reload_lists.py
+"""issue #265: правка списков должна доезжать до живого nfqws2 (SIGHUP).
+
+nfqws2 читает хостлисты/ipset-ы один раз при старте и перечитывает их только
+по SIGHUP. Без сигнала «добавил домен в Exclude» не действовало до
+перезапуска обхода — сайт продолжал ломаться десинком.
+"""
+
+import os
+import signal
+import tempfile
+import unittest
+from unittest import mock
+
+from core.config_manager import get_config_manager
+from core.hostlist_manager import get_hostlist_manager
+from core.ipset_manager import get_ipset_manager
+
+
+class TestReloadOnListWrite(unittest.TestCase):
+
+    def setUp(self):
+        self.cfg = get_config_manager()
+        self.cfg.load()
+        self.lists_dir = tempfile.mkdtemp()
+        self.ipset_dir = tempfile.mkdtemp()
+        self.cfg.set("zapret", "lists_path", self.lists_dir)
+        self.cfg.set("zapret", "ipset_path", self.ipset_dir)
+
+    # ── hostlists ──
+    def test_save_hostlist_signals_running_nfqws(self):
+        hm = get_hostlist_manager()
+        with mock.patch("core.nfqws_reload.find_nfqws_pids",
+                        return_value=[4242]), \
+             mock.patch("core.nfqws_reload.os.kill") as kill:
+            self.assertTrue(hm.save_hostlist("netrogat", ["aliexpress.ru"]))
+
+        kill.assert_called_once_with(4242, signal.SIGHUP)
+        with open(os.path.join(self.lists_dir, "netrogat.txt")) as f:
+            self.assertIn("aliexpress.ru", f.read())
+
+    def test_add_domains_signals_running_nfqws(self):
+        # Путь из GUI: «Добавить домен» в список исключений.
+        hm = get_hostlist_manager()
+        hm.save_hostlist("netrogat", [])
+        with mock.patch("core.nfqws_reload.find_nfqws_pids",
+                        return_value=[7]), \
+             mock.patch("core.nfqws_reload.os.kill") as kill:
+            self.assertEqual(hm.add_domains("netrogat", ["deepseek.com"]), 1)
+        kill.assert_called_once_with(7, signal.SIGHUP)
+
+    def test_save_hostlist_ok_when_nfqws_not_running(self):
+        # Обход выключен — запись обязана пройти без ошибок.
+        hm = get_hostlist_manager()
+        with mock.patch("core.nfqws_reload.find_nfqws_pids", return_value=[]):
+            self.assertTrue(hm.save_hostlist("other2", ["example.com"]))
+
+    def test_dead_pid_does_not_break_save(self):
+        hm = get_hostlist_manager()
+        with mock.patch("core.nfqws_reload.find_nfqws_pids",
+                        return_value=[999999]), \
+             mock.patch("core.nfqws_reload.os.kill",
+                        side_effect=ProcessLookupError()):
+            self.assertTrue(hm.save_hostlist("other2", ["example.com"]))
+
+    # ── ipsets ──
+    def test_save_ipset_signals_running_nfqws(self):
+        im = get_ipset_manager()
+        with mock.patch("core.nfqws_reload.find_nfqws_pids",
+                        return_value=[11]), \
+             mock.patch("core.nfqws_reload.os.kill") as kill:
+            self.assertTrue(im.save_ipset("my-ipset", ["1.2.3.4"]))
+        kill.assert_called_once_with(11, signal.SIGHUP)
+
+
+class TestFindNfqwsPids(unittest.TestCase):
+
+    def test_pidfile_and_proc_scan_are_merged_without_dupes(self):
+        from core import nfqws_reload
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
+            f.write("100\n")
+            pidfile = f.name
+        self.addCleanup(os.unlink, pidfile)
+
+        with mock.patch.object(nfqws_reload, "PID_FILES", (pidfile,)), \
+             mock.patch("core.nfqws_manager.NFQWSManager._find_nfqws_pids",
+                        return_value=[100, 200]):
+            self.assertEqual(nfqws_reload.find_nfqws_pids(), [100, 200])
+
+    def test_proc_scan_finds_pid_without_pidfile(self):
+        """GUI поднимает nfqws2 без --daemon — PID-файла может не быть."""
+        from core import nfqws_reload
+
+        with mock.patch.object(nfqws_reload, "PID_FILES", ()), \
+             mock.patch("core.nfqws_manager.NFQWSManager._find_nfqws_pids",
+                        return_value=[321]):
+            self.assertEqual(nfqws_reload.find_nfqws_pids(), [321])
+
+    def test_reload_reports_not_running(self):
+        from core import nfqws_reload
+
+        with mock.patch.object(nfqws_reload, "find_nfqws_pids",
+                               return_value=[]):
+            result = nfqws_reload.reload_lists("netrogat.txt")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["pids"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_undefined_names.py
+++ b/tests/test_no_undefined_names.py
@@ -1,0 +1,125 @@
+# tests/test_no_undefined_names.py
+"""Статический сторож: в коде нет обращений к несуществующим именам.
+
+`make lint` гоняет только ``ast.parse`` — он ловит синтаксис, но НЕ ловит
+опечатку в имени переменной. Именно так уехал issue #266: в цикле сканера
+осталось ``actual_idx >= total - 1`` вместо ``self._total``, и весь подбор
+стратегий падал в рантайме с ``name 'total' is not defined``.
+
+Проверка построена на stdlib-модуле ``symtable`` (без внешних зависимостей —
+на роутере их ставить нечем). Для каждой функции берём имена, которые она
+ЧИТАЕТ и которые резолвятся в глобальную область (``is_global()``), но при
+этом нигде в модуле не объявлены и не являются встроенными → это
+гарантированный ``NameError`` при исполнении ветки.
+
+Ложных срабатываний тут не бывает по построению: локальные, параметры и
+замыкания ``is_global()`` не возвращают. Единственное исключение — модульные
+дандеры (``__file__`` и т.п.), которых нет в таблице символов модуля.
+"""
+
+import builtins
+import os
+import symtable
+import unittest
+
+# Каталоги проекта, которые проверяем.
+CHECKED_DIRS = ("core", "api", "tools", "tests", "config")
+CHECKED_FILES = ("app.py",)
+
+# Дандеры модуля: реально существуют в рантайме, но в symtable модуля их нет.
+MODULE_DUNDERS = frozenset({
+    "__file__", "__name__", "__doc__", "__package__",
+    "__spec__", "__loader__", "__builtins__", "__debug__",
+})
+
+BUILTIN_NAMES = frozenset(dir(builtins)) | MODULE_DUNDERS
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _walk(table, module_globals, relpath, found):
+    """Рекурсивно собрать неразрешимые глобальные имена во вложенных областях."""
+    for sym in table.get_symbols():
+        # is_assigned() отсекает `global x; x = ...` — там имя создаётся.
+        if not (sym.is_referenced() and sym.is_global()
+                and not sym.is_assigned()):
+            continue
+        name = sym.get_name()
+        if name in module_globals or name in BUILTIN_NAMES:
+            continue
+        found.append(
+            "%s:%d  %s() → %s"
+            % (relpath, table.get_lineno(), table.get_name(), name)
+        )
+    for child in table.get_children():
+        _walk(child, module_globals, relpath, found)
+
+
+def _check_file(path):
+    relpath = os.path.relpath(path, PROJECT_ROOT)
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    try:
+        top = symtable.symtable(src, path, "exec")
+    except SyntaxError as e:          # ловится отдельно (make lint)
+        return ["%s: синтаксическая ошибка: %s" % (relpath, e)]
+
+    module_globals = {s.get_name() for s in top.get_symbols()}
+    found = []
+    for child in top.get_children():
+        _walk(child, module_globals, relpath, found)
+    return found
+
+
+def _iter_python_files():
+    for d in CHECKED_DIRS:
+        base = os.path.join(PROJECT_ROOT, d)
+        if not os.path.isdir(base):
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [n for n in dirnames if n != "__pycache__"]
+            for fn in sorted(filenames):
+                if fn.endswith(".py"):
+                    yield os.path.join(dirpath, fn)
+    for fn in CHECKED_FILES:
+        p = os.path.join(PROJECT_ROOT, fn)
+        if os.path.isfile(p):
+            yield p
+
+
+class TestNoUndefinedNames(unittest.TestCase):
+
+    def test_no_undefined_global_names(self):
+        problems = []
+        for path in _iter_python_files():
+            problems.extend(_check_file(path))
+
+        self.assertEqual(
+            problems, [],
+            "Обращение к несуществующим именам (гарантированный NameError "
+            "в рантайме):\n  " + "\n  ".join(problems),
+        )
+
+    def test_detector_catches_regression(self):
+        """Сам сторож работает — на образце issue #266 он срабатывает."""
+        import tempfile
+
+        sample = (
+            "SELF_TOTAL = 1\n"
+            "def scan(items):\n"
+            "    for idx, it in enumerate(items):\n"
+            "        if idx >= total - 1:\n"
+            "            return it\n"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".py",
+                                         delete=False) as f:
+            f.write(sample)
+            tmp = f.name
+        self.addCleanup(os.unlink, tmp)
+
+        found = _check_file(tmp)
+        self.assertTrue(any(item.endswith("total") for item in found), found)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_strategy_list_modes.py
+++ b/tests/test_strategy_list_modes.py
@@ -67,12 +67,40 @@ class TestListFlagModes(unittest.TestCase):
         self.assertEqual(self._flags("none"), [])
 
     # ── _inject_list_flags ──
-    def test_inject_respects_existing_hostlist(self):
+    def test_inject_keeps_exclude_with_existing_hostlist(self):
+        # issue #265: у профиля со своим include-списком предохранитель
+        # netrogat раньше терялся целиком — исключения не действовали.
         args = ["--filter-tcp=443", "--hostlist=/x/custom.txt",
                 "--lua-desync=multisplit"]
         out = self.sm._inject_list_flags(
             args, ["--hostlist-exclude=/y/netrogat.txt"])
-        self.assertEqual(out, args)  # не трогаем — профиль сам задал список
+        self.assertIn("--hostlist-exclude=/y/netrogat.txt", out)
+        self.assertIn("--hostlist=/x/custom.txt", out)   # свой список цел
+        self.assertEqual(len(out), len(args) + 1)
+
+    def test_inject_does_not_narrow_existing_hostlist(self):
+        # include/auto-флаги в чужой отбор не лезут — только exclude.
+        args = ["--filter-tcp=443", "--hostlist=/x/custom.txt",
+                "--lua-desync=multisplit"]
+        out = self.sm._inject_list_flags(
+            args, ["--hostlist-auto=/y/auto.txt",
+                   "--hostlist-exclude=/y/netrogat.txt"])
+        self.assertNotIn("--hostlist-auto=/y/auto.txt", out)
+        self.assertIn("--hostlist-exclude=/y/netrogat.txt", out)
+
+    def test_inject_respects_own_exclude(self):
+        # Профиль сам управляет исключениями — не трогаем.
+        args = ["--filter-tcp=443", "--hostlist-exclude=/x/mine.txt",
+                "--lua-desync=multisplit"]
+        out = self.sm._inject_list_flags(
+            args, ["--hostlist-exclude=/y/netrogat.txt"])
+        self.assertEqual(out, args)
+
+    def test_inject_skips_ipset_only_profile_without_exclude_flag(self):
+        # ipset-режим отдаёт пустой список флагов → профиль не меняется.
+        args = ["--filter-udp=443", "--ipset=/x/ipset-youtube.txt",
+                "--lua-desync=fake"]
+        self.assertEqual(self.sm._inject_list_flags(args, []), args)
 
     def test_inject_after_filter(self):
         args = ["--filter-tcp=443", "--lua-desync=multisplit"]


### PR DESCRIPTION
…#266)

issue #265 — «добавил сайт в Exclude, но не помогает»:

1. nfqws2 читает --hostlist / --hostlist-exclude / --ipset один раз, при разборе опций, и перечитывает их только по SIGHUP. GUI честно писал домен в lists/netrogat.txt, но живой движок продолжал работать со старой копией списка — исключение начинало действовать только после ручного перезапуска обхода. Добавлен core/nfqws_reload.py: запись любого списка доменов/IP шлёт SIGHUP всем живым nfqws2. PID ищется и по PID-файлам, и сканом /proc — GUI поднимает движок обычным Popen, без --daemon, так что PID-файла может не быть вовсе. strategy_state.reload_nfqws() переведён на тот же поиск.

2. Профиль, который сам несёт --hostlist= (полные winws2-пресеты), полностью пропускал подмешивание флагов списков — вместе с предохранителем --hostlist-exclude=netrogat.txt. На таких стратегиях пользовательские исключения не работали вообще. Теперь exclude доезжает и туда; include/auto-флаги по-прежнему не лезут в чужой отбор, а профиль со своим --hostlist-exclude не трогаем.

3. aliexpress.ru добавлен в дефолтные исключения (ломался десинком, ERR_TLS13_DOWNGRADE_DETECTED) — во все три представления netrogat.

issue #266 — «ERROR [scanner] Scanner error: name 'total' is not defined»:

В throttle-условии сохранения resume-state осталось необъявленное `total` вместо счётчика цикла — NameError ронял весь подбор стратегий на второй итерации. Сравниваем с len(strategies): idx нумерует срез, уже обрезанный по _start_index, поэтому self._total здесь дал бы ложные срабатывания при resume.

`make lint` (ast.parse) такой класс ошибок не ловит, поэтому добавлен статический сторож tests/test_no_undefined_names.py на stdlib-symtable: ищет чтение глобальных имён, которых нет ни в модуле, ни в builtins. На дереве до фикса он находит ровно строку из #266.


Claude-Session: https://claude.ai/code/session_01YN9VxZWcsmkR9pYSBreo9h