### PR TITLE
AWG: GUI не видел релизы, а новые не выпускались с мая

### DIFF
--- a/.github/workflows/build-awg-binaries.yml
+++ b/.github/workflows/build-awg-binaries.yml
@@ -52,6 +52,14 @@ jobs:
     name: Auto-tag on upstream release
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
+    outputs:
+      # Непустой = появилась новая комбинация версий, надо собирать ПРЯМО
+      # в этом прогоне. Полагаться на `on: push: tags` нельзя: тег пушится
+      # штатным GITHUB_TOKEN, а GitHub принципиально не запускает workflow
+      # от событий, порождённых этим токеном (защита от рекурсии). Из-за
+      # этого тег создавался, сборка не стартовала никогда, и cron годами
+      # оставался «зелёным» без единого релиза.
+      new_tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -59,6 +67,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect & maybe tag
+        id: tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -103,6 +112,7 @@ jobs:
           if git rev-parse "refs/tags/$NEW_TAG" >/dev/null 2>&1 \
              || gh api "repos/${{ github.repository }}/git/refs/tags/$NEW_TAG" >/dev/null 2>&1; then
             echo "Tag $NEW_TAG уже существует — пропускаем"
+            echo "new_tag=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -110,14 +120,23 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$NEW_TAG" -m "Auto: amneziawg-go=$GO_VER amneziawg-tools=$TOOLS_VER"
           git push origin "$NEW_TAG"
-          echo "Создан и запушен тэг $NEW_TAG — он триггернёт релизный run"
+          echo "new_tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          echo "Создан тэг $NEW_TAG — собираем и публикуем в этом же прогоне"
 
   # ── 1. Определить версии (для всех остальных триггеров) ────
   resolve-versions:
     name: Resolve upstream versions
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule'
+    needs: [auto-tag]
+    # always(), потому что для не-schedule событий auto-tag пропускается, и
+    # без него зависимый job тоже считался бы пропущенным.
+    if: |
+      always() && (
+        github.event_name != 'schedule' ||
+        needs.auto-tag.outputs.new_tag != ''
+      )
     outputs:
+      release_tag: ${{ needs.auto-tag.outputs.new_tag }}
       awg_go_ref: ${{ steps.resolve.outputs.awg_go_ref }}
       awg_tools_ref: ${{ steps.resolve.outputs.awg_tools_ref }}
       awg_go_version: ${{ steps.resolve.outputs.awg_go_version }}
@@ -500,7 +519,8 @@ jobs:
     needs: [resolve-versions, build-awg-go, build-awg-tools]
     if: |
       startsWith(github.ref, 'refs/tags/awg-bin-') ||
-      (github.event_name == 'workflow_dispatch' && inputs.publish_release == 'true')
+      (github.event_name == 'workflow_dispatch' && inputs.publish_release == 'true') ||
+      (github.event_name == 'schedule' && needs.resolve-versions.outputs.release_tag != '')
 
     steps:
       - name: Download all artifacts
@@ -519,8 +539,15 @@ jobs:
 
           GO_VER="${{ needs.resolve-versions.outputs.awg_go_version }}"
           TOOLS_VER="${{ needs.resolve-versions.outputs.awg_tools_version }}"
+          # Приоритет: тег, на который нас триггернули → тег, созданный
+          # auto-tag в этом же прогоне → manual-<дата> для ручных запусков.
+          # Без второго варианта плановый прогон публиковал релиз под
+          # именем manual-*, которого GUI не видит (он ищет awg-bin-*).
           TAG="${GITHUB_REF#refs/tags/}"
-          [ "$TAG" = "$GITHUB_REF" ] && TAG="manual-$(date -u +%Y%m%d%H%M%S)"
+          if [ "$TAG" = "$GITHUB_REF" ]; then
+            TAG="${{ needs.resolve-versions.outputs.release_tag }}"
+          fi
+          [ -n "$TAG" ] || TAG="manual-$(date -u +%Y%m%d%H%M%S)"
 
           REPO="${{ github.repository }}"
           BASE_URL="https://github.com/$REPO/releases/download/$TAG"

--- a/core/awg_installer.py
+++ b/core/awg_installer.py
@@ -44,6 +44,43 @@ from core.safe_io import is_safe_member_name
 HTTP_TIMEOUT = 30
 DOWNLOAD_TIMEOUT = 300
 
