### PR TITLE
fix(diagnostics): Keenetic определялся как OpenWrt в «Системной инфор…

### DIFF
--- a/core/kmod_manager.py
+++ b/core/kmod_manager.py
@@ -97,18 +97,13 @@ def detect_pkg_manager():
 def _platform_kind():
     """keenetic | openwrt | entware | linux — лёгкий файловый детект.
 
-    Та же логика, что core/system_info._get_platform и
-    core/network_env._platform_kind (Keenetic проверяем раньше OpenWrt, т.к.
-    на Keenetic-Entware /etc/openwrt_release может отсутствовать, а ndnproxy —
-    характерный маркер).
+    Реализация одна на всех — core/system_info.platform_kind. Здесь это
+    критично: по платформе решается, можно ли ставить модули ядра (на
+    Keenetic нельзя), а прежняя копия проверок принимала Keenetic за
+    OpenWrt и предлагала несуществующий там opkg-пакет.
     """
-    if os.path.exists("/tmp/ndnproxy_acl"):
-        return "keenetic"
-    if os.path.exists("/etc/openwrt_release"):
-        return "openwrt"
-    if os.path.exists("/opt/etc/entware_release"):
-        return "entware"
-    return "linux"
+    from core.system_info import platform_kind
+    return platform_kind()
 
 
 def _detect_fw_type():

--- a/core/network_env.py
+++ b/core/network_env.py
@@ -71,17 +71,14 @@ def _route_lines():
 
 def _platform_kind() -> str:
     """
-    'keenetic' | 'openwrt' | 'entware' | 'linux' — лёгкий файловый детект
-    (та же логика, что core/system_info._get_platform; тяжёлый
-    awg_detector здесь ни к чему).
+    'keenetic' | 'openwrt' | 'entware' | 'linux' — лёгкий файловый детект.
+
+    Реализация одна на всех — core/system_info.platform_kind (тяжёлый
+    awg_detector здесь ни к чему). Раньше тут лежала своя копия проверок,
+    и на Keenetic без ndnproxy она отвечала «openwrt».
     """
-    if _exists("/tmp/ndnproxy_acl"):
-        return "keenetic"
-    if _exists("/etc/openwrt_release"):
-        return "openwrt"
-    if _exists("/opt/etc/entware_release"):
-        return "entware"
-    return "linux"
+    from core.system_info import platform_kind
+    return platform_kind()
 
 
 def list_interfaces() -> dict:

--- a/core/system_info.py
+++ b/core/system_info.py
@@ -3,10 +3,23 @@
 Сбор информации о системе роутера.
 
 Версия ядра, архитектура, RAM, uptime, IP-адреса.
