### PR TITLE
Публикация релиза больше не зависит от codeload.github.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,15 +161,27 @@ jobs:
           path: release-artifacts/
 
   # ── 3. Публикация релиза ────────────────────────────────────
+  #
+  # В этом job'е намеренно НЕТ ни одного `uses:`. Каждый action раннер
+  # тянет с codeload.github.com в шаге «Set up job» — до единой строки
+  # нашего кода. Когда codeload отвечает 429/502/503, job падает там же:
+  # так v0.24.16 не вышел (run #153, обе попытки — три ретрая раннера и
+  # отказ на actions/download-artifact). Пакеты при этом собраны и лежат
+  # артефактом. gh CLI предустановлен в образе раннера и не скачивается,
+  # поэтому публикация больше не зависит от доступности codeload.
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+    permissions:
+      contents: write
+      actions: read           # gh run download читает артефакт этого прогона
 
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
       - name: Extract version
         id: version
         run: |
@@ -179,36 +191,55 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: release-packages
-          path: ./artifacts
+        run: |
+          mkdir -p artifacts
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name release-packages --dir artifacts
+          echo "── Артефакты релиза ──"
+          ls -lh artifacts/
 
+      # CHANGELOG берём через API, а не checkout'ом: ради одного файла
+      # тянуть action (и рисковать тем же codeload) незачем.
       - name: Extract changelog
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           VERSION="${{ steps.version.outputs.version }}"
           NOTES=""
-          if [ -f CHANGELOG.md ]; then
-            NOTES=$(awk "/^## $TAG|^## v?$VERSION/{found=1; next} /^## /{if(found) exit} found{print}" CHANGELOG.md)
+          if gh api "repos/$GITHUB_REPOSITORY/contents/CHANGELOG.md?ref=$TAG" \
+                 -H "Accept: application/vnd.github.raw" > /tmp/CHANGELOG.md; then
+            NOTES=$(awk "/^## $TAG|^## v?$VERSION/{found=1; next} /^## /{if(found) exit} found{print}" /tmp/CHANGELOG.md)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="Релиз $TAG"
           fi
