### PR TITLE
unified: failover уходил с исправного метода обратно на сломанный

### DIFF
--- a/core/unified/failover.py
+++ b/core/unified/failover.py
@@ -129,8 +129,12 @@ def step(route) -> dict:
     from core.unified import monitor, applier
     chain = route.method_chain()
     cur = current_method(route.id) or route.method
-    rate = monitor.success_rate(route.id)
-    samples = len(monitor.history(route.id))
+    # Успешность — ТОЛЬКО по замерам текущего метода. Со сквозной
+    # историей сразу после переключения окно состояло из провалов
+    # предыдущего метода, и маршрут уходил с исправного метода обратно
+    # на сломанный, как только истекал cooldown.
+    rate = monitor.success_rate(route.id, method=cur)
+    samples = len(monitor.history(route.id, method=cur))
     st = state(route.id)
     decision = decide(
         chain=chain, current=current_method(route.id),
@@ -141,6 +145,14 @@ def step(route) -> dict:
         return {"switched": False, "method": cur, "reason": decision["reason"]}
 
     new_method = decision["method"]
+    if new_method == cur:
+        # Первый шаг: активный метод ещё не зафиксирован, но он совпадает
+        # с основным. Просто запоминаем его. Переприменять маршрут здесь
+        # не нужно — он уже применён, а лишний apply означал бы снос и
+        # пересборку ipset'ов с перезагрузкой dnsmasq на ровном месте.
+        set_current(route.id, new_method)
+        return {"switched": False, "method": cur,
+                "reason": decision["reason"]}
     set_current(route.id, new_method)
     res = applier.apply_route(route, method=new_method)
     log.info("unified failover: маршрут %s %s → %s (%s)"

--- a/core/unified/monitor.py
+++ b/core/unified/monitor.py
@@ -7,16 +7,23 @@
 RAM (как traffic-буферы — без записи на flash).
 
 Архитектура:
-  - история: {route_id: deque[(ts, ok)]} (maxlen ограничен);
+  - история: {route_id: deque[(ts, ok, method)]} (maxlen ограничен);
   - `record()` — добавить замер;
   - `success_rate()` — доля успехов в окне (или None, если данных нет);
-  - `probe_destination()` — реальная проба (TLS-connect к probe-домену);
+  - `probe_route()` — реальная проба (TLS-connect к probe-домену);
   - фоновый цикл (singleton, default OFF) — `start()/stop()`.
 
 Проба намеренно простая и без внешних зависимостей: TCP+TLS handshake
 к <probe_domain>:443 с таймаутом. Это не полноценный DPI-тест (для него
 есть core/testers), а быстрый сигнал «достучались/нет» через текущий
 маршрут.
+
+Замер помнит МЕТОД, через который он сделан. Без этого failover считал
+успешность нового метода вместе с неудачами старого: сразу после
+переключения окно из 10 замеров почти целиком состояло из провалов
+предыдущего метода, rate оставался ниже порога, и по истечении cooldown
+маршрут уходил с исправного метода обратно на сломанный — и так по
+кругу.
 """
 
 import socket
@@ -35,32 +42,42 @@ _history_lock = threading.Lock()
 
 # ─────────────────────── history ─────────────────────────────────────
 
-def record(route_id: str, ok: bool, ts: float = None):
+def record(route_id: str, ok: bool, ts: float = None, method: str = ""):
     ts = ts if ts is not None else time.time()
     with _history_lock:
         dq = _history.get(route_id)
         if dq is None:
             dq = deque(maxlen=_HISTORY_MAXLEN)
             _history[route_id] = dq
-        dq.append((ts, bool(ok)))
+        dq.append((ts, bool(ok), method or ""))
 
 
-def history(route_id: str) -> list:
+def history(route_id: str, method: str = None) -> list:
+    """Замеры маршрута; с `method` — только сделанные через этот метод.
+
+    Замеры без метода (сделанные до того, как он стал записываться) при
+    фильтрации отбрасываются: приписать их какому-то методу нельзя, а
+    зачесть чужие провалы новому методу — ровно та ошибка, из-за которой
+    failover и уводил маршрут с исправного метода.
+    """
     with _history_lock:
         dq = _history.get(route_id)
-        return list(dq) if dq else []
+        items = list(dq) if dq else []
+    if method is None:
+        return items
+    return [e for e in items if len(e) > 2 and e[2] == method]
 
 
-def success_rate(route_id: str, window: int = 10):
+def success_rate(route_id: str, window: int = 10, method: str = None):
     """
     Доля успехов среди последних `window` замеров (0.0..1.0) или None,
-    если замеров ещё нет.
+    если замеров ещё нет. С `method` — только по замерам этого метода.
     """
-    h = history(route_id)
+    h = history(route_id, method=method)
     if not h:
         return None
     recent = h[-window:]
-    oks = sum(1 for _ts, ok in recent if ok)
+    oks = sum(1 for e in recent if e[1])
     return oks / len(recent)
 
 
@@ -74,24 +91,36 @@ def clear(route_id: str = None):
     with _history_lock:
         if route_id is None:
             _history.clear()
+            _warned_unprobeable.clear()
         else:
             _history.pop(route_id, None)
+            _warned_unprobeable.discard(route_id)
 
 
 def stats() -> dict:
-    """Сводка по всем маршрутам для UI/API."""
+    """Сводка по всем маршрутам для UI/API.
+
+    `rate` считается по замерам ТЕКУЩЕГО метода (метод последнего
+    замера) — иначе после переключения UI показывал бы успешность,
+    в которой половина провалов относится к уже брошенному методу.
+    """
     out = {}
     with _history_lock:
-        for rid, dq in _history.items():
-            data = list(dq)
-            recent = data[-10:]
-            oks = sum(1 for _t, ok in recent if ok)
-            out[rid] = {
-                "samples": len(data),
-                "rate": (oks / len(recent)) if recent else None,
-                "last_ok": data[-1][1] if data else None,
-                "last_ts": data[-1][0] if data else None,
-            }
+        snapshot = {rid: list(dq) for rid, dq in _history.items()}
+    for rid, data in snapshot.items():
+        if not data:
+            continue
+        method = data[-1][2] if len(data[-1]) > 2 else ""
+        same = [e for e in data if (e[2] if len(e) > 2 else "") == method]
+        recent = same[-10:]
+        oks = sum(1 for e in recent if e[1])
+        out[rid] = {
+            "samples": len(same),
+            "rate": (oks / len(recent)) if recent else None,
+            "last_ok": data[-1][1],
+            "last_ts": data[-1][0],
+            "method": method,
+        }
     return out
 
 
@@ -127,10 +156,19 @@ def probe_host(host: str, port: int = 443, timeout: float = 4.0,
             pass
 
 
-def probe_route(route) -> bool:
+def probe_route(route):
     """
     Проба маршрута: берём probe_domain (или первый домен назначения).
     Если доменов нет (только CIDR) — пробуем первый IP из cidrs.
+
+    Возвращает True/False, либо **None — «пробовать нечего»**. Последнее
+    бывает у маршрутов, назначение которых состоит только из geosite/
+    geoip: категории разворачивает движок, конкретного адреса у маршрута
+    нет. Раньше такой маршрут возвращал False, то есть выглядел вечно
+    деградировавшим, и failover бесконечно гонял его по всей цепочке
+    методов — включая заведомо неподходящие. Ответ None означает «нет
+    данных»: замер не пишется, решение не принимается. Чтобы включить
+    здесь failover, достаточно задать у маршрута probe_domain.
     """
     domain = (route.probe_domain or "").strip()
     if not domain:
@@ -143,7 +181,7 @@ def probe_route(route) -> bool:
             if cidrs:
                 host = cidrs[0].split("/", 1)[0]
                 return probe_host(host, port=443, tls=False)
-            return False
+            return None
     return probe_host(domain, port=443, tls=True)
 
 
@@ -184,7 +222,7 @@ class _MonitorLoop:
             self._stop.wait(self._interval)
 
     def _tick(self):
-        from core.unified import storage
+        from core.unified import storage, failover
         for route in storage.load_routes():
             # failover требует проб — поэтому пробуем маршрут, если включён
             # мониторинг ЛИБО автопереключение.
@@ -193,10 +231,15 @@ class _MonitorLoop:
             if not (route.monitor_enabled or route.failover_enabled):
                 continue
             ok = probe_route(route)
-            record(route.id, ok)
+            if ok is None:
+                _warn_unprobeable(route)
+                continue
+            # Замер принадлежит методу, через который он сделан:
+            # успешность считается по каждому методу отдельно.
+            record(route.id, ok,
+                   method=failover.current_method(route.id) or route.method)
             if route.failover_enabled:
                 try:
-                    from core.unified import failover
                     failover.step(route)
                 except Exception as e:
                     log.warning("unified failover step %s: %s"
@@ -204,6 +247,21 @@ class _MonitorLoop:
 
 
 _loop = _MonitorLoop()
+
+# Про какие маршруты уже сказали «пробовать нечего». Тик идёт раз в
+# минуту — без этого предупреждение засоряло бы лог бесконечно.
+_warned_unprobeable = set()
+
+
+def _warn_unprobeable(route) -> None:
+    if route.id in _warned_unprobeable:
+        return
+    _warned_unprobeable.add(route.id)
+    log.warning(
+        "unified monitor: у маршрута «%s» нечего пробовать (назначение —"
+        " только geosite/geoip). Мониторинг и автопереключение для него"
+        " не работают: укажите «домен для проверки» в настройках маршрута."
+        % (route.name or route.id), source="unified")
 
 
 def needs_monitor() -> bool:

--- a/tests/test_unified_monitor_failover.py
+++ b/tests/test_unified_monitor_failover.py
@@ -38,6 +38,31 @@ class TestMonitorHistory(unittest.TestCase):
         self.assertIn("r3", s)
         self.assertEqual(s["r3"]["samples"], 1)
 
+    def test_rate_is_per_method(self):
+        """Провалы старого метода не должны портить успешность нового."""
+        for _ in range(9):
+            monitor.record("r4", False, method="awg:awg0")
+        monitor.record("r4", True, method="nfqws2")
+        self.assertAlmostEqual(monitor.success_rate("r4", method="nfqws2"), 1.0)
+        self.assertAlmostEqual(monitor.success_rate("r4", method="awg:awg0"), 0.0)
+        # Без фильтра — как раньше, по всем замерам.
+        self.assertAlmostEqual(monitor.success_rate("r4"), 0.1)
+
+    def test_stats_reports_active_method_only(self):
+        for _ in range(9):
+            monitor.record("r5", False, method="awg:awg0")
+        monitor.record("r5", True, method="nfqws2")
+        s = monitor.stats()["r5"]
+        self.assertEqual(s["method"], "nfqws2")
+        self.assertAlmostEqual(s["rate"], 1.0)
+        self.assertEqual(s["samples"], 1)
+
+    def test_history_filter_drops_samples_without_method(self):
+        """Замер без метода нельзя зачесть новому методу."""
+        monitor.record("r6", False)
+        self.assertEqual(len(monitor.history("r6")), 1)
+        self.assertEqual(monitor.history("r6", method="nfqws2"), [])
+
 
 class TestFailoverDecide(unittest.TestCase):
 
@@ -102,10 +127,10 @@ class TestFailoverState(unittest.TestCase):
         route = UnifiedRoute(name="t", method="nfqws2",
                              fallbacks=["awg:awg0"],
                              destination=Destination(domains=["a.com"]))
-        # история — сплошные неудачи
+        # история — сплошные неудачи ТЕКУЩЕГО метода
         monitor.clear()
         for _ in range(10):
-            monitor.record(route.id, False)
+            monitor.record(route.id, False, method="nfqws2")
         failover.set_current(route.id, "nfqws2", ts=0)
         with mock.patch("core.unified.applier.apply_route",
                         return_value={"ok": True}) as ap:
@@ -113,6 +138,55 @@ class TestFailoverState(unittest.TestCase):
         self.assertTrue(res["switched"])
         self.assertEqual(res["method"], "awg:awg0")
         ap.assert_called_once()
+        monitor.clear()
+
+    def test_step_does_not_reapply_when_method_unchanged(self):
+        """Первый шаг лишь фиксирует активный метод.
+
+        Раньше он ещё и переприменял маршрут — то есть сносил и заново
+        собирал ipset'ы с перезагрузкой dnsmasq на ровном месте.
+        """
+        from core.unified.model import UnifiedRoute, Destination
+        route = UnifiedRoute(name="t", method="nfqws2",
+                             fallbacks=["awg:awg0"],
+                             destination=Destination(domains=["a.com"]))
+        monitor.clear()
+        with mock.patch("core.unified.applier.apply_route") as ap:
+            res = failover.step(route)
+        self.assertFalse(res["switched"])
+        ap.assert_not_called()
+        self.assertEqual(failover.current_method(route.id), "nfqws2")
+
+    def test_healthy_fallback_is_not_abandoned(self):
+        """Переключившись на исправный метод, маршрут на нём и остаётся.
+
+        Регрессия: успешность считалась по сквозной истории, поэтому
+        сразу после переключения окно состояло из провалов ПРЕДЫДУЩЕГО
+        метода. Через cooldown маршрут уходил с исправного метода обратно
+        на сломанный — и так по кругу.
+        """
+        from core.unified.model import UnifiedRoute, Destination
+        route = UnifiedRoute(name="t", method="awg:awg0",
+                             fallbacks=["nfqws2"],
+                             destination=Destination(domains=["a.com"]),
+                             failover_enabled=True)
+        healthy = "nfqws2"
+        monitor.clear()
+        now = [0.0]
+        switches = []
+        with mock.patch("core.unified.applier.apply_route",
+                        return_value={"ok": True}), \
+             mock.patch("core.unified.failover.time.time",
+                        side_effect=lambda: now[0]):
+            for _ in range(40):                       # 40 тиков по минуте
+                cur = failover.current_method(route.id) or route.method
+                monitor.record(route.id, cur == healthy, ts=now[0], method=cur)
+                r = failover.step(route)
+                if r.get("switched"):
+                    switches.append(r["method"])
+                now[0] += 60
+        self.assertEqual(switches, [healthy])
+        self.assertEqual(failover.current_method(route.id), healthy)
         monitor.clear()
 
 
@@ -160,6 +234,59 @@ class TestNeedsMonitorAutostart(unittest.TestCase):
             self.assertFalse(loop.running())
         finally:
             loop.stop()
+
+
+class TestUnprobeableRoutes(unittest.TestCase):
+    """Маршрут по geosite/geoip пробовать нечем — и это не «деградация».
+
+    Регрессия: probe_route возвращал False (конкретного адреса у такого
+    маршрута нет), маршрут выглядел вечно сломанным, и failover
+    бесконечно гонял его по всей цепочке методов.
+    """
+
+    def setUp(self):
+        monitor.clear()
+
+    def tearDown(self):
+        monitor.clear()
+
+    def _route(self, **kw):
+        from core.unified.model import UnifiedRoute, Destination
+        kw.setdefault("destination", Destination(geosite=["youtube"]))
+        return UnifiedRoute(name="geo", method="awg:awg0",
+                            fallbacks=["nfqws2"], failover_enabled=True, **kw)
+
+    def test_probe_returns_none_for_geo_only(self):
+        self.assertIsNone(monitor.probe_route(self._route()))
+
+    def test_probe_domain_makes_route_probeable(self):
+        route = self._route(probe_domain="youtube.com")
+        with mock.patch("core.unified.monitor.probe_host",
+                        return_value=True) as ph:
+            self.assertTrue(monitor.probe_route(route))
+        ph.assert_called_once()
+
+    def test_tick_records_nothing_and_skips_failover(self):
+        route = self._route()
+        loop = monitor._MonitorLoop()
+        with mock.patch("core.unified.storage.load_routes",
+                        return_value=[route]), \
+             mock.patch("core.unified.failover.step") as st:
+            loop._tick()
+        self.assertEqual(monitor.history(route.id), [])
+        st.assert_not_called()
+
+    def test_tick_records_active_method(self):
+        from core.unified.model import UnifiedRoute, Destination
+        route = UnifiedRoute(name="d", method="awg:awg0",
+                             destination=Destination(domains=["a.com"]),
+                             monitor_enabled=True)
+        loop = monitor._MonitorLoop()
+        with mock.patch("core.unified.storage.load_routes",
+                        return_value=[route]), \
+             mock.patch("core.unified.monitor.probe_route", return_value=True):
+            loop._tick()
+        self.assertEqual(monitor.history(route.id)[0][2], "awg:awg0")
 
 
 class TestFailoverNeedsProbeOnly(unittest.TestCase):

--- a/web/js/pages/routing_unified.js
+++ b/web/js/pages/routing_unified.js
@@ -634,6 +634,29 @@ const RoutingUnifiedPage = (() => {
 
     // ─────── редактор ───────
 
+    /**
+     * Предупреждение для маршрута, который нечем пробовать.
+     *
+     * geosite/geoip разворачивает движок — конкретного адреса у такого
+     * назначения нет, и фоновая проверка не знает, куда стучаться. Без
+     * probe-домена мониторинг и автопереключение для него просто не
+     * работают (бэкенд такой маршрут пропускает, см.
+     * core/unified/monitor.probe_route).
+     */
+    function probeHintHtml(e) {
+        const d = e.destination || {};
+        const hasGeo = (d.geosite || []).length || (d.geoip || []).length;
+        const hasAddr = (d.domains || []).length || (d.cidrs || []).length
+                      || (d.list_ids || []).length;
+        if (!hasGeo || hasAddr || (e.probe_domain || '').trim()) return '';
+        return `<span class="text-error" style="font-size:11px; margin-left:22px;">
+                    Назначение — только geosite/geoip: проверять нечего, и обе
+                    галки останутся без эффекта. Укажите «Probe-домен»
+                    (например, <code>youtube.com</code>) — он виден в режиме
+                    эксперта.
+                </span>`;
+    }
+
     function blankRoute() {
         // Пресет метода — по активному фильтру: на AWG-виде логично
         // сразу предлагать первый AWG-туннель.
@@ -752,6 +775,7 @@ const RoutingUnifiedPage = (() => {
                         <span class="text-muted" style="font-size:11px; margin-left:22px;">
                             Любая из галок включает фоновую проверку автоматически —
                             отдельно запускать мониторинг сверху не нужно.</span>
+                        ${probeHintHtml(e)}
                     </div>
                 </div>
                 ${typeof Expert !== 'undefined'


### PR DESCRIPTION
Проверка по жалобе «каждый метод по отдельности работает, а в правиле с несколькими — инет отваливается». Воспроизвёл симуляцией тиков монитора; нашлись две причины, обе приводят к бесконечной ротации по цепочке.

1. Успешность считалась по СКВОЗНОЙ истории маршрута, без привязки к методу. Монитор опрашивает раз в 60 с, cooldown между переключениями 180 с, окно rate — 10 замеров. Значит сразу после переключения в окне лежит максимум 3 свежих замера, а остальные 7 — провалы предыдущего метода. rate = 0.3 < порога 0.5 всегда, и по истечении cooldown маршрут уходил с ИСПРАВНОГО метода обратно на сломанный — независимо от того, работает новый метод или нет.

   Симуляция «основной сломан, запасной работает», 40 минут: было  — 4 переключения, исправный метод брошен на 6-й минуте; стало — 1 переключение, метод держится до конца.

   Замер теперь помнит метод, через который сделан; failover считает rate и samples только по замерам текущего метода. Свежий метод начинает с нуля замеров и получает честную отсрочку «мало данных» вместо чужого приговора.

2. probe_route() возвращал False для маршрутов, у которых назначение — только geosite/geoip. Категории разворачивает движок, конкретного адреса у маршрута нет и пробовать физически нечего, но False читался как «метод деградировал»: такой маршрут вечно выглядел сломанным и гонялся по всей цепочке методов, включая заведомо неподходящие. Теперь это None — «нет данных»: замер не пишется, решение не принимается, в лог один раз пишется совет задать probe-домен. В редакторе маршрута рядом с галкой failover появилось то же предупреждение — раньше настройка молча не работала.

Попутно: первый шаг failover фиксировал активный метод и ТУТ ЖЕ переприменял маршрут, хотя метод не менялся. Для доменного правила это снос и пересборка ipset'ов с перезагрузкой dnsmasq на ровном месте. Теперь при неизменном методе маршрут не трогается.

Когда не работает ни один метод цепочки, перебор продолжается — это намеренно.

Тесты: +9, включая симуляцию 40 тиков (исправный метод не бросается) и поведение непробуемых маршрутов.


Claude-Session: https://claude.ai/code/session_013zEdtdJjPUTZm9y5CCFrmZ