+def _looks_like_awg_assets(asset_names) -> bool:
+    """Ассеты релиза принадлежат именно AWG.
+
+    Нужно, чтобы принимать исторические релизы с тэгом `manual-<дата>`, но
+    не подхватить чужой релиз, у которого тоже есть `manifest.json`
+    (issue #111): проверяем не имя тэга, а содержимое.
+    """
+    return any(n.startswith("amneziawg-go-")
+               or n.startswith("amneziawg-tools-")
+               for n in asset_names)
+
+
+def _version_from_assets(asset_names, prefix: str) -> str:
+    """Версия из имени ассета `<prefix><version>-<arch>.tar.gz`.
+
+    У тэгов `manual-*` версий в имени нет, а показать их в списке надо —
+    иначе пользователь выбирает между несколькими одинаковыми строками.
+    """
+    for name in asset_names:
+        if not name.startswith(prefix) or not name.endswith(".tar.gz"):
+            continue
+        rest = name[len(prefix):-len(".tar.gz")]
+        # Отрезаем архитектуру справа: она всегда после последнего дефиса,
+        # но у `mips-softfloat` дефис внутри — поэтому режем по первому
+        # сегменту, который перестал быть похож на версию.
+        parts = rest.split("-")
+        ver = []
+        for p in parts:
+            if p and (p[0].isdigit() or (ver and p[0].isdigit())):
+                ver.append(p)
+            else:
+                break
+        if ver:
+            return "-".join(ver)
+    return ""
+
+
 DEFAULT_REPO         = "avatardd/zapret-gui"
 DEFAULT_TAG_PREFIX   = "awg-bin-"
 GITHUB_API_BASE      = "https://api.github.com"
@@ -370,10 +407,21 @@ class AwgInstaller:
     def list_releases(self, transport: str = "",
                       force: bool = False) -> dict:
         """
-        Релизы с бинарниками AWG (тэги awg-bin-* с manifest.json) для
-        выбора версии при установке. manual-* не включаем: их manifest
-        может принадлежать другому движку (issue #111), а опция
-        «Последняя» и так умеет manual-фолбэк. Кэш 5 минут.
+        Релизы с бинарниками AWG для выбора версии при установке.
+
+        Берём релизы с `manifest.json`, у которых тэг начинается на
+        `awg-bin-`, **а также** релизы с иным тэгом (исторические
+        `manual-<дата>`), если по именам ассетов видно, что это точно AWG.
+
+        Раньше `manual-*` отбрасывались целиком — из осторожности, потому
+        что их manifest мог принадлежать другому движку (issue #111). Но
+        AWG-релизы по факту публиковались именно под такими тэгами, а
+        `awg-bin-*` не существовало ни одного: список в GUI выходил пустым
+        («не видит релизы»), хотя установка работала — у неё свой
+        manual-фолбэк. Отсекаем чужое не по имени тэга, а по содержимому:
+        в релизе должны быть ассеты `amneziawg-go-*` / `amneziawg-tools-*`.
+
+        Кэш 5 минут.
         """
         s = self._settings()
         now = time.time()
@@ -392,10 +440,13 @@ class AwgInstaller:
             if not isinstance(rel, dict) or rel.get("draft"):
                 continue
             tag = rel.get("tag_name") or ""
-            if not tag.startswith(s["tag_prefix"]):
+            names = [(a.get("name") or "").lower()
+                     for a in rel.get("assets") or []]
+            if "manifest.json" not in names:
                 continue
-            if not any((a.get("name") or "").lower() == "manifest.json"
-                       for a in rel.get("assets") or []):
+            prefixed = tag.startswith(s["tag_prefix"])
+            if not prefixed and not _looks_like_awg_assets(names):
+                # Чужой релиз с manifest.json (issue #111) — не наш движок.
                 continue
             item = {"tag": tag,
                     "published_at": rel.get("published_at") or ""}
@@ -404,6 +455,16 @@ class AwgInstaller:
                 item["go_version"] = m.group("go")
                 item["tools_version"] = m.group("tools")
                 item["version"] = m.group("go")
+            else:
+                # Тэг без версий в имени (manual-*) — достаём их из имён
+                # ассетов: amneziawg-go-<ver>-<arch>.tar.gz.
+                go_v = _version_from_assets(names, "amneziawg-go-")
+                tools_v = _version_from_assets(names, "amneziawg-tools-")
+                if go_v:
+                    item["go_version"] = go_v
+                    item["version"] = go_v
+                if tools_v:
+                    item["tools_version"] = tools_v
             rels.append(item)
         out = {"ok": True, "releases": rels}
         with self._lock:

