### PR TITLE
Проверка бинарника ловит и чужую разрядность, а не только e_machine

### DIFF
--- a/core/ext_binary_installer.py
+++ b/core/ext_binary_installer.py
@@ -490,6 +490,12 @@ _ELF_MACHINES = {
 }
 
 
+def _host_bits() -> int:
+    """Разрядность системы (по интерпретатору — он собран под неё же)."""
+    import sys
+    return 64 if sys.maxsize > 2 ** 32 else 32
+
+
 def _elf_arch(path: str):
     """
     (arch, error): что за файл лежит по пути.
@@ -497,6 +503,11 @@ def _elf_arch(path: str):
     arch — наше имя архитектуры ('mipsel'/'mips'/'aarch64'/'armv7'/
     'x86_64') либо '' если распознать не удалось. error — человеческое
     объяснение, если файл заведомо не исполняемый.
+
+    Разрядность (EI_CLASS) проверяется отдельно от e_machine: 64-битная
+    сборка на 32-битном роутере — самый частый способ получить «Exec
+    format error», и ловить её нужно даже когда e_machine нам незнаком
+    (mips64el, riscv и прочее, чего нет в таблице).
     """
     try:
         with open(path, "rb") as f:
@@ -516,6 +527,13 @@ def _elf_arch(path: str):
 
     if len(head) < 20:
         return "", "ELF-заголовок обрезан — файл повреждён"
+
+    bits = 64 if head[4] == 2 else 32     # EI_CLASS: 1 = 32-bit, 2 = 64-bit
+    host_bits = _host_bits()
+    if bits != host_bits:
+        return "", ("%d-битная сборка, а система %d-битная"
+                    % (bits, host_bits))
+
     little = head[5] == 1                 # EI_DATA: 1 = LSB, 2 = MSB
     machine = (head[18] | (head[19] << 8)) if little \
         else (head[19] | (head[18] << 8))

--- a/tests/test_ext_installer_exec_check.py
+++ b/tests/test_ext_installer_exec_check.py
@@ -29,16 +29,21 @@ from core import ext_binary_installer as ebi
 
 # Минимальные ELF-заголовки: 64 байта, дальше содержимое не важно —
 # _elf_arch читает только e_ident/e_machine.
-def _elf(machine: int, little: bool = True) -> bytes:
+def _elf(machine: int, little: bool = True, bits: int = 0) -> bytes:
     head = bytearray(64)
     head[0:4] = b"\x7fELF"
-    head[4] = 1                       # ELFCLASS32
+    head[4] = 2 if (bits or _host_bits()) == 64 else 1   # EI_CLASS
     head[5] = 1 if little else 2      # EI_DATA
     if little:
         head[18], head[19] = machine & 0xFF, machine >> 8
     else:
         head[18], head[19] = machine >> 8, machine & 0xFF
     return bytes(head) + b"\0" * 64
+
+
+def _host_bits() -> int:
+    import sys
+    return 64 if sys.maxsize > 2 ** 32 else 32
 
 
 ELF_MIPSEL = _elf(0x08, little=True)
@@ -78,6 +83,22 @@ class TestElfArch(unittest.TestCase):
         arch, err = ebi._elf_arch(self._write(b"<!DOCTYPE html><html>404"))
         self.assertEqual(arch, "")
         self.assertIn("HTML", err)
+
+    def test_wrong_bitness_is_reported(self):
+        """64-битная сборка на 32-битном роутере — ровно случай
+        пользователя: `od -c` показал `177 E L F 002` (EI_CLASS=2)."""
+        other = 32 if _host_bits() == 64 else 64
+        arch, err = ebi._elf_arch(self._write(_elf(0x08, bits=other)))
+        self.assertEqual(arch, "")
+        self.assertIn("битная", err)
+        self.assertIn(str(other), err)
+
+    def test_unknown_machine_with_wrong_bitness_still_caught(self):
+        """Даже незнакомый e_machine не должен проскочить по разрядности."""
+        other = 32 if _host_bits() == 64 else 64
+        arch, err = ebi._elf_arch(self._write(_elf(0xF3, bits=other)))
+        self.assertEqual(arch, "")
+        self.assertTrue(err)
 
 
 class TestVerifyInstalledBinary(unittest.TestCase):


### PR DESCRIPTION
У пользователя на mipsel-роутере в /opt/usr/bin/usque лежит 64-битный ELF: `head -c 8 … | od -c` → `177 E L F 002` (EI_CLASS=2). Такой файл ядро не запустит никогда — отсюда «[Errno 8] Exec format error».

Прежняя проверка сравнивала e_machine с архитектурой системы и этот файл поймала бы (x86_64/aarch64 ≠ mipsel), но ровно до тех пор, пока e_machine есть в таблице: для mips64el (машина та же, что у mips) или любой незнакомой архитектуры arch выходил пустым, сравнивать было не с чем, и оставался только сам запуск. Теперь разрядность сверяется отдельно и первой — и в сообщении видно ровно то, что случилось: «64-битная сборка, а система 32-битная».

Регрессия: tests/test_ext_installer_exec_check.py


Claude-Session: https://claude.ai/code/session_01GDkaqcd5j4acHFGjKxy33A