### PR TITLE
AWG: сборка пропускалась из-за транзитивного skip в needs

### DIFF
--- a/.github/workflows/build-awg-binaries.yml
+++ b/.github/workflows/build-awg-binaries.yml
@@ -213,6 +213,12 @@ jobs:
     name: Build amneziawg-go (${{ matrix.arch_name }})
     runs-on: ubuntu-latest
     needs: resolve-versions
+    # `needs` пропускает skip ТРАНЗИТИВНО: auto-tag не выполняется
+    # при workflow_dispatch/push, и неявный success() у наследников
+    # проверяет всех предков цепочки, а не только прямого. Без
+    # status-функции в if() сборка молча пропускалась. `!cancelled()`
+    # отменяет неявную проверку, результат предка проверяем явно.
+    if: ${{ !cancelled() && needs.resolve-versions.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -341,6 +347,12 @@ jobs:
     name: Build amneziawg-tools (${{ matrix.arch_name }})
     runs-on: ubuntu-latest
     needs: resolve-versions
+    # `needs` пропускает skip ТРАНЗИТИВНО: auto-tag не выполняется
+    # при workflow_dispatch/push, и неявный success() у наследников
+    # проверяет всех предков цепочки, а не только прямого. Без
+    # status-функции в if() сборка молча пропускалась. `!cancelled()`
+    # отменяет неявную проверку, результат предка проверяем явно.
+    if: ${{ !cancelled() && needs.resolve-versions.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -517,10 +529,18 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     needs: [resolve-versions, build-awg-go, build-awg-tools]
+    # !cancelled() — та же причина, что у build-* выше: без status-функции
+    # неявный success() учитывает пропущенный auto-tag и валит весь publish.
+    # Успех самих сборок поэтому проверяем явно.
     if: |
-      startsWith(github.ref, 'refs/tags/awg-bin-') ||
-      (github.event_name == 'workflow_dispatch' && inputs.publish_release == 'true') ||
-      (github.event_name == 'schedule' && needs.resolve-versions.outputs.release_tag != '')
+      !cancelled()
+      && needs.build-awg-go.result == 'success'
+      && needs.build-awg-tools.result == 'success'
+      && (
+        startsWith(github.ref, 'refs/tags/awg-bin-') ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish_release == 'true') ||
+        (github.event_name == 'schedule' && needs.resolve-versions.outputs.release_tag != '')
+      )
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
Регрессия из предыдущего коммита: добавив `needs: [auto-tag]` к resolve-versions, я отравил всю цепочку. В GitHub Actions skip распространяется по needs ТРАНЗИТИВНО — неявный success() у наследника проверяет всех предков графа, а не только прямого. При workflow_dispatch и push job auto-tag не выполняется, поэтому build-awg-go/build-awg-tools и publish молча пропускались: прогон #93 отработал за 13 секунд, «успешно» и без артефактов.

Лечится status-функцией в if(): она отменяет неявную проверку, и результат предка проверяется явно. У build-* — !cancelled() плюс needs.resolve-versions.result == 'success', у publish — то же плюс явная проверка успеха обеих сборок, чтобы релиз не публиковался из пустоты.


Claude-Session: https://claude.ai/code/session_01QibseTx3nhKpY6byqrQZkK