-          echo "$NOTES" > /tmp/release_notes.md
+          printf '%s\n' "$NOTES" > /tmp/release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
-        with:
-          name: "Zapret Web-GUI ${{ steps.version.outputs.tag }}"
-          body_path: /tmp/release_notes.md
-          draft: false
-          prerelease: ${{ contains(steps.version.outputs.tag, '-') }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
           # "latest" должен принадлежать релизу GUI, и только ему: на него
           # завязаны все ссылки /releases/latest/download/zapret-gui-*.
           # Явно, а не по умолчанию — чтобы было видно, что это требование,
-          # а не побочный эффект (issue #305). Пререлиз latest'ом не делаем.
-          make_latest: ${{ contains(steps.version.outputs.tag, '-') && 'false' || 'true' }}
-          files: artifacts/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # а не побочный эффект (issue #305). Пререлиз (тэг с дефисом,
+          # v1.2.3-rc1) latest'ом не делаем.
+          if [ "${{ contains(steps.version.outputs.tag, '-') }}" = "true" ]; then
+            CHANNEL=(--prerelease --latest=false)
+          else
+            CHANNEL=(--latest)
+          fi
+
+          # Повторный прогон после сбоя (частично созданный релиз) не должен
+          # упираться в «release already exists» — дописываем, а не падаем.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "Zapret Web-GUI $TAG" \
+              --notes-file /tmp/release_notes.md \
+              --draft=false "${CHANNEL[@]}"
+            gh release upload "$TAG" artifacts/* --clobber
+          else
+            gh release create "$TAG" artifacts/* \
+              --title "Zapret Web-GUI $TAG" \
+              --notes-file /tmp/release_notes.md \
+              "${CHANNEL[@]}"
+          fi
+          echo "✓ Релиз опубликован: $TAG"

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -34,14 +34,23 @@ WORKFLOW_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
 # Workflow релиза самого GUI — единственный, кому «latest» разрешён.
 GUI_RELEASE_WORKFLOW = "release.yml"
 
-# Публикация релиза (softprops/action-gh-release) — по ней и опознаём
-# workflow, который вообще создаёт Release.
-PUBLISH_RE = re.compile(r"uses:\s*softprops/action-gh-release@", re.M)
+# Публикация релиза — по ней и опознаём workflow, который вообще создаёт
+# Release. Способов два: action softprops/action-gh-release и gh CLI
+# (`gh release create`). Второй появился в release.yml после того, как
+# codeload.github.com отдал 429 на скачивании самих actions и релиз
+# v0.24.16 не вышел вовсе: gh предустановлен на раннере и не скачивается.
+PUBLISH_RE = re.compile(
+    r"uses:\s*softprops/action-gh-release@|gh release create", re.M)
 
-# `make_latest: "false"` / make_latest: false — кавычки не принципиальны.
-MAKE_LATEST_FALSE_RE = re.compile(
-    r"^\s*make_latest:\s*['\"]?false['\"]?\s*$", re.M)
-MAKE_LATEST_ANY_RE = re.compile(r"^\s*make_latest:", re.M)
+# Заявка «этот релиз — latest»: у action это `make_latest:` с не-false
+# значением, у gh CLI — флаг `--latest` (именно без `=false`).
+CLAIMS_LATEST_RE = re.compile(
+    r"^\s*make_latest:\s*(?!['\"]?false)|--latest(?![=\w])", re.M)
+
+# Отказ от latest: `make_latest: "false"` / `make_latest: false` /
+# `--latest=false`.
+DISCLAIMS_LATEST_RE = re.compile(
+    r"^\s*make_latest:\s*['\"]?false['\"]?\s*$|--latest=false", re.M)
 
 # Пререлиз в «latest» не попадает по определению — с него спроса нет.
 PRERELEASE_TRUE_RE = re.compile(r"^\s*prerelease:\s*true\s*$", re.M)
@@ -85,9 +94,10 @@ class TestReleaseWorkflows(unittest.TestCase):
                 continue          # пререлиз «latest» не станет
             checked.append(name)
             self.assertRegex(
-                text, MAKE_LATEST_FALSE_RE,
-                "%s публикует НЕ-пререлиз без `make_latest: \"false\"`. "
-                "Такой релиз перехватит «latest» у vX.Y.Z, и ссылки "
+                text, DISCLAIMS_LATEST_RE,
+                "%s публикует НЕ-пререлиз, не отказавшись от «latest» "
+                "(`make_latest: \"false\"` или `--latest=false`). Такой "
+                "релиз перехватит «latest» у vX.Y.Z, и ссылки "
                 "/releases/latest/download/zapret-gui-*.apk отдадут 404 "
                 "(issue #305)." % name)
 
@@ -97,16 +107,17 @@ class TestReleaseWorkflows(unittest.TestCase):
             "проверка перестала что-либо проверять")
 
     def test_gui_release_claims_latest(self):
-        """У релиза GUI «latest» задан явно и не выключен наглухо."""
+        """У релиза GUI «latest» заявлен явно.
+
+        `--latest=false` в release.yml допустим — но только в ветке для
+        пререлиза; безусловная заявка на latest обязана быть рядом, иначе
+        «latest» не будет указывать ни на один релиз с пакетами GUI.
+        """
         text = self.workflows[GUI_RELEASE_WORKFLOW]
         self.assertRegex(
-            text, MAKE_LATEST_ANY_RE,
-            "release.yml должен явно объявлять make_latest: на «latest» "
-            "завязаны все ссылки на пакеты в README")
-        self.assertNotRegex(
-            text, MAKE_LATEST_FALSE_RE,
-            "release.yml выключил make_latest — тогда «latest» не будет "
-            "указывать ни на один релиз с пакетами GUI")
+            text, CLAIMS_LATEST_RE,
+            "release.yml должен явно заявлять «latest» (make_latest: или "
+            "--latest): на него завязаны все ссылки на пакеты в README")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Релиз v0.24.16 не вышел: job «Create GitHub Release» падал на шаге «Set up job» — раннер не смог скачать actions/download-artifact@v8 с codeload.github.com (429 Too Many Requests, затем 502 и 503; три попытки раннера и отказ). Это происходит ДО единой строки нашего кода, и повтор прогона не помог — оба раза одно и то же. Пакеты при этом собраны и лежат артефактом: не хватило только шага публикации.

Убран весь `uses:` из job'а публикации. Каждый action раннер тянет с codeload в «Set up job», поэтому три action'а — это три возможности уронить релиз по чужой инфраструктуре. gh CLI предустановлен в образе раннера и не скачивается ниоткуда:

  actions/download-artifact  → gh run download (нужен actions: read)
  softprops/action-gh-release → gh release create
  actions/checkout           → gh api contents/CHANGELOG.md (нужен был
                               ровно один файл — заметки к релизу)

Семантика сохранена: имя «Zapret Web-GUI <тэг>», заметки из CHANGELOG, пререлиз для тэга с дефисом, «latest» только за релизом GUI (issue #305). Плюс повторный прогон после сбоя теперь не упирается в «release already exists»: существующий релиз дополняется (edit + upload --clobber), а не роняет job.

Сторож test_release_workflows опознавал публикацию по строке softprops/action-gh-release — теперь понимает оба способа и проверяет заявку на «latest» в обеих формах (make_latest: и --latest), не считая отказом `--latest=false` из ветки пререлиза.


Claude-Session: https://claude.ai/code/session_01Bs2LTp7whVSkgZweCLDMd2