--- a/tests/test_awg_installer_arch.py
+++ b/tests/test_awg_installer_arch.py
@@ -154,3 +154,49 @@ class TestCheckForUpdatesArch(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestReleaseListingSeesManualTags(unittest.TestCase):
+    """Список релизов AWG в GUI не должен быть пустым (сообщение о баге).
+
+    Исторически бинарники AWG публиковались под тэгами `manual-<дата>`, а
+    релизов с тэгом `awg-bin-*` не существовало ни одного. list_releases()
+    отбрасывал всё, что не начинается на `awg-bin-`, поэтому в GUI список
+    выходил пустым — «не видит релизы». При этом установка работала: у неё
+    свой manual-фолбэк, отсюда и странность симптома.
+
+    Отсекать чужое надо по содержимому релиза, а не по имени тэга.
+    """
+
+    GO = "amneziawg-go-0.2.18-aarch64.tar.gz"
+    TOOLS = "amneziawg-tools-1.0.20260223-mips-softfloat.tar.gz"
+
+    def test_manual_tag_with_awg_assets_is_awg(self):
+        from core.awg_installer import _looks_like_awg_assets
+        self.assertTrue(_looks_like_awg_assets(
+            [self.GO, self.TOOLS, "manifest.json"]))
+
+    def test_foreign_release_with_manifest_is_rejected(self):
+        """issue #111: чужой релиз тоже носит manifest.json."""
+        from core.awg_installer import _looks_like_awg_assets
+        self.assertFalse(_looks_like_awg_assets(
+            ["usque-linux-arm64.tar.gz", "manifest.json"]))
+        self.assertFalse(_looks_like_awg_assets(["manifest.json"]))
+
+    def test_versions_recovered_from_asset_names(self):
+        """У manual-тэга версий в имени нет — берём их из ассетов."""
+        from core.awg_installer import _version_from_assets
+        names = [self.GO, self.TOOLS, "manifest.json"]
+        self.assertEqual(_version_from_assets(names, "amneziawg-go-"),
+                         "0.2.18")
+        # Архитектура mips-softfloat содержит дефис — версия не должна
+        # его захватить.
+        self.assertEqual(_version_from_assets(names, "amneziawg-tools-"),
+                         "1.0.20260223")
+
+    def test_version_missing_is_empty_not_crash(self):
+        from core.awg_installer import _version_from_assets
+        self.assertEqual(_version_from_assets(["manifest.json"],
+                                              "amneziawg-go-"), "")
+
+


### PR DESCRIPTION
Симптом «awg при проверке обновления не видит релизы» оказался двумя независимыми поломками. Установка при этом работала — у неё свой фолбэк, отсюда странность картины.

1. Релизы перестали выпускаться. Плановый прогон делает только job auto-tag: он создаёт тег awg-bin-go-<X>-tools-<Y> и рассчитывает, что сборку запустит триггер `on: push: tags`. Но тег пушится штатным GITHUB_TOKEN, а GitHub принципиально не запускает workflow от событий, порождённых этим токеном (защита от рекурсии). Тег создавался, сборка не стартовала, следующий cron видел «тег уже есть» и выходил с успехом. В итоге 8 тегов awg-bin-*, ноль релизов под ними и 30 из 30 «зелёных» прогонов подряд.

Теперь auto-tag отдаёт созданный тег наружу, а resolve-versions/publish принимают плановый прогон и доводят его до релиза в том же run. Имя тега для релиза берётся из auto-tag, а не превращается в manual-<дата>.

2. Существующие релизы не показывались. Бинарники исторически публиковались под тегами manual-<дата> (последние — amneziawg-go 0.2.18 + tools 1.0.20260223 от мая), а list_releases() отбрасывал всё, что не начинается на awg-bin-. Поскольку релизов с таким тегом не существовало вовсе, список выходил пустым.

Отбрасывание было не произвольным: manual-релиз мог принадлежать другому движку (issue #111). Но отсекать чужое правильнее по содержимому, а не по имени тега — теперь требуются ассеты amneziawg-go-*/amneziawg-tools-*, а версии для таких релизов достаются из имён ассетов (с учётом того, что в mips-softfloat дефис внутри архитектуры, а не в версии).


Claude-Session: https://claude.ai/code/session_01QibseTx3nhKpY6byqrQZkK