### PR TITLE
Версия Go для сборок берётся из go.mod апстрима, а не зашита

### DIFF
--- a/.github/workflows/build-awg-binaries.yml
+++ b/.github/workflows/build-awg-binaries.yml
@@ -253,7 +253,14 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.22'
+          # Версию берём ИЗ go.mod самого амнезиевского исходника, а не
+          # прибиваем гвоздём. Апстрим прыгнул с 0.2.19 сразу на 3.0.x и
+          # поднял требование до go >= 1.25; с зашитым '1.22' сборка падала
+          # на `go.mod requires go >= 1.25.0 (running go 1.22.12;
+          # GOTOOLCHAIN=local)` — setup-go выставляет GOTOOLCHAIN=local, так
+          # что сам Go подтянуть новый toolchain не может. С go-version-file
+          # версия следует за апстримом автоматически.
+          go-version-file: src/go.mod
           cache: false
 
       - name: Install UPX

--- a/.github/workflows/build-singbox-binaries.yml
+++ b/.github/workflows/build-singbox-binaries.yml
@@ -230,8 +230,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          # sing-box традиционно требует свежий Go; берём с запасом.
-          go-version: '1.23'
+          # Версию берём ИЗ go.mod самого sing-box, а не прибиваем гвоздём:
+          # «с запасом» устаревает молча. На v1.13.15 апстрим требует уже
+          # go 1.24.7, и зашитый '1.23' валил бы сборку на
+          # `go.mod requires go >= 1.24.7 ... GOTOOLCHAIN=local` (setup-go
+          # выставляет GOTOOLCHAIN=local, сам Go новый toolchain не тянет).
+          # Так же сделано у opera/usque/tgproto/awg.
+          go-version-file: src/go.mod
           cache: false
 
       - name: Install UPX (mipsel/mips/armv7 only)


### PR DESCRIPTION
Сборка amneziawg-go падала на всех пяти архитектурах:

  go: go.mod requires go >= 1.25.0 (running go 1.22.12; GOTOOLCHAIN=local)

Прямое следствие скачка апстрима 0.2.19 → 3.0.x: в go.mod v3.0.3 стоит go 1.25.0, а в workflow было прибито go-version: '1.22'. Сам Go подтянуть новый toolchain не мог — setup-go выставляет GOTOOLCHAIN=local.

Теперь go-version-file: src/go.mod, то есть версия следует за апстримом автоматически. Это и есть конвенция проекта — opera, usque и tgproto так делают давно, выбивались только awg и singbox.

Заодно та же мина обезврежена у sing-box: там было зашито '1.23' с комментарием «берём с запасом», а v1.13.15 требует уже go 1.24.7 — следующая сборка упала бы ровно так же. Зашитых версий Go в workflow'ах больше не осталось.


Claude-Session: https://claude.ai/code/session_01QibseTx3nhKpY6byqrQZkK