+
+Здесь же живёт лёгкий детект платформы (`platform_kind`) — единственный
+источник правды для тех мест, где нельзя платить за тяжёлые пробы:
+эта функция вызывается на каждый опрос дашборда, поэтому она смотрит
+ТОЛЬКО файлы и PATH, без запуска ndmc/ndmq (их сессии на
+/var/run/ndm.core.socket забивают системный лог роутера).
+
+Для задач, где точность важнее цены (выбор бинарников, путей, init-
+скриптов), есть полноценный детектор — core/awg_detector.AwgDetector:
+он при необходимости дёргает `ndmc` и кэширует результат на процесс.
+Маркеры Keenetic здесь подобраны так, чтобы совпадать с ним.
 """
 
 import os
 import platform
+import re
+import shutil
 import subprocess
 
 
@@ -35,16 +48,87 @@ def _read_file(path: str, default: str = "") -> str:
         return default
 
 
-def _get_platform() -> str:
-    """Определить платформу (Keenetic, OpenWrt, generic Linux)."""
+def _is_keenetic() -> bool:
+    """Keenetic — по любому из дешёвых маркеров (без запуска ndmc).
+
+    Раньше признаком служил один `/tmp/ndnproxy_acl`, но этот файл
+    создаёт ndnproxy — компонент DNS-прокси KeenOS. У кого DNS отдан
+    dnsmasq/AdGuard (типовой случай для zapret-gui), файла нет, и роутер
+    определялся как «OpenWrt» (у KeenOS есть /etc/openwrt_release) либо
+    как «Entware».
+    """
     if os.path.exists("/tmp/ndnproxy_acl"):
-        return "Keenetic (NDMS)"
-    if os.path.exists("/etc/openwrt_release"):
-        return "OpenWrt"
-    if os.path.exists("/opt/etc/entware_release"):
-        release = _read_file("/opt/etc/entware_release")
-        return f"Entware ({release.split(chr(10))[0]})" if release else "Entware"
-    return "Linux"
+        return True
+    # Каталог хуков NDMS — им же пользуется firewall_persistence.is_keenetic.
+    if os.path.isdir("/opt/etc/ndm"):
+        return True
+    # Наличие CLI NDMS в PATH. Именно which, а не запуск: каждый вызов
+    # ndmc открывает сессию на ndm.core.socket и пишет в лог роутера.
+    if shutil.which("ndmc") or shutil.which("ndmq"):
+        return True
+    if "keenetic" in _read_file("/proc/version").lower():
+        return True
+    # KeenOS на OpenWrt-основе: файл есть, но это не «просто OpenWrt».
+    return "keenetic" in _read_file("/etc/openwrt_release").lower()
+
+
+def platform_kind() -> str:
+    """'keenetic' | 'openwrt' | 'entware' | 'linux' — лёгкий детект.
+
+    Keenetic проверяем раньше OpenWrt: у KeenOS бывает и
+    /etc/openwrt_release, и Entware, поэтому обратный порядок давал
+    неверную платформу.
+    """
+    if _is_keenetic():
+        return "keenetic"
+    if os.path.exists("/etc/openwrt_release") or \
+            os.path.exists("/etc/openwrt_version"):
+        return "openwrt"
+    if os.path.exists("/opt/etc/entware_release") or \
+            os.path.exists("/opt/bin/opkg"):
+        return "entware"
+    return "linux"
+
+
+def _keenos_version() -> str:
+    """Версия KeenOS из /proc/version, если она там есть (без ndmc)."""
+    m = re.search(r"Keenetic[^\d]*(\d+\.\d+\.\d+)",
+                  _read_file("/proc/version"), re.I)
+    if m:
+        return m.group(1)
+    m = re.search(r'DISTRIB_DESCRIPTION="[^"]*Keenetic[^"]*?(\d+\.\d+\.\d+)',
+                  _read_file("/etc/openwrt_release"), re.I)
+    return m.group(1) if m else ""
+
+
+def _openwrt_version() -> str:
+    """DISTRIB_RELEASE из /etc/openwrt_release."""
+    m = re.search(r"DISTRIB_RELEASE=['\"]?([^'\"\n]+)",
+                  _read_file("/etc/openwrt_release"))
+    return m.group(1).strip() if m else ""
+
+
+def _get_platform() -> str:
+    """Человекочитаемая платформа для карточки «Системная информация»."""
+    kind = platform_kind()
+    entware = os.path.exists("/opt/etc/entware_release") or \
+        os.path.exists("/opt/bin/opkg")
+
+    if kind == "keenetic":
+        ver = _keenos_version()
+        label = f"Keenetic {ver} (NDMS)" if ver else "Keenetic (NDMS)"
+    elif kind == "openwrt":
+        ver = _openwrt_version()
+        label = f"OpenWrt {ver}" if ver else "OpenWrt"
+    elif kind == "entware":
+        release = _read_file("/opt/etc/entware_release").split("\n")[0]
+        return f"Entware ({release})" if release else "Entware"
+    else:
+        return "Linux"
+
+    # Entware на Keenetic/OpenWrt — норма, и знать о нём полезно: именно
+    # там лежат наши бинарники и init-скрипты.
+    return f"{label} + Entware" if entware else label
 
 
 def _get_uptime() -> int:

--- a/tests/test_system_info_platform.py
+++ b/tests/test_system_info_platform.py
@@ -1,0 +1,183 @@
+# tests/test_system_info_platform.py
+"""
+Тесты лёгкого детекта платформы core/system_info.platform_kind().
+
+Он питает карточку «Системная информация» в разделе «Диагностика»,
+дашборд и решение kmod_manager «можно ли ставить модули ядра». Прежняя
+версия опознавала Keenetic по одному `/tmp/ndnproxy_acl` (файл ndnproxy),
+и на роутерах, где DNS отдан dnsmasq/AdGuard, платформа определялась как
+OpenWrt — у KeenOS есть /etc/openwrt_release.
+
+Файловую систему и PATH мокаем целиком: тесты должны давать один и тот же
+результат и на роутере, и на CI.
+"""
+
+import unittest
+from unittest import mock
+
+from core import system_info
+
+
+def _fake_env(paths=(), dirs=(), which=(), files=None):
+    """Контекст с подменённой ФС: exists/isdir/which/чтение файлов."""
+    paths = set(paths) | set(dirs)
+    dirs = set(dirs)
+    which = set(which)
+    files = files or {}
+
+    return (
+        mock.patch.object(system_info.os.path, "exists",
+                          side_effect=lambda p: p in paths),
+        mock.patch.object(system_info.os.path, "isdir",
+                          side_effect=lambda p: p in dirs),
+        mock.patch.object(system_info.shutil, "which",
+                          side_effect=lambda n: ("/opt/bin/%s" % n)
+                          if n in which else None),
+        mock.patch.object(system_info, "_read_file",
+                          side_effect=lambda p, default="": files.get(p, default)),
+    )
+
+
+class _EnvCase(unittest.TestCase):
+    """База: self.env(...) поднимает моки на время блока."""
+
+    def env(self, **kw):
+        patches = _fake_env(**kw)
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+
+class TestKeeneticMarkers(_EnvCase):
+
+    def test_ndm_hooks_dir(self):
+        self.env(dirs=["/opt/etc/ndm"])
+        self.assertEqual(system_info.platform_kind(), "keenetic")
+
+    def test_ndmc_in_path(self):
+        self.env(which=["ndmc"])
+        self.assertEqual(system_info.platform_kind(), "keenetic")
+
+    def test_ndmq_in_path(self):
+        self.env(which=["ndmq"])
+        self.assertEqual(system_info.platform_kind(), "keenetic")
+
+    def test_proc_version(self):
+        self.env(files={"/proc/version": "Linux version 4.9 (Keenetic 4.1.5)"})
+        self.assertEqual(system_info.platform_kind(), "keenetic")
+
+    def test_legacy_ndnproxy_marker_still_works(self):
+        self.env(paths=["/tmp/ndnproxy_acl"])
+        self.assertEqual(system_info.platform_kind(), "keenetic")
+
+    def test_openwrt_release_mentioning_keenetic(self):
+        self.env(paths=["/etc/openwrt_release"],
+                 files={"/etc/openwrt_release":
+                        'DISTRIB_DESCRIPTION="Keenetic 4.1.5"'})
+        self.assertEqual(system_info.platform_kind(), "keenetic")
+
+    def test_keenetic_without_ndnproxy_is_not_openwrt(self):
+        # Регрессия: DNS отдан dnsmasq → /tmp/ndnproxy_acl нет, а
+        # /etc/openwrt_release и Entware есть. Раньше выходил «OpenWrt».
+        self.env(paths=["/etc/openwrt_release", "/opt/etc/entware_release",
+                        "/opt/bin/opkg"],
+                 dirs=["/opt/etc/ndm"],
+                 files={"/etc/openwrt_release": "DISTRIB_RELEASE='19.07.7'"})
+        self.assertEqual(system_info.platform_kind(), "keenetic")
+
+
+class TestOtherPlatforms(_EnvCase):
+
+    def test_openwrt(self):
+        self.env(paths=["/etc/openwrt_release"],
+                 files={"/etc/openwrt_release": "DISTRIB_RELEASE='23.05.2'"})
+        self.assertEqual(system_info.platform_kind(), "openwrt")
+
+    def test_openwrt_by_version_file(self):
+        self.env(paths=["/etc/openwrt_version"])
+        self.assertEqual(system_info.platform_kind(), "openwrt")
+
+    def test_entware_by_release(self):
+        self.env(paths=["/opt/etc/entware_release"])
+        self.assertEqual(system_info.platform_kind(), "entware")
+
+    def test_entware_by_opkg(self):
+        # Entware на прошивке без openwrt_release (Padavan/ASUS и пр.).
+        self.env(paths=["/opt/bin/opkg"])
+        self.assertEqual(system_info.platform_kind(), "entware")
+
+    def test_plain_linux(self):
+        self.env()
+        self.assertEqual(system_info.platform_kind(), "linux")
+
+
+class TestHumanLabel(_EnvCase):
+
+    def test_keenetic_with_version_and_entware(self):
+        self.env(dirs=["/opt/etc/ndm"], paths=["/opt/bin/opkg"],
+                 files={"/proc/version": "Linux version 4.9-ndm (Keenetic 4.1.5)"})
+        self.assertEqual(system_info._get_platform(),
+                         "Keenetic 4.1.5 (NDMS) + Entware")
+
+    def test_keenetic_without_version(self):
+        self.env(dirs=["/opt/etc/ndm"])
+        self.assertEqual(system_info._get_platform(), "Keenetic (NDMS)")
+
+    def test_keenetic_version_from_openwrt_release(self):
+        self.env(paths=["/etc/openwrt_release"],
+                 files={"/etc/openwrt_release":
+                        'DISTRIB_DESCRIPTION="Keenetic 5.0.3 rc"'})
+        self.assertEqual(system_info._get_platform(), "Keenetic 5.0.3 (NDMS)")
+
+    def test_openwrt_with_release(self):
+        self.env(paths=["/etc/openwrt_release"],
+                 files={"/etc/openwrt_release": "DISTRIB_RELEASE='23.05.2'"})
+        self.assertEqual(system_info._get_platform(), "OpenWrt 23.05.2")
+
+    def test_openwrt_with_entware(self):
+        self.env(paths=["/etc/openwrt_release", "/opt/etc/entware_release"],
+                 files={"/etc/openwrt_release": "DISTRIB_RELEASE='23.05.2'"})
+        self.assertEqual(system_info._get_platform(), "OpenWrt 23.05.2 + Entware")
+
+    def test_entware_release_text(self):
+        self.env(paths=["/opt/etc/entware_release"],
+                 files={"/opt/etc/entware_release": "Entware 2024.05\nmipsel"})
+        self.assertEqual(system_info._get_platform(), "Entware (Entware 2024.05)")
+
+    def test_linux(self):
+        self.env()
+        self.assertEqual(system_info._get_platform(), "Linux")
+
+
+class TestNoSubprocessProbes(_EnvCase):
+    """Детект не должен запускать ndmc/ndmq: их сессии засоряют лог роутера,
+    а platform_kind вызывается на каждый опрос дашборда."""
+
+    def test_platform_kind_runs_no_commands(self):
+        self.env(dirs=["/opt/etc/ndm"])
+        with mock.patch.object(system_info.subprocess, "run") as run:
+            system_info.platform_kind()
+            system_info._get_platform()
+        run.assert_not_called()
+
+
+class TestSingleSourceOfTruth(unittest.TestCase):
+    """Копии детекта в других модулях сведены к общей функции."""
+
+    def test_network_env_delegates(self):
+        from core import network_env
+        with mock.patch("core.system_info.platform_kind",
+                        return_value="keenetic") as pk:
+            self.assertEqual(network_env._platform_kind(), "keenetic")
+        pk.assert_called_once()
+
+    def test_kmod_manager_delegates(self):
+        from core import kmod_manager
+        with mock.patch("core.system_info.platform_kind",
+                        return_value="openwrt") as pk:
+            self.assertEqual(kmod_manager._platform_kind(), "openwrt")
+        pk.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…мации»

Платформа в карточке опознавалась по одному маркеру — /tmp/ndnproxy_acl. Этот файл создаёт ndnproxy, DNS-прокси KeenOS. У кого DNS отдан dnsmasq или AdGuard (типовая для zapret-gui конфигурация), файла нет, проверка проваливалась на следующую — /etc/openwrt_release, — а он у KeenOS есть. Роутер показывался как «OpenWrt», а если файла не было — как «Entware» или «Linux».

Детект переписан на дешёвые, но надёжные маркеры (без запуска ndmc: platform_kind вызывается на каждый опрос дашборда, а каждая сессия на ndm.core.socket — строки в логе роутера):
  - каталог хуков NDMS /opt/etc/ndm;
  - ndmc/ndmq в PATH (только which, без exec);
  - «keenetic» в /proc/version или в /etc/openwrt_release;
  - прежний /tmp/ndnproxy_acl оставлен как дополнительный признак. Keenetic проверяется раньше OpenWrt, OpenWrt — раньше Entware.

Заодно строка стала информативнее: версия KeenOS/OpenWrt, когда её видно без запуска команд, и пометка «+ Entware» (там лежат наши бинарники).

Копий этой логики было три — в system_info, network_env и kmod_manager, причём две последние прямо ссылались комментарием на первую. Теперь источник один: core/system_info.platform_kind(). Для kmod_manager это не косметика: по платформе решается, можно ли ставить модули ядра, и на Keenetic с /etc/openwrt_release GUI раньше предлагал opkg-установку kmod-nfnetlink-queue, которой там взяться неоткуда.

Точный детектор (core/awg_detector, с ndmc и кэшем) остаётся для задач, где важнее точность, чем цена; маркеры Keenetic согласованы с ним.

Тесты: tests/test_system_info_platform.py — все маркеры, регрессия «Keenetic без ndnproxy → не OpenWrt», формат подписи, отсутствие subprocess-проб и делегирование из network_env/kmod_manager.


Claude-Session: https://claude.ai/code/session_01QzESFZqSehACB4eMmnoW5s