### PR TITLE
Страница «Обновления»: AWG показывал прочерки, usque звал откатиться

### DIFF
--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -18,6 +18,7 @@ Unified Update Checker: проверка обновлений ВСЕХ бина�
 """
 
 import json
+import re
 import threading
 import time
 import urllib.request
@@ -178,18 +179,33 @@ def _check_mihomo() -> dict:
 
 
 def _check_awg() -> dict:
-    """Проверить AmneziaWG."""
+    """Проверить AmneziaWG.
+
+    Ключи берём ровно те, что отдаёт `check_for_updates()`. Раньше здесь
+    читались несуществующие: `installed.version` (на деле `go_version`),
+    `latest.version` (плоские `latest_go`/`latest_tag`) и `has_update`
+    (на деле `update_available`). Из-за этого на странице «Обновления»
+    AmneziaWG всегда показывал «–» и никогда не предлагал обновление,
+    хотя своя страница AWG ту же новую версию видела — она читает
+    правильные поля.
+    """
     try:
         from core.awg_installer import get_awg_installer
         inst = get_awg_installer()
         result = inst.check_for_updates()
+        if not result.get("ok"):
+            return {"name": "awg", "display_name": "AmneziaWG",
+                    "installed": False, "current": "", "latest": "",
+                    "has_update": False,
+                    "error": result.get("error") or "нет манифеста"}
+        inst_info = result.get("installed") or {}
         return {
             "name": "awg",
             "display_name": "AmneziaWG",
-            "installed": result.get("installed", {}).get("installed", False),
-            "current": result.get("installed", {}).get("version", ""),
-            "latest": result.get("latest", {}).get("version", ""),
-            "has_update": result.get("has_update", False),
+            "installed": bool(inst_info.get("installed")),
+            "current": inst_info.get("go_version") or "",
+            "latest": result.get("latest_go") or "",
+            "has_update": bool(result.get("update_available")),
         }
     except Exception as e:
         return {"name": "awg", "display_name": "AmneziaWG",
@@ -226,16 +242,20 @@ def _check_usque() -> dict:
         from core.usque_manager import get_usque_manager
         mgr = get_usque_manager()
         env = mgr.detect()
-        # Проверяем GitHub releases
-        latest = _github_latest("side-effect-tm/usque-keenetic")
+        # Источник — НАША сборка (релизы `usque-bin-<версия>` в этом же
+        # репозитории), ровно откуда ставит установщик. Раньше спрашивали
+        # `side-effect-tm/usque-keenetic` — это давно лишь ЗАПАСНОЙ источник,
+        # который отстаёт от самого usque: его последний релиз 0.3.0 несёт
+        # usque 4.2.0. В итоге при установленной 4.2.1 «последней» значилась
+        # 0.3.0, и GUI предлагал обновиться назад.
+        latest = _latest_from_our_release("usque")
         return {
             "name": "usque",
             "display_name": "usque (WARP/MASQUE)",
             "installed": env.get("installed", False),
             "current": env.get("version", ""),
             "latest": latest,
-            "has_update": bool(latest and env.get("version") and
-                               latest != env["version"]),
+            "has_update": _is_newer(latest, env.get("version", "")),
         }
     except Exception as e:
         return {"name": "usque", "display_name": "usque (WARP/MASQUE)",
@@ -360,6 +380,55 @@ def _check_opera() -> dict:
         return {"name": "opera", "display_name": "opera-proxy",
                 "installed": False, "current": "", "latest": "",
                 "has_update": False, "error": str(e)}
+
+
+def _latest_from_our_release(name: str) -> str:
+    """Версия последнего НАШЕГО релиза бинарника `name`.
+
+    Мы собираем часть движков сами и публикуем как `<name>-bin-<версия>`
+    в собственном репозитории — установщик берёт их именно оттуда
+    (`BINARIES[name]["release_prefix"]`). Спрашивать вместо этого чужой
+    репозиторий-донор неверно: он живёт своей жизнью и отстаёт, отчего
+    «последняя» версия оказывается старше установленной.
+    """
+    try:
+        from core.ext_binary_installer import (BINARIES,
+                                               github_release_by_prefix)
+        cfg = BINARIES.get(name) or {}
+        prefix = cfg.get("release_prefix") or ""
+        repo = cfg.get("repo") or ""
+        if not prefix or not repo:
+            return ""
+        rel = github_release_by_prefix(repo, prefix) or {}
+        tag = rel.get("tag_name") or ""
+        return tag[len(prefix):].lstrip("v") if tag.startswith(prefix) else ""
+    except Exception:
+        return ""
+
+
+def _version_tuple(v: str):
+    """Числовой ключ версии; None — не разбирается."""
+    m = re.match(r"^v?(\d+(?:\.\d+)*)", (v or "").strip())
+    if not m:
+        return None
+    return tuple(int(x) for x in m.group(1).split("."))
+
+
+def _is_newer(latest: str, current: str) -> bool:
+    """Есть ли смысл предлагать обновление.
+
+    Сравниваем ЧИСЛАМИ, а не `!=`. Простое неравенство строк даёт две
+    беды: предлагает «обновиться» на версию старше (usque 4.2.1 → 0.3.0)
+    и срабатывает на разнице записи одной и той же версии. Если версии
+    не разбираются как числа — откатываемся на строгое неравенство,
+    чтобы не потерять обновление там, где формат нестандартный.
+    """
+    if not latest or not current:
+        return False
+    lv, cv = _version_tuple(latest), _version_tuple(current)
+    if lv is None or cv is None:
+        return latest.strip() != current.strip()
+    return lv > cv
 
 
 def _github_latest(repo: str) -> str:

--- a/tests/test_update_checker_interval.py
+++ b/tests/test_update_checker_interval.py
@@ -12,6 +12,7 @@
 import unittest
 
 from core import update_checker as uc
+import core.update_checker as uc
 
 
 class TestSaneInterval(unittest.TestCase):
@@ -70,3 +71,85 @@ class TestDaemonStartStopRace(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestVersionComparison(unittest.TestCase):
+    """«Обновление есть» = версия НОВЕЕ, а не «отличается».
+
+    Строковое `!=` давало абсурд: у usque установлено 4.2.1, «последней»
+    значилась 0.3.0 (её брали из запасного репозитория-донора), и GUI
+    предлагал обновиться назад.
+    """
+
+    def test_older_latest_is_not_an_update(self):
+        self.assertFalse(uc._is_newer("0.3.0", "4.2.1"))
+
+    def test_newer_latest_is_an_update(self):
+        self.assertTrue(uc._is_newer("4.2.1", "4.2.0"))
+        self.assertTrue(uc._is_newer("1.19.29", "1.19.27"))
+
+    def test_compare_is_numeric_not_lexicographic(self):
+        """'1.9.7' > '1.13.0' как строки, но 1.13 новее."""
+        self.assertFalse(uc._is_newer("1.9.7", "1.13.0"))
+        self.assertTrue(uc._is_newer("1.13.0", "1.9.7"))
+
+    def test_same_version_is_not_an_update(self):
+        self.assertFalse(uc._is_newer("1.0.4", "1.0.4"))
+        self.assertFalse(uc._is_newer("v1.0.4", "1.0.4"))
+
+    def test_missing_side_is_not_an_update(self):
+        self.assertFalse(uc._is_newer("", "1.0"))
+        self.assertFalse(uc._is_newer("1.0", ""))
+
+    def test_unparseable_falls_back_to_inequality(self):
+        """Нестандартный формат — лучше предложить, чем потерять."""
+        self.assertTrue(uc._is_newer("20260726-ab13e3d", "20260101-000000f"))
+        self.assertFalse(uc._is_newer("abc", "abc"))
+
+
+class TestAwgResultContract(unittest.TestCase):
+    """Страница «Обновления» читает те же поля, что отдаёт установщик AWG.
+
+    Раньше читались несуществующие ключи (`installed.version`,
+    `latest.version`, `has_update`), поэтому AmneziaWG всегда показывал
+    «–» и не предлагал обновление — при том что своя страница AWG новую
+    версию видела.
+    """
+
+    def _run_with(self, payload):
+        from unittest import mock
+        inst = mock.Mock()
+        inst.check_for_updates.return_value = payload
+        with mock.patch("core.awg_installer.get_awg_installer",
+                        return_value=inst):
+            return uc._check_awg()
+
+    def test_versions_and_flag_are_extracted(self):
+        row = self._run_with({
+            "ok": True,
+            "installed": {"installed": True, "go_version": "0.2.18",
+                          "tools_version": "1.0.20260223", "tag": "old"},
+            "latest_go": "3.0.3", "latest_tools": "3.0.20260730",
+            "latest_tag": "awg-bin-go-3.0.3-tools-3.0.20260730",
+            "update_available": True,
+        })
+        self.assertTrue(row["installed"])
+        self.assertEqual(row["current"], "0.2.18")
+        self.assertEqual(row["latest"], "3.0.3")
+        self.assertTrue(row["has_update"])
+
+    def test_no_update_when_installer_says_so(self):
+        row = self._run_with({
+            "ok": True,
+            "installed": {"installed": True, "go_version": "3.0.3"},
+            "latest_go": "3.0.3", "update_available": False,
+        })
+        self.assertFalse(row["has_update"])
+        self.assertEqual(row["current"], "3.0.3")
+
+    def test_failed_check_reports_error_not_silence(self):
+        row = self._run_with({"ok": False, "error": "нет манифеста"})
+        self.assertFalse(row["has_update"])
+        self.assertIn("error", row)
+
+


### PR DESCRIPTION
Оба симптома из одного места — core/update_checker.py, агрегатор ходит мимо тех контрактов, которые используют сами страницы движков.

1. AmneziaWG всегда «–» и никогда не предлагал обновление. _check_awg читал ключи, которых в ответе нет: installed.version (на деле go_version), latest.version (на деле плоские latest_go/latest_tag) и has_update (на деле update_available). Своя страница AWG ту же новую версию видела, потому что читает правильные поля — отсюда и расхождение между разделами. Добавлена и обработка ok=false: раньше неудачная проверка выглядела как «обновлений нет».

2. usque предлагал обновиться с 4.2.1 на 0.3.0. «Последнюю» версию брали из side-effect-tm/usque-keenetic — это давно лишь ЗАПАСНОЙ источник, который отстаёт от самого usque (в его релизе 0.3.0 лежит usque 4.2.0). Теперь версия берётся из нашего релиза usque-bin-*, ровно оттуда же, откуда ставит установщик.

Заодно сравнение версий стало числовым (_is_newer) вместо строкового `!=`. Неравенство строк не только пропускало откаты назад, но и считало бы «1.9.7» новее «1.13.0». Для неразбираемых форматов остаётся прежнее поведение — лучше предложить лишнее, чем потерять обновление.


Claude-Session: https://claude.ai/code/session_01QibseTx3nhKpY6byqrQZkK