### PR TITLE
CI: action-gh-release на v3 — последнее предупреждение о Node 20

### DIFF
--- a/.github/workflows/build-awg-binaries.yml
+++ b/.github/workflows/build-awg-binaries.yml
@@ -564,7 +564,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.stage.outputs.tag }}
           name: "AWG binaries ${{ steps.stage.outputs.tag }}"

--- a/.github/workflows/build-opera-binaries.yml
+++ b/.github/workflows/build-opera-binaries.yml
@@ -328,7 +328,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.stage.outputs.tag }}
           name: "opera-proxy binaries ${{ steps.stage.outputs.tag }}"

--- a/.github/workflows/build-singbox-binaries.yml
+++ b/.github/workflows/build-singbox-binaries.yml
@@ -397,7 +397,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.stage.outputs.tag }}
           name: "sing-box binaries ${{ steps.stage.outputs.tag }}"

--- a/.github/workflows/build-tgproto-binaries.yml
+++ b/.github/workflows/build-tgproto-binaries.yml
@@ -301,7 +301,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.stage.outputs.tag }}
           name: "tg-mtproxy-client binaries ${{ steps.stage.outputs.tag }}"

--- a/.github/workflows/build-usque-binaries.yml
+++ b/.github/workflows/build-usque-binaries.yml
@@ -340,7 +340,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.stage.outputs.tag }}
           name: "usque binaries ${{ steps.stage.outputs.tag }}"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -187,7 +187,7 @@ jobs:
           echo "── Release notes ──"; cat /tmp/dev_notes.md
 
       - name: Create dev pre-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.build.outputs.dev_tag }}
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
           echo "$NOTES" > /tmp/release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "Zapret Web-GUI ${{ steps.version.outputs.tag }}"
           body_path: /tmp/release_notes.md


### PR DESCRIPTION
После обновления первых экшенов остался один источник: третьесторонний softprops/action-gh-release@v2 (виден в job «Publish release»). В v3 рантайм переехал с Node 20 на Node 24 — берём его во всех workflow.

Требование v3 — runner с поддержкой Node 24; на GitHub-hosted это уже так, для self-hosted апстрим оставил ветку v2.6.2.


Claude-Session: https://claude.ai/code/session_01VfNptDsUqJD1JZLnJ7o4aM